### PR TITLE
feat: retention flag, widen release and backfill migration

### DIFF
--- a/convex/analytics.seeds.ts
+++ b/convex/analytics.seeds.ts
@@ -29,6 +29,7 @@ export async function seedRoom(t: T, name = "R"): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -4,7 +4,9 @@
  * re-run.
  */
 
+import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 
 /**
  * Backfills `issueLinks.roomId` from the parent issue. The field was added
@@ -31,5 +33,56 @@ export const backfillIssueLinksRoomId = internalMutation({
       tagged: outcomes.filter((o) => o === "tagged").length,
       orphaned: outcomes.filter((o) => o === "orphaned").length,
     };
+  },
+});
+
+/**
+ * How many rooms one backfill invocation stamps before handing off to a
+ * scheduled continuation. Keeps each transaction small on a large table.
+ */
+const RETAINED_BACKFILL_BATCH = 100;
+
+/**
+ * Stamps `rooms.retained: false` on every row written before the field
+ * existed (ADR-0019, widen release #284). Reads the `undefined` range of
+ * `by_retention_activity`; patched rows leave that range, so the query
+ * self-terminates and no cursor is carried. While a batch comes back full
+ * the mutation reschedules itself with `runAfter(0)`. Idempotent and safe
+ * to re-run. `dryRun` reads one batch without writing: `found` is exact
+ * when it is below `batchSize` (0 means the backfill is complete), and
+ * "at least that many" otherwise.
+ *
+ * Must run to completion in prod before the narrow release (#285) makes the
+ * field required — the Convex push validates data at rest and would abort.
+ *
+ *   npx convex run migrations:backfillRoomsRetained '{"dryRun": true}' --prod
+ *   npx convex run migrations:backfillRoomsRetained --prod
+ */
+export const backfillRoomsRetained = internalMutation({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = args.batchSize ?? RETAINED_BACKFILL_BATCH;
+    const batch = await ctx.db
+      .query("rooms")
+      .withIndex("by_retention_activity", (q) => q.eq("retained", undefined))
+      .take(batchSize);
+
+    const found = batch.length;
+    if (args.dryRun) {
+      return { found, stamped: 0, rescheduled: false };
+    }
+
+    await Promise.all(batch.map((room) => ctx.db.patch(room._id, { retained: false })));
+
+    const rescheduled = found === batchSize;
+    if (rescheduled) {
+      await ctx.scheduler.runAfter(0, internal.migrations.backfillRoomsRetained, {
+        batchSize,
+      });
+    }
+    return { found, stamped: found, rescheduled };
   },
 });

--- a/convex/model/rooms.ts
+++ b/convex/model/rooms.ts
@@ -96,6 +96,8 @@ export async function createRoom(
     votingScale,
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
+    // Always false until rooms can belong to a Team (ADR-0019).
+    retained: false,
     ...(args.ownerId ? { ownerId: args.ownerId } : {}),
   });
 

