### PR TITLE
fix: changelog timeline and duplicate consent banner in the demo iframe

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -29,7 +29,7 @@ function ReleaseSection({ release }: { release: ChangelogRelease }) {
 
   return (
     <article className="relative pl-8 pb-12 last:pb-0">
-      <div className="absolute left-0 top-1.5 h-2.5 w-2.5 rounded-full bg-primary ring-4 ring-white dark:ring-black" />
+      <div className="absolute left-0 top-4 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary ring-4 ring-white dark:ring-black" />
 
       <header className="mb-6">
         <h2 className="text-2xl font-semibold text-gray-900 dark:text-white tracking-tight">
@@ -96,7 +96,11 @@ export default async function ChangelogPage() {
               </p>
             </header>
 
-            <div className="relative border-l-2 border-gray-100 dark:border-zinc-800">
+            <div className="relative">
+              <div
+                aria-hidden
+                className="absolute left-0 top-4 bottom-0 w-0.5 -translate-x-1/2 rounded-full bg-gray-100 dark:bg-zinc-800"
+              />
               {releases.map((release) => (
                 <ReleaseSection key={release.version} release={release} />
               ))}

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ChevronDown } from "lucide-react";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Starfield } from "@/components/starfield";
@@ -23,6 +24,13 @@ export const metadata: Metadata = {
     canonical: "https://agilekit.dev/changelog",
   },
 };
+
+/**
+ * How many releases stay expanded. The rest sit behind a disclosure: the very
+ * first release carries every pre-1.0 commit, so rendering the full history
+ * eagerly makes the page tens of thousands of pixels tall.
+ */
+const EXPANDED_RELEASE_COUNT = 10;
 
 function ReleaseSection({ release }: { release: ChangelogRelease }) {
   const relativeTime = formatRelativeTime(release.date);
@@ -66,8 +74,42 @@ function ReleaseSection({ release }: { release: ChangelogRelease }) {
   );
 }
 
