### PR TITLE
feat: retention flag, narrow release

### DIFF
--- a/convex/actingUser.test.ts
+++ b/convex/actingUser.test.ts
@@ -17,6 +17,7 @@ async function seedRoom(t: T): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }

--- a/convex/integrationsModel.test.ts
+++ b/convex/integrationsModel.test.ts
@@ -30,6 +30,7 @@ async function seedRoom(t: T): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }

--- a/convex/issueCreation.test.ts
+++ b/convex/issueCreation.test.ts
@@ -19,6 +19,7 @@ async function seedRoom(t: T): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }

--- a/convex/jiraEstimatePush.test.ts
+++ b/convex/jiraEstimatePush.test.ts
@@ -70,6 +70,7 @@ async function seedRoomMidRound(t: T): Promise<{
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     });
     const issueId = await ctx.db.insert("issues", {
       roomId,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -4,9 +4,7 @@
  * re-run.
  */
 
-import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
-import { internal } from "./_generated/api";
 
 /**
  * Backfills `issueLinks.roomId` from the parent issue. The field was added
@@ -33,56 +31,5 @@ export const backfillIssueLinksRoomId = internalMutation({
       tagged: outcomes.filter((o) => o === "tagged").length,
       orphaned: outcomes.filter((o) => o === "orphaned").length,
     };
-  },
-});
-
-/**
- * How many rooms one backfill invocation stamps before handing off to a
- * scheduled continuation. Keeps each transaction small on a large table.
- */
-const RETAINED_BACKFILL_BATCH = 100;
-
-/**
- * Stamps `rooms.retained: false` on every row written before the field
- * existed (ADR-0019, widen release #284). Reads the `undefined` range of
- * `by_retention_activity`; patched rows leave that range, so the query
- * self-terminates and no cursor is carried. While a batch comes back full
- * the mutation reschedules itself with `runAfter(0)`. Idempotent and safe
- * to re-run. `dryRun` reads one batch without writing: `found` is exact
- * when it is below `batchSize` (0 means the backfill is complete), and
- * "at least that many" otherwise.
- *
- * Must run to completion in prod before the narrow release (#285) makes the
- * field required — the Convex push validates data at rest and would abort.
- *
- *   npx convex run migrations:backfillRoomsRetained '{"dryRun": true}' --prod
- *   npx convex run migrations:backfillRoomsRetained --prod
- */
-export const backfillRoomsRetained = internalMutation({
-  args: {
-    dryRun: v.optional(v.boolean()),
-    batchSize: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const batchSize = args.batchSize ?? RETAINED_BACKFILL_BATCH;
-    const batch = await ctx.db
-      .query("rooms")
-      .withIndex("by_retention_activity", (q) => q.eq("retained", undefined))
-      .take(batchSize);
-
-    const found = batch.length;
-    if (args.dryRun) {
-      return { found, stamped: 0, rescheduled: false };
-    }
-
-    await Promise.all(batch.map((room) => ctx.db.patch(room._id, { retained: false })));
-
-    const rescheduled = found === batchSize;
-    if (rescheduled) {
-      await ctx.scheduler.runAfter(0, internal.migrations.backfillRoomsRetained, {
-        batchSize,
-      });
-    }
-    return { found, stamped: found, rescheduled };
   },
 });

--- a/convex/model/cleanup.ts
+++ b/convex/model/cleanup.ts
@@ -16,8 +16,10 @@ export interface RemoveInactiveRoomsResult {
 const INACTIVE_ROOMS_PER_TICK = 100;
 
 /**
- * Schedules deletion of inactive rooms (default 5 days of inactivity). Each
- * room's cascade runs as its own scheduled mutation
+ * Schedules deletion of non-retained inactive rooms (default 5 days of
+ * inactivity). A retained room (ADR-0019: one that belongs to a Team) is
+ * never swept, whatever its age or type. Each room's cascade runs as its own
+ * scheduled mutation
  * (internal.maintenance.deleteRoomAggregateChunk), so one oversized or
  * failing room can neither blow the cron's transaction limits nor take the
  * other rooms down with it.
@@ -30,7 +32,9 @@ export async function removeInactiveRooms(
 
   const inactiveRooms = await ctx.db
     .query("rooms")
-    .withIndex("by_activity", (q) => q.lt("lastActivityAt", cutoffTime))
+    .withIndex("by_retention_activity", (q) =>
+      q.eq("retained", false).lt("lastActivityAt", cutoffTime)
+    )
     .take(INACTIVE_ROOMS_PER_TICK);
 
   console.log(`Scheduling ${inactiveRooms.length} inactive rooms for cleanup`);

--- a/convex/requireCan.test.ts
+++ b/convex/requireCan.test.ts
@@ -34,6 +34,7 @@ async function seedRoom(
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
       ...(opts.permissions ? { permissions: opts.permissions } : {}),
       ...(opts.ownerId ? { ownerId: opts.ownerId } : {}),
     })

--- a/convex/retention.test.ts
+++ b/convex/retention.test.ts
@@ -12,47 +12,40 @@ const modules = import.meta.glob("./**/*.*s");
 type T = TestConvex<typeof schema>;
 
 /**
- * Retention flag, widen release (#284, ADR-0019). Every writer stamps
- * `retained` on new rows; legacy rows are stamped by the self-scheduling
- * backfill. The sweep is untouched here — its tests live in
- * roomAggregate.test.ts and still read `by_activity`.
+ * Retention (ADR-0019): `retained` is the sweep's only discriminator. Every
+ * writer stamps it on new rows, and the sweep deletes a non-retained room
+ * after five quiet days while leaving a retained one alone regardless of
+ * age or room type.
  */
 
-/** A legacy row: written before the field existed, so `retained` is absent. */
-async function seedLegacyRoom(t: T, name: string): Promise<Id<"rooms">> {
+const TEN_DAYS_AGO = Date.now() - 10 * 24 * 60 * 60 * 1000;
+
+async function seedStaleRoom(
+  t: T,
+  opts: { retained: boolean; roomType?: "canvas" }
+): Promise<Id<"rooms">> {
   return t.run((ctx) =>
     ctx.db.insert("rooms", {
-      name,
+      name: opts.retained ? "kept" : "stale",
       autoCompleteVoting: false,
       isGameOver: false,
-      createdAt: Date.now(),
-      lastActivityAt: Date.now(),
+      createdAt: TEN_DAYS_AGO,
+      lastActivityAt: TEN_DAYS_AGO,
+      retained: opts.retained,
+      ...(opts.roomType ? { roomType: opts.roomType } : {}),
     })
   );
 }
 
-async function retainedById(t: T): Promise<Map<Id<"rooms">, boolean | undefined>> {
-  const rooms = await t.run((ctx) => ctx.db.query("rooms").collect());
-  return new Map(rooms.map((r) => [r._id, r.retained]));
-}
-
-async function pendingBackfills(t: T): Promise<number> {
+async function scheduledCascadeRoomIds(t: T): Promise<Set<string>> {
   const jobs = await t.run((ctx) =>
     ctx.db.system.query("_scheduled_functions").collect()
   );
-  return jobs.filter(
-    (j) => j.name.endsWith("backfillRoomsRetained") && j.state.kind === "pending"
-  ).length;
-}
-
-/** Fires runAfter(0) continuations until none are pending. */
-async function drainScheduled(t: T): Promise<void> {
-  for (let i = 0; i < 50; i++) {
-    await new Promise((r) => setTimeout(r, 5));
-    await t.finishInProgressScheduledFunctions();
-    if ((await pendingBackfills(t)) === 0) return;
-  }
-  throw new Error("backfill continuations did not drain");
+  return new Set(
+    jobs
+      .filter((j) => j.name.endsWith(":deleteRoomAggregateChunk"))
+      .map((j) => (j.args as [{ roomId: string }])[0].roomId)
+  );
 }
 
 describe("retained: writers", () => {
@@ -73,74 +66,42 @@ describe("retained: writers", () => {
   });
 });
 
-describe("backfillRoomsRetained", () => {
-  it("stamps only rows where retained is undefined, batching until done", async () => {
+describe("removeInactiveRooms: retention", () => {
+  it("a retained room outlives five quiet days", async () => {
     const t = convexTest(schema, modules);
-    const legacy = await Promise.all(
-      ["L1", "L2", "L3"].map((name) => seedLegacyRoom(t, name))
-    );
-    const alreadyTrue = await t.run((ctx) =>
-      ctx.db.insert("rooms", {
-        name: "kept",
-        autoCompleteVoting: false,
-        isGameOver: false,
-        createdAt: Date.now(),
-        lastActivityAt: Date.now(),
-        retained: true,
-      })
-    );
-    const alreadyFalse = await seedRoom(t, "fresh");
+    const keptId = await seedStaleRoom(t, { retained: true });
 
-    const first = await t.mutation(internal.migrations.backfillRoomsRetained, {
-      batchSize: 2,
-    });
-    expect(first).toEqual({ found: 2, stamped: 2, rescheduled: true });
-    expect(await pendingBackfills(t)).toBe(1);
+    const result = await t.mutation(internal.cleanup.removeInactiveRooms, {});
 
-    await drainScheduled(t);
-
-    const retained = await retainedById(t);
-    for (const id of legacy) expect(retained.get(id)).toBe(false);
-    expect(retained.get(alreadyTrue)).toBe(true);
-    expect(retained.get(alreadyFalse)).toBe(false);
-    expect(await pendingBackfills(t)).toBe(0);
+    expect(result.roomsScheduled).toBe(0);
+    expect(await scheduledCascadeRoomIds(t)).toEqual(new Set());
+    expect(await t.run((ctx) => ctx.db.get(keptId))).not.toBeNull();
   });
 
-  it("terminates without rescheduling once the batch comes back short", async () => {
+  it("a non-retained room is scheduled for deletion after five quiet days", async () => {
     const t = convexTest(schema, modules);
-    await seedLegacyRoom(t, "L1");
+    const staleId = await seedStaleRoom(t, { retained: false });
+    const activeId = await seedRoom(t, "active");
 
-    const result = await t.mutation(internal.migrations.backfillRoomsRetained, {
-      batchSize: 2,
-    });
-    expect(result).toEqual({ found: 1, stamped: 1, rescheduled: false });
-    expect(await pendingBackfills(t)).toBe(0);
+    const result = await t.mutation(internal.cleanup.removeInactiveRooms, {});
 
-    // Idempotent: a re-run finds nothing left to stamp.
-    const again = await t.mutation(internal.migrations.backfillRoomsRetained, {});
-    expect(again).toEqual({ found: 0, stamped: 0, rescheduled: false });
+    expect(result.roomsScheduled).toBe(1);
+    expect(await scheduledCascadeRoomIds(t)).toEqual(new Set([staleId]));
+    expect(await t.run((ctx) => ctx.db.get(activeId))).not.toBeNull();
   });
 
-  it("dryRun reports the unstamped count, bounded by batchSize, and writes nothing", async () => {
+  it("retention is the only discriminator: roomType does not matter", async () => {
     const t = convexTest(schema, modules);
-    const legacy = await Promise.all(
-      ["L1", "L2", "L3"].map((name) => seedLegacyRoom(t, name))
+    const staleCanvas = await seedStaleRoom(t, { retained: false, roomType: "canvas" });
+    const staleUntyped = await seedStaleRoom(t, { retained: false });
+    await seedStaleRoom(t, { retained: true, roomType: "canvas" });
+    await seedStaleRoom(t, { retained: true });
+
+    const result = await t.mutation(internal.cleanup.removeInactiveRooms, {});
+
+    expect(result.roomsScheduled).toBe(2);
+    expect(await scheduledCascadeRoomIds(t)).toEqual(
+      new Set([staleCanvas, staleUntyped])
     );
-    await seedRoom(t, "fresh");
-
-    const result = await t.mutation(internal.migrations.backfillRoomsRetained, {
-      dryRun: true,
-    });
-    expect(result).toEqual({ found: 3, stamped: 0, rescheduled: false });
-
-    const bounded = await t.mutation(internal.migrations.backfillRoomsRetained, {
-      dryRun: true,
-      batchSize: 2,
-    });
-    expect(bounded).toEqual({ found: 2, stamped: 0, rescheduled: false });
-
-    const retained = await retainedById(t);
-    for (const id of legacy) expect(retained.get(id)).toBeUndefined();
-    expect(await pendingBackfills(t)).toBe(0);
   });
 });

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -33,6 +33,7 @@ async function seedRoom(t: T, lastActivityAt: number): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: lastActivityAt,
       lastActivityAt,
+      retained: false,
     })
   );
 }

--- a/convex/roomAggregate.test.ts
+++ b/convex/roomAggregate.test.ts
@@ -109,6 +109,7 @@ async function seedRoom(t: T): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }
@@ -159,6 +160,7 @@ async function seedFullRoom(
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     });
     const userId = await ctx.db.insert("users", {
       authUserId: `auth-${crypto.randomUUID()}`,
@@ -350,6 +352,7 @@ describe("removeInactiveRooms", () => {
         isGameOver: false,
         createdAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
         lastActivityAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        retained: false,
       })
     );
     const activeId = await seedRoom(t);
@@ -381,6 +384,7 @@ describe("removeInactiveRooms", () => {
         isGameOver: false,
         createdAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
         lastActivityAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        retained: false,
       })
     );
     const userId = await t.run((ctx) =>
@@ -428,6 +432,7 @@ describe("removeInactiveRooms", () => {
         isGameOver: false,
         createdAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
         lastActivityAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        retained: false,
       })
     );
     const userId = await t.run((ctx) =>

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -36,10 +36,10 @@ export default defineSchema({
     createdAt: v.number(),
     lastActivityAt: v.number(),
     // Retention (ADR-0019): true iff the room belongs to a Team, so the
-    // five-day sweep leaves it alone. Optional during the widen release;
-    // migrations.backfillRoomsRetained stamps legacy rows `false`, then the
-    // narrow release (#285) makes it required and drops `by_activity`.
-    retained: v.optional(v.boolean()),
+    // five-day sweep leaves it alone. Every row carries it: new rows from
+    // the writers, legacy rows from the backfill that ran before this field
+    // became required.
+    retained: v.boolean(),
     // Room permissions & ownership
     ownerId: v.optional(v.id("users")),
     permissions: v.optional(
@@ -67,8 +67,7 @@ export default defineSchema({
       })
     ),
   })
-    .index("by_activity", ["lastActivityAt"]) // Sweep reads this until #285
-    .index("by_retention_activity", ["retained", "lastActivityAt"]) // Sweep's next read path; backfill reads the undefined range
+    .index("by_retention_activity", ["retained", "lastActivityAt"]) // The sweep: non-retained rooms by staleness
     .index("by_created", ["createdAt"]) // For querying recent rooms
     .index("by_owner", ["ownerId"]), // For transferring ownership on account linking
 

--- a/convex/timerState.test.ts
+++ b/convex/timerState.test.ts
@@ -149,6 +149,7 @@ async function seedRoom(t: T): Promise<Id<"rooms">> {
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
     })
   );
 }

--- a/convex/votingRound.test.ts
+++ b/convex/votingRound.test.ts
@@ -27,6 +27,7 @@ async function seedRoom(
       isGameOver: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
+      retained: false,
       ...overrides,
     })
   );

--- a/src/components/room/demo/DemoSimulationProvider.tsx
+++ b/src/components/room/demo/DemoSimulationProvider.tsx
@@ -85,6 +85,7 @@ function buildRoom(state: DemoSimulationState): Doc<"rooms"> {
     name: "Planning Poker Demo",
     roomType: "canvas",
     autoCompleteVoting: true,
+    retained: false,
     // `isGameOver` is this codebase's per-round reveal toggle, NOT a terminal
     // "session done" flag: reveal sets it true and the next round's reset clears
     // it (votingRound.ts reveal/reset), and phaseOf returns "revealed" iff it is

--- a/src/components/room/hooks/useCanvasNodes.test.tsx
+++ b/src/components/room/hooks/useCanvasNodes.test.tsx
@@ -63,6 +63,7 @@ const ROOM_DATA: RoomWithRelatedData = {
     isGameOver: false,
     createdAt: 0,
     lastActivityAt: 0,
+    retained: false,
   },
   users: [
     {


### PR DESCRIPTION
Closes #285. Narrow half of the `rooms.retained` migration (ADR-0019, spec §3 step 3).

## Release ordering constraint

This must deploy separately from #284 and only after the backfill has run to completion in prod. Every merge to `main` deploys to production, so the merge is the ordering unit: #304 (widen) merged and deployed first, the backfill ran, and this PR merges second. Both may appear in the same release-please changelog; that is fine.

Backfill state before this merge (2026-09-04): `backfillRoomsRetained` stamped 78 legacy rooms and a follow-up dry run reported 0 unstamped. The Convex push validates data at rest, so the narrowed schema would refuse to deploy if any room lacked the field.

This PR removes the backfill migration (a required field makes its `undefined` index query a type error, and its job is done). If the narrow push were ever to abort on an unstamped row, recovery is a revert of this PR, not a re-run.

## What changed

- `convex/schema.ts`: `retained` is a required boolean. `by_activity` is dropped.
- `convex/model/cleanup.ts`: the sweep reads `by_retention_activity` with `retained = false` and `lastActivityAt` before the cutoff. Batch size and scheduling are unchanged.
- `convex/migrations.ts`: `backfillRoomsRetained` removed.
- `convex/retention.test.ts`: a retained room outlives five quiet days, a non-retained room is scheduled for deletion, and retention is the only discriminator (non-retained rooms with `roomType` canvas and undefined are treated identically).
- Thirteen raw room inserts across nine convex test files, plus two `Doc<"rooms">` literals in `src/` (demo provider and a hook test), gained `retained: false`.

https://claude.ai/code/session_01LTuViwbbbictkKbzyZCBaa