--- a/convex/retention.test.ts
+++ b/convex/retention.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import * as Rooms from "./model/rooms";
+import { seedRoom } from "./analytics.seeds";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+/**
+ * Retention flag, widen release (#284, ADR-0019). Every writer stamps
+ * `retained` on new rows; legacy rows are stamped by the self-scheduling
+ * backfill. The sweep is untouched here — its tests live in
+ * roomAggregate.test.ts and still read `by_activity`.
+ */
+
+/** A legacy row: written before the field existed, so `retained` is absent. */
+async function seedLegacyRoom(t: T, name: string): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name,
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function retainedById(t: T): Promise<Map<Id<"rooms">, boolean | undefined>> {
+  const rooms = await t.run((ctx) => ctx.db.query("rooms").collect());
+  return new Map(rooms.map((r) => [r._id, r.retained]));
+}
+
+async function pendingBackfills(t: T): Promise<number> {
+  const jobs = await t.run((ctx) =>
+    ctx.db.system.query("_scheduled_functions").collect()
+  );
+  return jobs.filter(
+    (j) => j.name.endsWith("backfillRoomsRetained") && j.state.kind === "pending"
+  ).length;
+}
+
+/** Fires runAfter(0) continuations until none are pending. */
+async function drainScheduled(t: T): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+    await t.finishInProgressScheduledFunctions();
+    if ((await pendingBackfills(t)) === 0) return;
+  }
+  throw new Error("backfill continuations did not drain");
+}
+
+describe("retained: writers", () => {
+  it("createRoom stamps a new room retained: false", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await t.run((ctx) =>
+      Rooms.createRoom(ctx, { name: "New", votingScale: { type: "fibonacci" } })
+    );
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room?.retained).toBe(false);
+  });
+
+  it("the analytics seed helper stamps retained: false", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room?.retained).toBe(false);
+  });
+});
+
+describe("backfillRoomsRetained", () => {
+  it("stamps only rows where retained is undefined, batching until done", async () => {
+    const t = convexTest(schema, modules);
+    const legacy = await Promise.all(
+      ["L1", "L2", "L3"].map((name) => seedLegacyRoom(t, name))
+    );
+    const alreadyTrue = await t.run((ctx) =>
+      ctx.db.insert("rooms", {
+        name: "kept",
+        autoCompleteVoting: false,
+        isGameOver: false,
+        createdAt: Date.now(),
+        lastActivityAt: Date.now(),
+        retained: true,
+      })
+    );
+    const alreadyFalse = await seedRoom(t, "fresh");
+
+    const first = await t.mutation(internal.migrations.backfillRoomsRetained, {
+      batchSize: 2,
+    });
+    expect(first).toEqual({ found: 2, stamped: 2, rescheduled: true });
+    expect(await pendingBackfills(t)).toBe(1);
+
+    await drainScheduled(t);
+
+    const retained = await retainedById(t);
+    for (const id of legacy) expect(retained.get(id)).toBe(false);
+    expect(retained.get(alreadyTrue)).toBe(true);
+    expect(retained.get(alreadyFalse)).toBe(false);
+    expect(await pendingBackfills(t)).toBe(0);
+  });
+
+  it("terminates without rescheduling once the batch comes back short", async () => {
+    const t = convexTest(schema, modules);
+    await seedLegacyRoom(t, "L1");
+
+    const result = await t.mutation(internal.migrations.backfillRoomsRetained, {
+      batchSize: 2,
+    });
+    expect(result).toEqual({ found: 1, stamped: 1, rescheduled: false });
+    expect(await pendingBackfills(t)).toBe(0);
+
+    // Idempotent: a re-run finds nothing left to stamp.
+    const again = await t.mutation(internal.migrations.backfillRoomsRetained, {});
+    expect(again).toEqual({ found: 0, stamped: 0, rescheduled: false });
+  });
+
+  it("dryRun reports the unstamped count, bounded by batchSize, and writes nothing", async () => {
+    const t = convexTest(schema, modules);
+    const legacy = await Promise.all(
+      ["L1", "L2", "L3"].map((name) => seedLegacyRoom(t, name))
+    );
+    await seedRoom(t, "fresh");
+
+    const result = await t.mutation(internal.migrations.backfillRoomsRetained, {
+      dryRun: true,
+    });
+    expect(result).toEqual({ found: 3, stamped: 0, rescheduled: false });
+
+    const bounded = await t.mutation(internal.migrations.backfillRoomsRetained, {
+      dryRun: true,
+      batchSize: 2,
+    });
+    expect(bounded).toEqual({ found: 2, stamped: 0, rescheduled: false });
+
+    const retained = await retainedById(t);
+    for (const id of legacy) expect(retained.get(id)).toBeUndefined();
+    expect(await pendingBackfills(t)).toBe(0);
+  });
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -35,6 +35,11 @@ export default defineSchema({
     nextIssueNumber: v.optional(v.number()), // Counter for sequential IDs (1, 2, 3...)
     createdAt: v.number(),
     lastActivityAt: v.number(),
+    // Retention (ADR-0019): true iff the room belongs to a Team, so the
+    // five-day sweep leaves it alone. Optional during the widen release;
+    // migrations.backfillRoomsRetained stamps legacy rows `false`, then the
+    // narrow release (#285) makes it required and drops `by_activity`.
+    retained: v.optional(v.boolean()),
     // Room permissions & ownership
     ownerId: v.optional(v.id("users")),
     permissions: v.optional(
@@ -62,7 +67,8 @@ export default defineSchema({
       })
     ),
   })
-    .index("by_activity", ["lastActivityAt"])
+    .index("by_activity", ["lastActivityAt"]) // Sweep reads this until #285
+    .index("by_retention_activity", ["retained", "lastActivityAt"]) // Sweep's next read path; backfill reads the undefined range
     .index("by_created", ["createdAt"]) // For querying recent rooms
     .index("by_owner", ["ownerId"]), // For transferring ownership on account linking
 


### PR DESCRIPTION
Closes #284. Widen half of the `rooms.retained` migration (ADR-0019, spec §3 step 1 and 2). The narrow half is #285 and must not ship in the same release.

## Human step before #285

Run the backfill in prod to completion before the narrow release is cut. The narrow schema makes `retained` required and the Convex push validates data at rest, so an unfinished backfill aborts that deploy.

```
npx convex run migrations:backfillRoomsRetained '{"dryRun": true}' --prod
npx convex run migrations:backfillRoomsRetained --prod
```

The dry run reads one batch and writes nothing. `found: 0` means every row is stamped and #285 is safe to release. The real run stamps 100 rows per invocation and reschedules itself with `runAfter(0)` while a batch comes back full, so one invocation drains the table. It is idempotent and safe to re-run.

## What changed

- `convex/schema.ts`: `rooms.retained` as an optional boolean and a `by_retention_activity` index on `[retained, lastActivityAt]`. `by_activity` is unchanged and the sweep still reads it.
- `convex/model/rooms.ts` and `convex/analytics.seeds.ts`: the two room writers stamp `retained: false`. Always false for now since nothing yet gives a room a Team.
- `convex/migrations.ts`: `backfillRoomsRetained`. Reads the `undefined` range of the new index, patches a batch, reschedules while full. Patched rows leave the range, so no cursor is carried and the query self-terminates.
- `convex/retention.test.ts`: a new room carries the flag, the seed helper carries the flag, the backfill stamps only undefined rows across batches and terminates, a re-run is a no-op, dry run writes nothing.

## Notes

- The index name follows ADR-0019 and the spec rather than the Convex naming guideline, since #285's sweep query depends on that string.
- Other test files that insert rooms without `retained` compile only because the field is optional. They will need a shared seed helper when #285 narrows the schema.

https://claude.ai/code/session_01LTuViwbbbictkKbzyZCBaa