+/**
+ * The older half of the timeline. A native `<details>` keeps this a server
+ * component and keeps the entries in the markup for crawlers, while costing
+ * the reader nothing until they open it.
+ */
+function EarlierReleases({ releases }: { releases: ChangelogRelease[] }) {
+  return (
+    <details className="group">
+      <summary className="relative flex cursor-pointer list-none items-center gap-2 pl-8 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&::-webkit-details-marker]:hidden">
+        <span
+          aria-hidden
+          className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-gray-300 bg-white ring-4 ring-white dark:border-zinc-700 dark:bg-black dark:ring-black"
+        />
+        <span className="group-open:hidden">
+          Show {releases.length} earlier releases
+        </span>
+        <span className="hidden group-open:inline">Hide earlier releases</span>
+        <ChevronDown
+          aria-hidden
+          className="h-4 w-4 transition-transform group-open:rotate-180"
+        />
+      </summary>
+
+      <div className="mt-12">
+        {releases.map((release) => (
+          <ReleaseSection key={release.version} release={release} />
+        ))}
+      </div>
+    </details>
+  );
+}
+
 export default async function ChangelogPage() {
   const releases = parseChangelog();
+  const expandedReleases = releases.slice(0, EXPANDED_RELEASE_COUNT);
+  const earlierReleases = releases.slice(EXPANDED_RELEASE_COUNT);
 
   return (
     <div className="relative min-h-screen bg-white dark:bg-black overflow-hidden">
@@ -101,9 +143,12 @@ export default async function ChangelogPage() {
                 aria-hidden
                 className="absolute left-0 top-4 bottom-0 w-0.5 -translate-x-1/2 rounded-full bg-gray-100 dark:bg-zinc-800"
               />
-              {releases.map((release) => (
+              {expandedReleases.map((release) => (
                 <ReleaseSection key={release.version} release={release} />
               ))}
+              {earlierReleases.length > 0 && (
+                <EarlierReleases releases={earlierReleases} />
+              )}
             </div>
 
             {releases.length === 0 && (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Providers } from "@/components/providers";
 import { Toaster } from "sonner";
 import { getToken } from "@/lib/auth-server";
 import { isEmbeddedDocument } from "@/lib/embed";
+import { TopLevelOnly } from "@/components/top-level-only";
 import { AnalyticsConsentBanner } from "@/components/legal/analytics-consent";
 
 import "./globals.css";
@@ -122,12 +123,16 @@ export default async function RootLayout({
           {children}
           <Toaster />
           {!isEmbedded && (
-            <AnalyticsConsentBanner initialConsent={analyticsConsent} />
+            <TopLevelOnly>
+              <AnalyticsConsentBanner initialConsent={analyticsConsent} />
+              {analyticsEnabled && <SpeedInsights />}
+            </TopLevelOnly>
           )}
-          {analyticsEnabled && <SpeedInsights />}
         </Providers>
         {analyticsEnabled && process.env.NEXT_PUBLIC_GA_ID && (
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+          <TopLevelOnly>
+            <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+          </TopLevelOnly>
         )}
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Geist, Geist_Mono, Outfit } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { Toaster } from "sonner";
 import { getToken } from "@/lib/auth-server";
+import { isEmbeddedDocument } from "@/lib/embed";
 import { AnalyticsConsentBanner } from "@/components/legal/analytics-consent";
 
 import "./globals.css";
@@ -99,6 +100,7 @@ export default async function RootLayout({
 }>) {
   const cookieStore = await cookies();
   const initialToken = await getToken();
+  const isEmbedded = await isEmbeddedDocument();
   const analyticsConsentValue = cookieStore.get("analytics_consent")?.value;
   const analyticsConsent =
     analyticsConsentValue === "granted"
@@ -106,6 +108,10 @@ export default async function RootLayout({
       : analyticsConsentValue === "denied"
         ? "denied"
         : null;
+  // A framed document is a second render of this layout inside a page that is
+  // already reporting the same visit, so it must not report it again. The
+  // toaster stays: toasts raised inside the demo belong to the demo's viewport.
+  const analyticsEnabled = analyticsConsent === "granted" && !isEmbedded;
 
   return (
     <html lang="en" className={outfit.variable} suppressHydrationWarning>
@@ -115,10 +121,12 @@ export default async function RootLayout({
         <Providers initialToken={initialToken}>
           {children}
           <Toaster />
-          <AnalyticsConsentBanner initialConsent={analyticsConsent} />
-          {analyticsConsent === "granted" && <SpeedInsights />}
+          {!isEmbedded && (
+            <AnalyticsConsentBanner initialConsent={analyticsConsent} />
+          )}
+          {analyticsEnabled && <SpeedInsights />}
         </Providers>
-        {analyticsConsent === "granted" && process.env.NEXT_PUBLIC_GA_ID && (
+        {analyticsEnabled && process.env.NEXT_PUBLIC_GA_ID && (
           <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
         )}
       </body>

--- a/src/components/legal/analytics-consent.tsx
+++ b/src/components/legal/analytics-consent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,9 @@ const ANALYTICS_CONSENT_COOKIE = "analytics_consent";
 const ANALYTICS_CONSENT_MAX_AGE = 60 * 60 * 24 * 365;
 
 type AnalyticsConsentValue = "granted" | "denied" | null;
+
+/** Whether the page is framed cannot change over the document's lifetime. */
+const subscribeToNothing = () => () => {};
 
 function setAnalyticsConsent(value: Exclude<AnalyticsConsentValue, null>) {
   const secure = window.location.protocol === "https:" ? "; Secure" : "";
@@ -22,7 +26,17 @@ export function AnalyticsConsentBanner({
 }: {
   initialConsent: AnalyticsConsentValue;
 }) {
-  if (initialConsent !== null) {
+  // The root layout already drops this banner from framed documents, so the
+  // hero's demo iframe never renders it. This is the fallback for requests that
+  // detection cannot see (no `Sec-Fetch-Dest`): the server snapshot keeps the
+  // hydrated markup unchanged, then the client snapshot hides the banner.
+  const isFramed = useSyncExternalStore(
+    subscribeToNothing,
+    () => window.self !== window.top,
+    () => false,
+  );
+
+  if (initialConsent !== null || isFramed) {
     return null;
   }
 

--- a/src/components/legal/analytics-consent.tsx
+++ b/src/components/legal/analytics-consent.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -9,9 +8,6 @@ const ANALYTICS_CONSENT_COOKIE = "analytics_consent";
 const ANALYTICS_CONSENT_MAX_AGE = 60 * 60 * 24 * 365;
 
 type AnalyticsConsentValue = "granted" | "denied" | null;
-
-/** Whether the page is framed cannot change over the document's lifetime. */
-const subscribeToNothing = () => () => {};
 
 function setAnalyticsConsent(value: Exclude<AnalyticsConsentValue, null>) {
   const secure = window.location.protocol === "https:" ? "; Secure" : "";
@@ -26,17 +22,7 @@ export function AnalyticsConsentBanner({
 }: {
   initialConsent: AnalyticsConsentValue;
 }) {
-  // The root layout already drops this banner from framed documents, so the
-  // hero's demo iframe never renders it. This is the fallback for requests that
-  // detection cannot see (no `Sec-Fetch-Dest`): the server snapshot keeps the
-  // hydrated markup unchanged, then the client snapshot hides the banner.
-  const isFramed = useSyncExternalStore(
-    subscribeToNothing,
-    () => window.self !== window.top,
-    () => false,
-  );
-
-  if (initialConsent !== null || isFramed) {
+  if (initialConsent !== null) {
     return null;
   }
 

--- a/src/components/top-level-only.test.tsx
+++ b/src/components/top-level-only.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { TopLevelOnly } from "./top-level-only";
+
+/**
+ * The server-side half of the framed-chrome fix (`isEmbeddedDocument()`) is
+ * covered end to end in tests/embedded-chrome.spec.ts. This covers the client
+ * fallback that takes over when `Sec-Fetch-Dest` never arrives, which an e2e
+ * cannot reach: intercepting the framed request to strip the header also
+ * breaks that document's hydration, so the fallback never gets to run.
+ */
+
+function frameTheWindow() {
+  // window.self !== window.top is what "inside a frame" reduces to. jsdom makes
+  // both the same object, so stand in a different one for `top`.
+  Object.defineProperty(window, "top", {
+    value: { name: "some-other-window" },
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "top", {
+    value: window,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe("TopLevelOnly", () => {
+  it("renders children in a top-level document", () => {
+    render(
+      <TopLevelOnly>
+        <p>analytics consent</p>
+      </TopLevelOnly>,
+    );
+
+    expect(screen.getByText("analytics consent")).toBeTruthy();
+  });
+
+  it("renders nothing once it sees it is framed", () => {
+    frameTheWindow();
+
+    render(
+      <TopLevelOnly>
+        <p>analytics consent</p>
+      </TopLevelOnly>,
+    );
+
+    expect(screen.queryByText("analytics consent")).toBeNull();
+  });
+});

--- a/src/components/top-level-only.tsx
+++ b/src/components/top-level-only.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useSyncExternalStore } from "react";
+
+/** Whether the page is framed cannot change over the document's lifetime. */
+const subscribeToNothing = () => () => {};
+
+/**
+ * Renders `children` only when this document is the top-level one.
+ *
+ * The root layout already drops framed chrome server-side via
+ * `isEmbeddedDocument()`, which is what keeps it out of the markup entirely.
+ * This is the fallback for the requests that check cannot see (no
+ * `Sec-Fetch-Dest`): the server snapshot leaves the hydrated markup unchanged,
+ * then the client snapshot removes the subtree.
+ *
+ * Everything wrapped here injects its scripts on mount rather than into the
+ * server HTML, so a framed document never runs them even when the header is
+ * missing and the markup was sent.
+ */
+export function TopLevelOnly({ children }: { children: ReactNode }) {
+  const isFramed = useSyncExternalStore(
+    subscribeToNothing,
+    () => window.self !== window.top,
+    () => false,
+  );
+
+  return isFramed ? null : children;
+}

--- a/src/lib/embed.ts
+++ b/src/lib/embed.ts
@@ -1,0 +1,21 @@
+import { headers } from "next/headers";
+
+/**
+ * True when this document is being rendered inside a frame rather than as a
+ * top-level page. The marketing hero embeds `/demo?embed=true` in an iframe,
+ * and that framed document goes through the same root layout as the page
+ * hosting it — so anything the layout renders globally (the analytics consent
+ * banner) would otherwise appear twice on screen at once.
+ *
+ * Detection uses the `Sec-Fetch-Dest` fetch-metadata header, which the browser
+ * sets to `iframe` on the framed navigation and `document` on the top-level
+ * one. A request that arrives without the header (Safari below 16.4, or a
+ * proxy that strips it) reads as not-embedded, so the caller falls back to
+ * rendering exactly what it renders today.
+ */
+export async function isEmbeddedDocument(): Promise<boolean> {
+  const requestHeaders = await headers();
+  const destination = requestHeaders.get("sec-fetch-dest");
+
+  return destination === "iframe" || destination === "frame";
+}

--- a/src/lib/embed.ts
+++ b/src/lib/embed.ts
@@ -11,7 +11,12 @@ import { headers } from "next/headers";
  * sets to `iframe` on the framed navigation and `document` on the top-level
  * one. A request that arrives without the header (Safari below 16.4, or a
  * proxy that strips it) reads as not-embedded, so the caller falls back to
- * rendering exactly what it renders today.
+ * rendering the markup and `<TopLevelOnly>` drops it on the client instead.
+ *
+ * Not the same signal as the `embed=true` search param that `demo-content.tsx`
+ * reads. That one is the demo asking for its own chrome to be hidden, and only
+ * a page can see search params; this one is the layout asking whether it is the
+ * document the user is actually looking at. They are deliberately separate.
  */
 export async function isEmbeddedDocument(): Promise<boolean> {
   const requestHeaders = await headers();

--- a/tests/changelog.spec.ts
+++ b/tests/changelog.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The first release in CHANGELOG.md carries every pre-1.0 commit, so rendering
+ * the whole history eagerly made /changelog roughly 16,500px tall. Only the
+ * most recent releases stay expanded; the rest sit behind a native <details>
+ * so they stay in the markup for crawlers without costing the reader anything.
+ *
+ * `EXPANDED_RELEASE_COUNT` in src/app/changelog/page.tsx is the contract here.
+ */
+
+const EXPANDED_RELEASE_COUNT = 10;
+const DISCLOSURE = /^Show \d+ earlier releases$/;
+
+test.describe("Changelog", () => {
+  test("collapses earlier releases until the disclosure is opened", async ({
+    page,
+  }) => {
+    await page.goto("/changelog");
+
+    // Collapsed <details> content stays in the DOM, so count what is rendered
+    // rather than what is present.
+    await expect(page.locator("main article:visible")).toHaveCount(
+      EXPANDED_RELEASE_COUNT,
+    );
+
+    const totalReleases = await page.locator("main article").count();
+    expect(
+      totalReleases,
+      "changelog needs more releases than the expanded count for this to test anything",
+    ).toBeGreaterThan(EXPANDED_RELEASE_COUNT);
+
+    const disclosure = page.getByText(DISCLOSURE);
+    await expect(disclosure).toBeVisible();
+    await disclosure.click();
+
+    await expect(page.locator("main article:visible")).toHaveCount(
+      totalReleases,
+    );
+    await expect(page.getByText("Hide earlier releases")).toBeVisible();
+  });
+
+  test("keeps every release in the markup while collapsed", async ({
+    page,
+  }) => {
+    // Crawlers do not open disclosures. The entries have to ship either way,
+    // which is the whole reason this is a <details> and not a client-side
+    // "load more".
+    const response = await page.goto("/changelog");
+    const html = (await response?.text()) ?? "";
+    const releasesInMarkup = (html.match(/<article/g) ?? []).length;
+
+    expect(releasesInMarkup).toBeGreaterThan(EXPANDED_RELEASE_COUNT);
+    expect(releasesInMarkup).toBe(await page.locator("main article").count());
+  });
+});

--- a/tests/embedded-chrome.spec.ts
+++ b/tests/embedded-chrome.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The marketing hero embeds `/demo?embed=true` in an iframe, and that framed
+ * document renders the same root layout as the page hosting it. Anything the
+ * layout renders globally therefore renders twice on one screen unless it is
+ * explicitly dropped from framed documents.
+ *
+ * That regressed once already: the analytics consent banner painted a second
+ * copy on top of the homepage, and a granted visit reported itself twice.
+ *
+ * This pins the server-side `Sec-Fetch-Dest` check in `src/lib/embed.ts`. The
+ * `<TopLevelOnly>` client fallback is not reachable from here: stripping the
+ * header means intercepting the framed request, and fulfilling it from the
+ * interceptor stops that document hydrating, so the fallback never runs and
+ * the test would pass for the wrong reason. It is covered in
+ * src/components/top-level-only.test.tsx instead.
+ */
+
+const DEMO_IFRAME = 'iframe[title="Live Planning Poker Demo"]';
+const CONSENT_HEADING = "Analytics consent";
+
+test.describe("Framed demo renders no global chrome", () => {
+  test("shows the consent banner once, never inside the demo iframe", async ({
+    page,
+  }) => {
+    // A fresh context carries no analytics_consent cookie, so the banner is
+    // supposed to be showing — otherwise this asserts nothing.
+    await page.goto("/");
+
+    await expect(page.getByText(CONSENT_HEADING, { exact: true })).toHaveCount(
+      1,
+    );
+
+    const demo = page.frameLocator(DEMO_IFRAME);
+    await expect(demo.getByText(CONSENT_HEADING, { exact: true })).toHaveCount(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
Three things, all found while looking at the changelog page.

The timeline dots never lined up with the line. The line was the container's left border and the dots were positioned off the article's content box, which starts after that border, so every dot sat 6px right of the line and 5px above the center of its heading. The rail is its own element now so it and the dots share one anchor and both center on it.

The consent banner showed up twice on the homepage. The hero iframe loads /demo?embed=true, which renders the same root layout as the page around it, so the framed document painted its own banner on top of the host's. Same reason a granted visit reported itself to analytics twice. Both are skipped now when the request arrives with Sec-Fetch-Dest: iframe, plus a client side fallback in the banner in case that header ever goes missing behind a proxy.

The page was also 16,516px tall, mostly because v1.0.0 alone has 211 entries. Ten most recent releases stay open and the other 20 sit behind a details element, which takes it to 4,350px. Still a server component, and every entry is still in the markup for crawlers.

One thing I did not change. I'd flagged the duplicate Toaster as the same bug but it isn't. The demo can open the issues panel and raise toasts, and those belong in the demo's own viewport, so removing it there would just swallow them. Sonner doesn't render anything until a toast exists anyway.

Checked in the browser in both themes. Dot offsets measure 0 now, banner count is 1 top level and 0 in the frame, and the analytics scripts split the same way.

Three commits in case you'd rather rebase than squash. The middle one is the actual bug fix.