### PR TITLE
feat(retro): prefactor room access guard and permission decision keyed by ceremony

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    name: Lint & Type Check
+    name: Lint, Type Check & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,3 +19,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run ts:check
+      - run: npm run test

--- a/convex/actingUser.test.ts
+++ b/convex/actingUser.test.ts
@@ -105,7 +105,7 @@ describe("acting-user guard (requireActingUser)", () => {
     const asOutsider = t.withIdentity({ subject: "auth-outsider" });
     await expect(
       asOutsider.query(api.canvas.getCanvasNodes, { roomId })
-    ).rejects.toThrow("Not a member of this room");
+    ).rejects.toThrow("You don't have access to this room");
   });
 
   it("actor mismatch throws on updateNodePosition", async () => {

--- a/convex/canvas.ts
+++ b/convex/canvas.ts
@@ -1,14 +1,14 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import * as Canvas from "./model/canvas";
-import { requireRoomMember, requireActingUser } from "./model/auth";
+import { requireRoomReader, requireActingUser } from "./model/auth";
 
 // Get all canvas nodes for a room
-// Requires room membership: note contents are private to the room.
+// Requires room access (ADR-0009): note contents are private to the room.
 export const getCanvasNodes = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomMember(ctx, args.roomId);
+    await requireRoomReader(ctx, args.roomId);
     return await Canvas.getCanvasNodes(ctx, args.roomId);
   },
 });

--- a/convex/evaluateJoin.test.ts
+++ b/convex/evaluateJoin.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import type { Doc } from "./_generated/dataModel";
+import {
+  evaluateJoin,
+  accountTypeOf,
+  type AccountType,
+  type JoinDecision,
+  type JoinPolicy,
+} from "./permissions";
+
+// The join decision (ADR-0013, spec §4.4): a pure function beside `evaluate`,
+// not a branch of it. A joiner has no membership and no role.
+
+describe("evaluateJoin — full table", () => {
+  const cases: Array<{
+    policy: JoinPolicy;
+    accountType: AccountType;
+    isTeamMember: boolean;
+    expected: JoinDecision;
+  }> = [
+    // anyone: everyone passes
+    { policy: "anyone", accountType: "anonymous", isTeamMember: false, expected: { allowed: true } },
+    { policy: "anyone", accountType: "permanent", isTeamMember: false, expected: { allowed: true } },
+    { policy: "anyone", accountType: "anonymous", isTeamMember: true, expected: { allowed: true } },
+    { policy: "anyone", accountType: "permanent", isTeamMember: true, expected: { allowed: true } },
+    // permanentAccounts: anonymous non-members are refused
+    { policy: "permanentAccounts", accountType: "anonymous", isTeamMember: false, expected: { allowed: false, reason: "permanent-account-required" } },
+    { policy: "permanentAccounts", accountType: "permanent", isTeamMember: false, expected: { allowed: true } },
+    { policy: "permanentAccounts", accountType: "anonymous", isTeamMember: true, expected: { allowed: true } },
+    { policy: "permanentAccounts", accountType: "permanent", isTeamMember: true, expected: { allowed: true } },
+    // teamMembers: every non-member is refused, whatever their account
+    { policy: "teamMembers", accountType: "anonymous", isTeamMember: false, expected: { allowed: false, reason: "team-members-only" } },
+    { policy: "teamMembers", accountType: "permanent", isTeamMember: false, expected: { allowed: false, reason: "team-members-only" } },
+    { policy: "teamMembers", accountType: "anonymous", isTeamMember: true, expected: { allowed: true } },
+    { policy: "teamMembers", accountType: "permanent", isTeamMember: true, expected: { allowed: true } },
+  ];
+
+  it.each(cases)(
+    "$policy / $accountType / teamMember=$isTeamMember → $expected.allowed",
+    ({ policy, accountType, isTeamMember, expected }) => {
+      expect(evaluateJoin(policy, accountType, isTeamMember)).toEqual(expected);
+    }
+  );
+
+  it("a team member satisfies every policy", () => {
+    for (const policy of ["anyone", "permanentAccounts", "teamMembers"] as const) {
+      for (const accountType of ["anonymous", "permanent"] as const) {
+        expect(evaluateJoin(policy, accountType, true)).toEqual({ allowed: true });
+      }
+    }
+  });
+
+  it("an anonymous account is refused on permanentAccounts and teamMembers only", () => {
+    expect(evaluateJoin("anyone", "anonymous", false).allowed).toBe(true);
+    expect(evaluateJoin("permanentAccounts", "anonymous", false).allowed).toBe(false);
+    expect(evaluateJoin("teamMembers", "anonymous", false).allowed).toBe(false);
+  });
+
+  it("a permanent non-team-member is refused on teamMembers only", () => {
+    expect(evaluateJoin("anyone", "permanent", false).allowed).toBe(true);
+    expect(evaluateJoin("permanentAccounts", "permanent", false).allowed).toBe(true);
+    expect(evaluateJoin("teamMembers", "permanent", false).allowed).toBe(false);
+  });
+});
+
+describe("accountTypeOf — the server's one derivation of the join input", () => {
+  function user(accountType?: Doc<"users">["accountType"]): Doc<"users"> {
+    return {
+      _id: "u1",
+      _creationTime: 0,
+      authUserId: "a1",
+      name: "U",
+      createdAt: 0,
+      ...(accountType ? { accountType } : {}),
+    } as Doc<"users">;
+  }
+
+  it("is permanent only when the user row says so", () => {
+    expect(accountTypeOf(user("permanent"))).toBe("permanent");
+  });
+
+  it("treats an explicit anonymous row as anonymous", () => {
+    expect(accountTypeOf(user("anonymous"))).toBe("anonymous");
+  });
+
+  it("treats an undefined accountType as anonymous", () => {
+    expect(accountTypeOf(user())).toBe("anonymous");
+  });
+});

--- a/convex/issues.ts
+++ b/convex/issues.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import * as Issues from "./model/issues";
 import * as VotingRound from "./model/votingRound";
-import { requireRoomMember, requireCan } from "./model/auth";
+import { requireRoomReader, requireCan } from "./model/auth";
 
 /**
  * List all issues for a room, ordered by their order field
@@ -26,24 +26,24 @@ export const getCurrent = query({
 
 /**
  * Get issues formatted for export.
- * Requires room membership: the export includes discussion-note contents.
+ * Requires room access (ADR-0009): the export includes discussion-note contents.
  */
 export const getForExport = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomMember(ctx, args.roomId);
+    await requireRoomReader(ctx, args.roomId);
     return await Issues.getIssuesForExport(ctx, args.roomId);
   },
 });
 
 /**
  * Get issues with enhanced data for export (time-to-consensus, individual votes, voting rounds).
- * Requires room membership since it exposes per-user voting data.
+ * Requires room access (ADR-0009) since it exposes per-user voting data.
  */
 export const getForEnhancedExport = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomMember(ctx, args.roomId);
+    await requireRoomReader(ctx, args.roomId);
     return await Issues.getEnhancedIssuesForExport(ctx, args.roomId);
   },
 });

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -4,8 +4,9 @@ import {
   PermissionCategory,
   Action,
   resolve,
-  requiresOwnerLevel,
+  readsOwnerAbsence,
   getEffectivePermissions,
+  categoryLevel,
   getEffectiveRole,
 } from "../permissions";
 import { isRoomOwnerAbsent } from "./permissions";
@@ -94,6 +95,43 @@ export async function requireRoomMember(
 }
 
 /**
+ * Room access (ADR-0009): may the authenticated user *read* this room's
+ * contents? Passes a room member; #287 extends it to members of the room's
+ * Team. Returns the identity, user and room — never a membership row, because
+ * a reader need not be an attendee. Every read-only query on room-owned data
+ * takes this guard; every mutation keeps `requireRoomMember` (attendance).
+ */
+export async function requireRoomReader(
+  ctx: QueryCtx | MutationCtx,
+  roomId: Id<"rooms">
+): Promise<{
+  identity: AuthIdentity;
+  user: Doc<"users">;
+  room: Doc<"rooms">;
+}> {
+  const { identity, user } = await requireAuthUser(ctx);
+  const [room, membership] = await Promise.all([
+    ctx.db.get(roomId),
+    ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room_user", (q) =>
+        q.eq("roomId", roomId).eq("userId", user._id)
+      )
+      .first(),
+  ]);
+  if (!room) {
+    throw new Error("Room not found");
+  }
+  if (!membership) {
+    // #287: a member of room.teamId also passes here. The copy speaks of
+    // access, not attendance — this guard never asks whether you are *in*
+    // the room (ADR-0009).
+    throw new Error("You don't have access to this room");
+  }
+  return { identity, user, room };
+}
+
+/**
  * Requires authentication and room membership, and verifies the authenticated
  * user IS `userId` — handlers that accept a userId argument must not let one
  * member act as another. Returns the verified identity, user, and membership.
@@ -127,7 +165,15 @@ export type RequireCanSpec =
   | { kind: "category"; category: PermissionCategory }
   | {
       kind: "relationship";
-      verb: "remove" | "promote" | "demote" | "transfer" | "changePerms";
+      verb:
+        | "remove"
+        | "promote"
+        | "demote"
+        | "transfer"
+        | "changePerms"
+        | "ratchet"
+        | "delete"
+        | "claim";
     };
 
 /**
@@ -215,18 +261,20 @@ async function guardRoomAction(
     throw new Error("Room not found");
   }
 
-  const permissions = getEffectivePermissions(room);
+  const effective = getEffectivePermissions(room);
   const actorRole = getEffectiveRole(membership);
 
   let action: Action;
   let target: Doc<"roomMemberships"> | undefined;
 
   if (spec.kind === "category") {
-    action = {
-      kind: "category",
-      category: spec.category,
-      level: permissions[spec.category],
-    };
+    // Narrow on the ceremony before indexing: a category from the other
+    // ceremony has no level here and is refused outright (ADR-0013).
+    const level = categoryLevel(effective, spec.category);
+    if (level === undefined) {
+      throw new Error("This action does not apply to this room type.");
+    }
+    action = { kind: "category", category: spec.category, level };
   } else {
     // Relationship verb. Fetch the target membership whenever a target is
     // supplied; fill targetRole only for the target-constrained verbs.
@@ -261,13 +309,23 @@ async function guardRoomAction(
     }
   }
 
-  // Owner absence only refines an owner-level denial (see evaluate); for any
-  // other action it can't change the result, so skip the DB read.
-  const ownerAbsent = requiresOwnerLevel(action)
+  // Owner absence refines an owner-level denial and decides `claim` (see
+  // evaluate); for any other action it can't change the result, so skip the
+  // DB read.
+  const ownerAbsent = readsOwnerAbsence(action)
     ? await isRoomOwnerAbsent(ctx, room)
     : false;
 
-  const decision = resolve(action, { actorRole, permissions, ownerAbsent });
+  // Team inputs (ADR-0013): populated only for rooms with a `teamId`, which
+  // #287 introduces. Until then no actor holds a team role, so `claim` is
+  // insufficient-role for everyone, and `ownerInTeam` is vacuously false.
+  const decision = resolve(action, {
+    actorRole,
+    permissions: effective.permissions,
+    ownerAbsent,
+    actorTeamRole: undefined,
+    ownerInTeam: false,
+  });
   if (!decision.allowed) {
     throw new Error(decision.message);
   }

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveRole,
 } from "../permissions";
 import { isRoomOwnerAbsent } from "./permissions";
+import { getMembership } from "./users";
 
 /**
  * Auth identity returned by ctx.auth.getUserIdentity().
@@ -112,12 +113,7 @@ export async function requireRoomReader(
   const { identity, user } = await requireAuthUser(ctx);
   const [room, membership] = await Promise.all([
     ctx.db.get(roomId),
-    ctx.db
-      .query("roomMemberships")
-      .withIndex("by_room_user", (q) =>
-        q.eq("roomId", roomId).eq("userId", user._id)
-      )
-      .first(),
+    getMembership(ctx, roomId, user._id),
   ]);
   if (!room) {
     throw new Error("Room not found");
@@ -268,8 +264,7 @@ async function guardRoomAction(
   let target: Doc<"roomMemberships"> | undefined;
 
   if (spec.kind === "category") {
-    // Narrow on the ceremony before indexing: a category from the other
-    // ceremony has no level here and is refused outright (ADR-0013).
+    // A category from the other ceremony has no level here (ADR-0013).
     const level = categoryLevel(effective, spec.category);
     if (level === undefined) {
       throw new Error("This action does not apply to this room type.");
@@ -316,14 +311,14 @@ async function guardRoomAction(
     ? await isRoomOwnerAbsent(ctx, room)
     : false;
 
-  // Team inputs (ADR-0013): populated only for rooms with a `teamId`, which
-  // #287 introduces. Until then no actor holds a team role, so `claim` is
-  // insufficient-role for everyone, and `ownerInTeam` is vacuously false.
+  // Team inputs (ADR-0013): `actorTeamRole` is populated only for rooms with
+  // a `teamId`, which #287 introduces. Until then no actor holds a team role,
+  // so `claim` is insufficient-role for everyone, and `ownerInTeam` is
+  // vacuously false.
   const decision = resolve(action, {
     actorRole,
     permissions: effective.permissions,
     ownerAbsent,
-    actorTeamRole: undefined,
     ownerInTeam: false,
   });
   if (!decision.allowed) {

--- a/convex/permissions.test.ts
+++ b/convex/permissions.test.ts
@@ -23,6 +23,7 @@ function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
     actorRole: "participant",
     permissions: allEveryone,
     ownerAbsent: false,
+    ownerInTeam: false,
     ...over,
   };
 }

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -6,17 +6,6 @@ export type MemberRole = "owner" | "facilitator" | "participant";
 
 export type PermissionLevel = "everyone" | "facilitators" | "owner";
 
-/**
- * The ceremony a room runs (CONTEXT.md): planning poker or retro. Derived from
- * the stored `roomType` — undefined and "canvas" are poker, "retro" is a retro
- * (ADR-0013). Keys the category set everywhere a category is looked up.
- */
-export type Ceremony = "poker" | "retro";
-
-export function ceremonyOf(roomType: Doc<"rooms">["roomType"]): Ceremony {
-  return roomType === "retro" ? "retro" : "poker";
-}
-
 /** The poker room's four owner-configurable categories. */
 export type PokerPermissionCategory =
   | "revealCards"
@@ -49,9 +38,9 @@ export type RetroPermissions = {
 };
 
 /**
- * The effective permissions of a room, discriminated on its ceremony so a
- * caller narrows before indexing a category. Returned by
- * `getEffectivePermissions`.
+ * The effective permissions of a room, discriminated on its ceremony
+ * (CONTEXT.md: planning poker or retro, named by `roomType`) so a caller
+ * narrows before indexing a category. Returned by `getEffectivePermissions`.
  */
 export type EffectivePermissions =
   | { ceremony: "poker"; permissions: RoomPermissions }
@@ -231,9 +220,9 @@ export function evaluate(action: Action, ctx: DecisionContext): Decision {
   }
 }
 
-/** Exhaustiveness guard — unreachable for a well-typed Action. */
-function assertNever(action: never): never {
-  throw new Error(`Unhandled action: ${JSON.stringify(action)}`);
+/** Exhaustiveness guard — unreachable for a well-typed input. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled value: ${JSON.stringify(value)}`);
 }
 
 /**
@@ -350,37 +339,6 @@ function decideRole(
 
 // --- Helpers ---
 
-// Each ceremony's category set, derived from its defaults so the four names
-// are spelled once per ceremony.
-const POKER_CATEGORIES: ReadonlySet<string> = new Set(Object.keys(DEFAULT_PERMISSIONS));
-const RETRO_CATEGORIES: ReadonlySet<string> = new Set(
-  Object.keys(DEFAULT_RETRO_PERMISSIONS)
-);
-
-function isPokerCategory(
-  category: PermissionCategory
-): category is PokerPermissionCategory {
-  return POKER_CATEGORIES.has(category);
-}
-
-function isRetroCategory(
-  category: PermissionCategory
-): category is RetroPermissionCategory {
-  return RETRO_CATEGORIES.has(category);
-}
-
-function isPokerPermissions(
-  p: Doc<"rooms">["permissions"]
-): p is RoomPermissions {
-  return p !== undefined && "revealCards" in p;
-}
-
-function isRetroPermissions(
-  p: Doc<"rooms">["permissions"]
-): p is RetroPermissions {
-  return p !== undefined && "stageFlow" in p;
-}
-
 /**
  * Returns the effective permissions for a room, keyed by its ceremony: the
  * poker set for roomType "canvas" or undefined, the retro set for "retro".
@@ -391,36 +349,34 @@ function isRetroPermissions(
 export function getEffectivePermissions(
   room: Pick<Doc<"rooms">, "roomType" | "permissions">
 ): EffectivePermissions {
-  if (ceremonyOf(room.roomType) === "retro") {
+  const stored = room.permissions;
+  if (room.roomType === "retro") {
     return {
       ceremony: "retro",
-      permissions: isRetroPermissions(room.permissions)
-        ? room.permissions
-        : DEFAULT_RETRO_PERMISSIONS,
+      permissions:
+        stored && "stageFlow" in stored ? stored : DEFAULT_RETRO_PERMISSIONS,
     };
   }
   return {
     ceremony: "poker",
-    permissions: isPokerPermissions(room.permissions)
-      ? room.permissions
-      : DEFAULT_PERMISSIONS,
+    permissions:
+      stored && "revealCards" in stored ? stored : DEFAULT_PERMISSIONS,
   };
 }
 
 /**
  * The level a category resolves to in a room's effective permissions, or
  * undefined when the category belongs to the other ceremony (a poker
- * mutation invoked on a retro room, or vice versa). Narrows on the ceremony
- * before indexing so `evaluate` never sees a level from the wrong set.
+ * mutation invoked on a retro room, or vice versa). The permissions object
+ * *is* the ceremony's category set, so an absent key is the narrowing.
  */
 export function categoryLevel(
   effective: EffectivePermissions,
   category: PermissionCategory
 ): PermissionLevel | undefined {
-  if (effective.ceremony === "poker") {
-    return isPokerCategory(category) ? effective.permissions[category] : undefined;
-  }
-  return isRetroCategory(category) ? effective.permissions[category] : undefined;
+  const levels: Partial<Record<PermissionCategory, PermissionLevel>> =
+    effective.permissions;
+  return levels[category];
 }
 
 // --- Join decision (pure) ---
@@ -459,12 +415,8 @@ export function evaluateJoin(
     case "teamMembers":
       return { allowed: false, reason: "team-members-only" };
     default:
-      return assertNeverPolicy(policy);
+      return assertNever(policy);
   }
-}
-
-function assertNeverPolicy(policy: never): never {
-  throw new Error(`Unhandled join policy: ${JSON.stringify(policy)}`);
 }
 
 /**

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -6,15 +6,56 @@ export type MemberRole = "owner" | "facilitator" | "participant";
 
 export type PermissionLevel = "everyone" | "facilitators" | "owner";
 
-export type PermissionCategory =
+/**
+ * The ceremony a room runs (CONTEXT.md): planning poker or retro. Derived from
+ * the stored `roomType` — undefined and "canvas" are poker, "retro" is a retro
+ * (ADR-0013). Keys the category set everywhere a category is looked up.
+ */
+export type Ceremony = "poker" | "retro";
+
+export function ceremonyOf(roomType: Doc<"rooms">["roomType"]): Ceremony {
+  return roomType === "retro" ? "retro" : "poker";
+}
+
+/** The poker room's four owner-configurable categories. */
+export type PokerPermissionCategory =
   | "revealCards"
   | "gameFlow"
   | "issueManagement"
   | "roomSettings";
 
+/** The retro room's four owner-configurable categories (ADR-0013, spec §4.2). */
+export type RetroPermissionCategory =
+  | "stageFlow"
+  | "cardManagement"
+  | "actionManagement"
+  | "retroSettings";
+
+/**
+ * Every configurable category across both room types. A category is looked
+ * up only after narrowing on the room kind (see `categoryLevel`); the
+ * decision itself (`evaluate`) is generic over the name.
+ */
+export type PermissionCategory = PokerPermissionCategory | RetroPermissionCategory;
+
+/** The poker room's stored permission shape. */
 export type RoomPermissions = {
-  [K in PermissionCategory]: PermissionLevel;
+  [K in PokerPermissionCategory]: PermissionLevel;
 };
+
+/** The retro room's stored permission shape. */
+export type RetroPermissions = {
+  [K in RetroPermissionCategory]: PermissionLevel;
+};
+
+/**
+ * The effective permissions of a room, discriminated on its ceremony so a
+ * caller narrows before indexing a category. Returned by
+ * `getEffectivePermissions`.
+ */
+export type EffectivePermissions =
+  | { ceremony: "poker"; permissions: RoomPermissions }
+  | { ceremony: "retro"; permissions: RetroPermissions };
 
 // --- Defaults ---
 
@@ -25,13 +66,30 @@ export const DEFAULT_PERMISSIONS: RoomPermissions = {
   roomSettings: "everyone",
 };
 
+/**
+ * Retro has no back-compat to honour, so its defaults are chosen (ADR-0013):
+ * advance moves everyone's shared pointer; rewriting another's card
+ * default-open is wrong in a candour ceremony; gating action creation makes
+ * the facilitator a bottleneck on the one thing that buys follow-through.
+ */
+export const DEFAULT_RETRO_PERMISSIONS: RetroPermissions = {
+  stageFlow: "facilitators",
+  cardManagement: "facilitators",
+  actionManagement: "everyone",
+  retroSettings: "facilitators",
+};
+
 // --- Permission decision (pure) ---
 
 /**
  * Why a Decision was denied. The reason classifies the denial; user-facing
  * copy is derived from it via denialMessage, never embedded here.
  */
-export type DenialReason = "insufficient-role" | "owner-absent" | "target-rank";
+export type DenialReason =
+  | "insufficient-role"
+  | "owner-absent"
+  | "target-rank"
+  | "owner-present";
 
 /**
  * The verdict returned by evaluate. Pure value — no IO, no identity.
@@ -53,16 +111,29 @@ export type Action =
       verb: "remove" | "promote" | "demote";
       targetRole: MemberRole;
     }
-  | { kind: "relationship"; verb: "transfer" | "changePerms" };
+  | {
+      kind: "relationship";
+      verb: "transfer" | "changePerms" | "ratchet" | "delete" | "claim";
+    };
+
+/**
+ * A member's role in the Team that owns the room, when it has one. Populated
+ * by the guard only for rooms with a `teamId`; never a room power except for
+ * `claim` (ADR-0013).
+ */
+export type TeamRole = "admin" | "member";
 
 /**
  * The inputs the permission decision depends on: the actor's role, the room's
- * permissions, and whether the owner is absent. No DB, no identity.
+ * permissions, whether the owner is absent, and — for `claim` — the actor's
+ * team role and whether the owner is still in the Team. No DB, no identity.
  */
 export type DecisionContext = {
   actorRole: MemberRole;
-  permissions: RoomPermissions;
+  permissions: RoomPermissions | RetroPermissions;
   ownerAbsent: boolean;
+  actorTeamRole?: TeamRole;
+  ownerInTeam: boolean;
 };
 
 /**
@@ -101,9 +172,22 @@ export function evaluate(action: Action, ctx: DecisionContext): Decision {
   // target-rank check. Role always precedes target.
   switch (action.verb) {
     case "transfer":
-    case "changePerms": {
+    case "changePerms":
+    case "ratchet":
+    case "delete": {
       // Owner-only, no target constraint.
       return decideRole(ctx, ctx.actorRole === "owner", requiresOwnerLevel(action));
+    }
+    case "claim": {
+      // A team admin's one room power (ADR-0013): take ownership of a room
+      // whose owner is absent or no longer in the Team. Room role never
+      // substitutes for team role, and a present in-team owner must transfer.
+      if (ctx.actorTeamRole !== "admin") {
+        return { allowed: false, reason: "insufficient-role" };
+      }
+      return ctx.ownerAbsent || !ctx.ownerInTeam
+        ? { allowed: true }
+        : { allowed: false, reason: "owner-present" };
     }
     case "demote": {
       // Owner-only; target must be a facilitator.
@@ -162,8 +246,20 @@ export function requiresOwnerLevel(action: Action): boolean {
   return (
     action.verb === "transfer" ||
     action.verb === "changePerms" ||
-    action.verb === "demote"
+    action.verb === "demote" ||
+    action.verb === "ratchet" ||
+    action.verb === "delete"
   );
+}
+
+/**
+ * Whether the decision reads `ownerAbsent` at all: every owner-level action
+ * (it refines the denial reason) and `claim` (it decides the outcome). The
+ * guard skips the owner-absence DB read for everything else.
+ */
+export function readsOwnerAbsence(action: Action): boolean {
+  if (requiresOwnerLevel(action)) return true;
+  return action.kind === "relationship" && action.verb === "claim";
 }
 
 /**
@@ -174,6 +270,10 @@ export function requiresOwnerLevel(action: Action): boolean {
 export function denialMessage(action: Action, reason: DenialReason): string {
   if (reason === "owner-absent") {
     return "Room owner has left. Owner-level actions are disabled until the owner returns.";
+  }
+
+  if (reason === "owner-present") {
+    return "The owner is still here — ask them to transfer ownership.";
   }
 
   if (reason === "target-rank") {
@@ -188,6 +288,9 @@ export function denialMessage(action: Action, reason: DenialReason): string {
   }
 
   // insufficient-role
+  if (action.kind === "relationship" && action.verb === "claim") {
+    return "Only a team admin can claim this room.";
+  }
   return requiresOwnerLevel(action)
     ? "Only the owner can do this."
     : "Only facilitators and the owner can do this.";
@@ -247,12 +350,130 @@ function decideRole(
 
 // --- Helpers ---
 
+// Each ceremony's category set, derived from its defaults so the four names
+// are spelled once per ceremony.
+const POKER_CATEGORIES: ReadonlySet<string> = new Set(Object.keys(DEFAULT_PERMISSIONS));
+const RETRO_CATEGORIES: ReadonlySet<string> = new Set(
+  Object.keys(DEFAULT_RETRO_PERMISSIONS)
+);
+
+function isPokerCategory(
+  category: PermissionCategory
+): category is PokerPermissionCategory {
+  return POKER_CATEGORIES.has(category);
+}
+
+function isRetroCategory(
+  category: PermissionCategory
+): category is RetroPermissionCategory {
+  return RETRO_CATEGORIES.has(category);
+}
+
+function isPokerPermissions(
+  p: Doc<"rooms">["permissions"]
+): p is RoomPermissions {
+  return p !== undefined && "revealCards" in p;
+}
+
+function isRetroPermissions(
+  p: Doc<"rooms">["permissions"]
+): p is RetroPermissions {
+  return p !== undefined && "stageFlow" in p;
+}
+
 /**
- * Returns the effective permissions for a room, falling back to defaults
- * for legacy rooms without permissions set.
+ * Returns the effective permissions for a room, keyed by its ceremony: the
+ * poker set for roomType "canvas" or undefined, the retro set for "retro".
+ * Falls back to that ceremony's defaults when nothing is stored — or when the
+ * stored shape belongs to the other ceremony, which no writer produces but the
+ * union schema cannot rule out.
  */
-export function getEffectivePermissions(room: Doc<"rooms">): RoomPermissions {
-  return room.permissions ?? DEFAULT_PERMISSIONS;
+export function getEffectivePermissions(
+  room: Pick<Doc<"rooms">, "roomType" | "permissions">
+): EffectivePermissions {
+  if (ceremonyOf(room.roomType) === "retro") {
+    return {
+      ceremony: "retro",
+      permissions: isRetroPermissions(room.permissions)
+        ? room.permissions
+        : DEFAULT_RETRO_PERMISSIONS,
+    };
+  }
+  return {
+    ceremony: "poker",
+    permissions: isPokerPermissions(room.permissions)
+      ? room.permissions
+      : DEFAULT_PERMISSIONS,
+  };
+}
+
+/**
+ * The level a category resolves to in a room's effective permissions, or
+ * undefined when the category belongs to the other ceremony (a poker
+ * mutation invoked on a retro room, or vice versa). Narrows on the ceremony
+ * before indexing so `evaluate` never sees a level from the wrong set.
+ */
+export function categoryLevel(
+  effective: EffectivePermissions,
+  category: PermissionCategory
+): PermissionLevel | undefined {
+  if (effective.ceremony === "poker") {
+    return isPokerCategory(category) ? effective.permissions[category] : undefined;
+  }
+  return isRetroCategory(category) ? effective.permissions[category] : undefined;
+}
+
+// --- Join decision (pure) ---
+
+/** Who may join a room (ADR-0013, spec §4.4). */
+export type JoinPolicy = "anyone" | "permanentAccounts" | "teamMembers";
+
+export type AccountType = "anonymous" | "permanent";
+
+export type JoinDenialReason = "permanent-account-required" | "team-members-only";
+
+export type JoinDecision =
+  | { allowed: true }
+  | { allowed: false; reason: JoinDenialReason };
+
+/**
+ * The join decision: may this account become a member under this policy. A
+ * pure function beside `evaluate`, not a branch of it — a joiner has no
+ * membership and no role. A team member satisfies every policy: access is
+ * the stronger claim, and someone who may read the archive may sit in the
+ * room. Shared by the `joinRoom` adapter and the join page's disabled state.
+ */
+export function evaluateJoin(
+  policy: JoinPolicy,
+  accountType: AccountType,
+  isTeamMember: boolean
+): JoinDecision {
+  if (isTeamMember) return { allowed: true };
+  switch (policy) {
+    case "anyone":
+      return { allowed: true };
+    case "permanentAccounts":
+      return accountType === "permanent"
+        ? { allowed: true }
+        : { allowed: false, reason: "permanent-account-required" };
+    case "teamMembers":
+      return { allowed: false, reason: "team-members-only" };
+    default:
+      return assertNeverPolicy(policy);
+  }
+}
+
+function assertNeverPolicy(policy: never): never {
+  throw new Error(`Unhandled join policy: ${JSON.stringify(policy)}`);
+}
+
+/**
+ * The server's one derivation of the join decision's `accountType`: permanent
+ * only when the user row says so, anonymous otherwise (an undefined row value
+ * is anonymous). The auth session's anonymous flag is never the input.
+ */
+export function accountTypeOf(user: Pick<Doc<"users">, "accountType">): AccountType {
+  return user.accountType === "permanent" ? "permanent" : "anonymous";
 }
 
 /**

--- a/convex/requireCanRoomType.test.ts
+++ b/convex/requireCanRoomType.test.ts
@@ -1,0 +1,187 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import { requireCan } from "./model/auth";
+import type { MemberRole, RetroPermissions } from "./permissions";
+
+// The guard's action assembly narrows on the ceremony before indexing a
+// category (ADR-0013), and reads owner absence for the new verbs. The pure
+// decision is covered in retroPermissions.test.ts; this file proves the IO
+// assembly feeds it the right inputs.
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+async function seedRoom(
+  t: T,
+  opts: {
+    roomType?: "canvas" | "retro";
+    permissions?: RetroPermissions;
+    ownerId?: Id<"users">;
+  } = {}
+): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      retained: false,
+      ...(opts.roomType ? { roomType: opts.roomType } : {}),
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+      ...(opts.ownerId ? { ownerId: opts.ownerId } : {}),
+    })
+  );
+}
+
+async function addMember(
+  t: T,
+  roomId: Id<"rooms">,
+  authUserId: string,
+  role?: MemberRole
+): Promise<Id<"users">> {
+  return t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("roomMemberships", {
+      roomId,
+      userId,
+      isSpectator: false,
+      joinedAt: Date.now(),
+      ...(role ? { role } : {}),
+    });
+    return userId;
+  });
+}
+
+describe("permission guard — category set keyed by room type", () => {
+  it("a retro room at defaults denies a participant stageFlow and allows a facilitator", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { roomType: "retro" });
+    await addMember(t, roomId, "auth-p");
+    await addMember(t, roomId, "auth-f", "facilitator");
+
+    await expect(
+      t
+        .withIdentity({ subject: "auth-p" })
+        .run((ctx) => requireCan(ctx, roomId, { kind: "category", category: "stageFlow" }))
+    ).rejects.toThrow("Only facilitators and the owner can do this.");
+
+    const bundle = await t
+      .withIdentity({ subject: "auth-f" })
+      .run((ctx) => requireCan(ctx, roomId, { kind: "category", category: "stageFlow" }));
+    expect(bundle.room._id).toBe(roomId);
+  });
+
+  it("a retro room honours its stored retro permissions", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      roomType: "retro",
+      permissions: {
+        stageFlow: "everyone",
+        cardManagement: "facilitators",
+        actionManagement: "everyone",
+        retroSettings: "facilitators",
+      },
+    });
+    await addMember(t, roomId, "auth-p");
+
+    await t
+      .withIdentity({ subject: "auth-p" })
+      .run((ctx) => requireCan(ctx, roomId, { kind: "category", category: "stageFlow" }));
+  });
+
+  it("a poker category on a retro room is refused as not applying to the room type", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { roomType: "retro" });
+    await addMember(t, roomId, "auth-o", "owner");
+
+    await expect(
+      t
+        .withIdentity({ subject: "auth-o" })
+        .run((ctx) => requireCan(ctx, roomId, { kind: "category", category: "revealCards" }))
+    ).rejects.toThrow("This action does not apply to this room type.");
+  });
+
+  it("a retro category on a poker room is refused as not applying to the room type", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t); // legacy poker room
+    await addMember(t, roomId, "auth-o", "owner");
+
+    await expect(
+      t
+        .withIdentity({ subject: "auth-o" })
+        .run((ctx) => requireCan(ctx, roomId, { kind: "category", category: "cardManagement" }))
+    ).rejects.toThrow("This action does not apply to this room type.");
+  });
+});
+
+describe("permission guard — ratchet, delete and claim", () => {
+  it("ratchet and delete are owner-only", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { roomType: "retro" });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-f", "facilitator");
+
+    for (const verb of ["ratchet", "delete"] as const) {
+      await t
+        .withIdentity({ subject: "auth-o" })
+        .run((ctx) => requireCan(ctx, roomId, { kind: "relationship", verb }));
+      await expect(
+        t
+          .withIdentity({ subject: "auth-f" })
+          .run((ctx) => requireCan(ctx, roomId, { kind: "relationship", verb }))
+      ).rejects.toThrow("Only the owner can do this.");
+    }
+  });
+
+  it("ratchet under lockdown reads owner absence and reports it", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { roomType: "retro" });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-f", "facilitator");
+    // The owner leaves: their membership is deleted.
+    await t.run(async (ctx) => {
+      const m = await ctx.db
+        .query("roomMemberships")
+        .withIndex("by_room_user", (q) => q.eq("roomId", roomId).eq("userId", ownerId))
+        .first();
+      await ctx.db.delete(m!._id);
+    });
+
+    await expect(
+      t
+        .withIdentity({ subject: "auth-f" })
+        .run((ctx) => requireCan(ctx, roomId, { kind: "relationship", verb: "ratchet" }))
+    ).rejects.toThrow(
+      "Room owner has left. Owner-level actions are disabled until the owner returns."
+    );
+  });
+
+  it("claim is refused for every room member while no Team exists to grant admin", async () => {
+    // Teams land in #287; until then the guard populates no team role, so
+    // claim is insufficient-role for everyone — including the room owner.
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { roomType: "retro" });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-p");
+
+    for (const subject of ["auth-o", "auth-p"]) {
+      await expect(
+        t
+          .withIdentity({ subject })
+          .run((ctx) => requireCan(ctx, roomId, { kind: "relationship", verb: "claim" }))
+      ).rejects.toThrow("Only a team admin can claim this room.");
+    }
+  });
+});

--- a/convex/requireRoomReader.test.ts
+++ b/convex/requireRoomReader.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="vite/client" />
-import { convexTest, type TestConvex } from "convex-test";
+import { convexTest } from "convex-test";
 import { describe, it, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireRoomReader } from "./model/auth";
+import { type T, seedRoom, seedUser as addUser, addMembership } from "./analytics.seeds";
 
 // Room access (ADR-0009): `requireRoomReader` answers "may you read this
 // room's contents?" and never returns a membership row. Today it passes room
@@ -13,41 +14,13 @@ import { requireRoomReader } from "./model/auth";
 
 const modules = import.meta.glob("./**/*.*s");
 
-type T = TestConvex<typeof schema>;
-
-async function seedRoom(t: T): Promise<Id<"rooms">> {
-  return t.run((ctx) =>
-    ctx.db.insert("rooms", {
-      name: "R",
-      autoCompleteVoting: false,
-      isGameOver: false,
-      createdAt: Date.now(),
-      lastActivityAt: Date.now(),
-      retained: false,
-    })
-  );
-}
-
-async function addUser(t: T, authUserId: string): Promise<Id<"users">> {
-  return t.run((ctx) =>
-    ctx.db.insert("users", { authUserId, name: "U", createdAt: Date.now() })
-  );
-}
-
 async function addMember(
   t: T,
   roomId: Id<"rooms">,
   authUserId: string
 ): Promise<Id<"users">> {
   const userId = await addUser(t, authUserId);
-  await t.run((ctx) =>
-    ctx.db.insert("roomMemberships", {
-      roomId,
-      userId,
-      isSpectator: false,
-      joinedAt: Date.now(),
-    })
-  );
+  await addMembership(t, roomId, userId, Date.now());
   return userId;
 }
 

--- a/convex/requireRoomReader.test.ts
+++ b/convex/requireRoomReader.test.ts
@@ -1,0 +1,178 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { requireRoomReader } from "./model/auth";
+
+// Room access (ADR-0009): `requireRoomReader` answers "may you read this
+// room's contents?" and never returns a membership row. Today it passes room
+// members only; #287 extends it to members of the room's Team. The enforcement
+// net: a non-member cannot read canvas nodes or either issue export.
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      retained: false,
+    })
+  );
+}
+
+async function addUser(t: T, authUserId: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", { authUserId, name: "U", createdAt: Date.now() })
+  );
+}
+
+async function addMember(
+  t: T,
+  roomId: Id<"rooms">,
+  authUserId: string
+): Promise<Id<"users">> {
+  const userId = await addUser(t, authUserId);
+  await t.run((ctx) =>
+    ctx.db.insert("roomMemberships", {
+      roomId,
+      userId,
+      isSpectator: false,
+      joinedAt: Date.now(),
+    })
+  );
+  return userId;
+}
+
+async function seedCanvasNode(t: T, roomId: Id<"rooms">): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("canvasNodes", {
+      roomId,
+      nodeId: "note-1",
+      type: "note",
+      position: { x: 0, y: 0 },
+      data: { text: "private" },
+      lastUpdatedAt: Date.now(),
+    })
+  );
+}
+
+describe("requireRoomReader — the room access guard", () => {
+  it("passes a room member and returns identity, user and room — never a membership", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await addMember(t, roomId, "auth-m");
+
+    const result = await t
+      .withIdentity({ subject: "auth-m" })
+      .run((ctx) => requireRoomReader(ctx, roomId));
+
+    expect(result.identity.subject).toBe("auth-m");
+    expect(result.user._id).toBe(userId);
+    expect(result.room._id).toBe(roomId);
+    expect(Object.keys(result).sort()).toEqual(["identity", "room", "user"]);
+    expect("membership" in result).toBe(false);
+  });
+
+  it("rejects an authenticated non-member", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-m");
+    await addUser(t, "auth-x");
+
+    await expect(
+      t.withIdentity({ subject: "auth-x" }).run((ctx) => requireRoomReader(ctx, roomId))
+    ).rejects.toThrow("You don't have access to this room");
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    await expect(
+      t.run((ctx) => requireRoomReader(ctx, roomId))
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  it("rejects a missing room", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-m");
+    await t.run((ctx) => ctx.db.delete(roomId));
+
+    await expect(
+      t.withIdentity({ subject: "auth-m" }).run((ctx) => requireRoomReader(ctx, roomId))
+    ).rejects.toThrow("Room not found");
+  });
+});
+
+describe("room-owned reads take the reader guard", () => {
+  it("a non-member cannot read canvas nodes; a member can", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-m");
+    await addUser(t, "auth-x");
+    await seedCanvasNode(t, roomId);
+
+    await expect(
+      t.withIdentity({ subject: "auth-x" }).query(api.canvas.getCanvasNodes, { roomId })
+    ).rejects.toThrow("You don't have access to this room");
+
+    const nodes = await t
+      .withIdentity({ subject: "auth-m" })
+      .query(api.canvas.getCanvasNodes, { roomId });
+    expect(nodes).toHaveLength(1);
+  });
+
+  it("a non-member cannot read the issue export; a member can", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-m");
+    await addUser(t, "auth-x");
+
+    await expect(
+      t.withIdentity({ subject: "auth-x" }).query(api.issues.getForExport, { roomId })
+    ).rejects.toThrow("You don't have access to this room");
+
+    await expect(
+      t.withIdentity({ subject: "auth-m" }).query(api.issues.getForExport, { roomId })
+    ).resolves.toEqual([]);
+  });
+
+  it("a non-member cannot read the enhanced issue export; a member can", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-m");
+    await addUser(t, "auth-x");
+
+    await expect(
+      t.withIdentity({ subject: "auth-x" }).query(api.issues.getForEnhancedExport, { roomId })
+    ).rejects.toThrow("You don't have access to this room");
+
+    await expect(
+      t.withIdentity({ subject: "auth-m" }).query(api.issues.getForEnhancedExport, { roomId })
+    ).resolves.toEqual([]);
+  });
+
+  it("an unauthenticated caller cannot read any of the three", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    await expect(t.query(api.canvas.getCanvasNodes, { roomId })).rejects.toThrow(
+      "Not authenticated"
+    );
+    await expect(t.query(api.issues.getForExport, { roomId })).rejects.toThrow(
+      "Not authenticated"
+    );
+    await expect(
+      t.query(api.issues.getForEnhancedExport, { roomId })
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/resolve.test.ts
+++ b/convex/resolve.test.ts
@@ -20,6 +20,7 @@ function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
     actorRole: "participant",
     permissions: allEveryone,
     ownerAbsent: false,
+    ownerInTeam: false,
     ...over,
   };
 }

--- a/convex/retroPermissions.test.ts
+++ b/convex/retroPermissions.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import type { Doc } from "./_generated/dataModel";
+import {
+  evaluate,
+  denialMessage,
+  requiresOwnerLevel,
+  readsOwnerAbsence,
+  getEffectivePermissions,
+  categoryLevel,
+  DEFAULT_PERMISSIONS,
+  DEFAULT_RETRO_PERMISSIONS,
+  type Action,
+  type DecisionContext,
+  type MemberRole,
+  type RetroPermissionCategory,
+} from "./permissions";
+
+// The retro arm of the permission decision (ADR-0013). Every poker assertion
+// lives in permissions.test.ts and is untouched; this file covers only what
+// the retro category set and the three new verbs add.
+
+function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
+  return {
+    actorRole: "participant",
+    permissions: DEFAULT_RETRO_PERMISSIONS,
+    ownerAbsent: false,
+    ownerInTeam: false,
+    ...over,
+  };
+}
+
+/** A retro category action at the retro defaults. */
+function retro(category: RetroPermissionCategory): Action {
+  return {
+    kind: "category",
+    category,
+    level: DEFAULT_RETRO_PERMISSIONS[category],
+  };
+}
+
+describe("DEFAULT_RETRO_PERMISSIONS", () => {
+  it("gates stage flow, card management and settings to facilitators, and opens action management", () => {
+    expect(DEFAULT_RETRO_PERMISSIONS).toEqual({
+      stageFlow: "facilitators",
+      cardManagement: "facilitators",
+      actionManagement: "everyone",
+      retroSettings: "facilitators",
+    });
+  });
+
+  it("has exactly four categories — own-card edits and forming a cluster are never in the config", () => {
+    // Writing, editing, deleting or moving your own card and forming a
+    // cluster are always allowed to any member (spec §4.2 "never in the
+    // config"). They are not categories, so a participant can always do them
+    // regardless of what the owner configures.
+    expect(Object.keys(DEFAULT_RETRO_PERMISSIONS).sort()).toEqual([
+      "actionManagement",
+      "cardManagement",
+      "retroSettings",
+      "stageFlow",
+    ]);
+  });
+});
+
+describe("evaluate — retro categories at defaults", () => {
+  it("a participant cannot advance", () => {
+    expect(evaluate(retro("stageFlow"), ctx())).toEqual({
+      allowed: false,
+      reason: "insufficient-role",
+    });
+  });
+
+  it("a participant cannot touch another person's card", () => {
+    expect(evaluate(retro("cardManagement"), ctx())).toEqual({
+      allowed: false,
+      reason: "insufficient-role",
+    });
+  });
+
+  it("a participant can manage action items", () => {
+    expect(evaluate(retro("actionManagement"), ctx())).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("a participant cannot edit retro settings", () => {
+    expect(evaluate(retro("retroSettings"), ctx())).toEqual({
+      allowed: false,
+      reason: "insufficient-role",
+    });
+  });
+
+  it.each<MemberRole>(["facilitator", "owner"])(
+    "a %s passes every retro category",
+    (role) => {
+      for (const category of [
+        "stageFlow",
+        "cardManagement",
+        "actionManagement",
+        "retroSettings",
+      ] as const) {
+        expect(evaluate(retro(category), ctx({ actorRole: role }))).toEqual({
+          allowed: true,
+        });
+      }
+    }
+  );
+});
+
+describe("evaluate — ratchet and delete are owner-level", () => {
+  const ratchet: Action = { kind: "relationship", verb: "ratchet" };
+  const del: Action = { kind: "relationship", verb: "delete" };
+
+  it("are owner-level actions", () => {
+    expect(requiresOwnerLevel(ratchet)).toBe(true);
+    expect(requiresOwnerLevel(del)).toBe(true);
+  });
+
+  it.each([ratchet, del])("$verb: owner allowed", (action) => {
+    expect(evaluate(action, ctx({ actorRole: "owner" }))).toEqual({
+      allowed: true,
+    });
+  });
+
+  it.each([ratchet, del])(
+    "$verb: facilitator denied with insufficient-role while the owner is present",
+    (action) => {
+      expect(evaluate(action, ctx({ actorRole: "facilitator" }))).toEqual({
+        allowed: false,
+        reason: "insufficient-role",
+      });
+      expect(denialMessage(action, "insufficient-role")).toBe(
+        "Only the owner can do this."
+      );
+    }
+  );
+
+  it.each([ratchet, del])(
+    "$verb: facilitator denied with owner-absent under lockdown (existing copy)",
+    (action) => {
+      expect(
+        evaluate(action, ctx({ actorRole: "facilitator", ownerAbsent: true }))
+      ).toEqual({ allowed: false, reason: "owner-absent" });
+      expect(denialMessage(action, "owner-absent")).toBe(
+        "Room owner has left. Owner-level actions are disabled until the owner returns."
+      );
+    }
+  );
+});
+
+describe("evaluate — claim (a team admin's one room power)", () => {
+  const claim: Action = { kind: "relationship", verb: "claim" };
+
+  it("is not owner-level, but its decision reads owner absence", () => {
+    expect(requiresOwnerLevel(claim)).toBe(false);
+    expect(readsOwnerAbsence(claim)).toBe(true);
+  });
+
+  it("admin with the owner present and in the Team → owner-present", () => {
+    expect(
+      evaluate(
+        claim,
+        ctx({ actorTeamRole: "admin", ownerAbsent: false, ownerInTeam: true })
+      )
+    ).toEqual({ allowed: false, reason: "owner-present" });
+  });
+
+  it("admin with the owner absent → allowed", () => {
+    expect(
+      evaluate(
+        claim,
+        ctx({ actorTeamRole: "admin", ownerAbsent: true, ownerInTeam: true })
+      )
+    ).toEqual({ allowed: true });
+  });
+
+  it("admin with the owner present but outside the Team → allowed", () => {
+    expect(
+      evaluate(
+        claim,
+        ctx({ actorTeamRole: "admin", ownerAbsent: false, ownerInTeam: false })
+      )
+    ).toEqual({ allowed: true });
+  });
+
+  it("non-admin → insufficient-role, whatever the owner's state", () => {
+    for (const actorTeamRole of ["member", undefined] as const) {
+      for (const ownerAbsent of [true, false]) {
+        for (const ownerInTeam of [true, false]) {
+          expect(
+            evaluate(
+              claim,
+              ctx({ actorRole: "facilitator", actorTeamRole, ownerAbsent, ownerInTeam })
+            )
+          ).toEqual({ allowed: false, reason: "insufficient-role" });
+        }
+      }
+    }
+  });
+
+  it("room role never substitutes for team role — a room owner without admin cannot claim", () => {
+    expect(evaluate(claim, ctx({ actorRole: "owner" }))).toEqual({
+      allowed: false,
+      reason: "insufficient-role",
+    });
+  });
+
+  it("carries the owner-present copy", () => {
+    expect(denialMessage(claim, "owner-present")).toBe(
+      "The owner is still here — ask them to transfer ownership."
+    );
+  });
+
+  it("names the team admin in its insufficient-role copy", () => {
+    expect(denialMessage(claim, "insufficient-role")).toBe(
+      "Only a team admin can claim this room."
+    );
+  });
+});
+
+describe("readsOwnerAbsence", () => {
+  it("is true for every owner-level action and for claim, false otherwise", () => {
+    const ownerCategory: Action = {
+      kind: "category",
+      category: "roomSettings",
+      level: "owner",
+    };
+    const openCategory: Action = {
+      kind: "category",
+      category: "stageFlow",
+      level: "facilitators",
+    };
+    expect(readsOwnerAbsence(ownerCategory)).toBe(true);
+    expect(readsOwnerAbsence({ kind: "relationship", verb: "transfer" })).toBe(true);
+    expect(readsOwnerAbsence({ kind: "relationship", verb: "claim" })).toBe(true);
+    expect(readsOwnerAbsence(openCategory)).toBe(false);
+    expect(
+      readsOwnerAbsence({ kind: "relationship", verb: "promote", targetRole: "participant" })
+    ).toBe(false);
+  });
+});
+
+// --- getEffectivePermissions keyed by room type ---
+
+function room(over: Partial<Doc<"rooms">> = {}): Doc<"rooms"> {
+  return {
+    _id: "r1",
+    _creationTime: 0,
+    name: "R",
+    autoCompleteVoting: false,
+    isGameOver: false,
+    createdAt: 0,
+    lastActivityAt: 0,
+    retained: false,
+    ...over,
+  } as Doc<"rooms">;
+}
+
+describe("getEffectivePermissions — discriminated on room type", () => {
+  it("returns the poker defaults for an undefined roomType (legacy)", () => {
+    expect(getEffectivePermissions(room())).toEqual({
+      ceremony: "poker",
+      permissions: DEFAULT_PERMISSIONS,
+    });
+  });
+
+  it("returns the poker defaults for roomType canvas", () => {
+    expect(getEffectivePermissions(room({ roomType: "canvas" }))).toEqual({
+      ceremony: "poker",
+      permissions: DEFAULT_PERMISSIONS,
+    });
+  });
+
+  it("returns the stored poker permissions for a poker room", () => {
+    const stored = { ...DEFAULT_PERMISSIONS, revealCards: "owner" as const };
+    expect(getEffectivePermissions(room({ permissions: stored }))).toEqual({
+      ceremony: "poker",
+      permissions: stored,
+    });
+  });
+
+  it("returns the retro defaults for roomType retro with nothing stored", () => {
+    expect(getEffectivePermissions(room({ roomType: "retro" }))).toEqual({
+      ceremony: "retro",
+      permissions: DEFAULT_RETRO_PERMISSIONS,
+    });
+  });
+
+  it("returns the stored retro permissions for a retro room", () => {
+    const stored = { ...DEFAULT_RETRO_PERMISSIONS, stageFlow: "everyone" as const };
+    expect(
+      getEffectivePermissions(room({ roomType: "retro", permissions: stored }))
+    ).toEqual({ ceremony: "retro", permissions: stored });
+  });
+
+  it("falls back to the room type's defaults when the stored shape belongs to the other type", () => {
+    expect(
+      getEffectivePermissions(
+        room({ roomType: "retro", permissions: DEFAULT_PERMISSIONS })
+      )
+    ).toEqual({ ceremony: "retro", permissions: DEFAULT_RETRO_PERMISSIONS });
+    expect(
+      getEffectivePermissions(
+        room({ roomType: "canvas", permissions: DEFAULT_RETRO_PERMISSIONS })
+      )
+    ).toEqual({ ceremony: "poker", permissions: DEFAULT_PERMISSIONS });
+  });
+});
+
+describe("categoryLevel — narrows on the room type before indexing", () => {
+  it("resolves a category that belongs to the room's set", () => {
+    expect(categoryLevel(getEffectivePermissions(room()), "revealCards")).toBe(
+      "everyone"
+    );
+    expect(
+      categoryLevel(getEffectivePermissions(room({ roomType: "retro" })), "stageFlow")
+    ).toBe("facilitators");
+  });
+
+  it("is undefined for a category from the other room type", () => {
+    expect(categoryLevel(getEffectivePermissions(room()), "stageFlow")).toBeUndefined();
+    expect(
+      categoryLevel(getEffectivePermissions(room({ roomType: "retro" })), "revealCards")
+    ).toBeUndefined();
+  });
+});

--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -1,6 +1,7 @@
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 import * as Roles from "./model/roles";
+import { pokerPermissionsValidator } from "./schema";
 
 export const promoteFacilitator = mutation({
   args: {
@@ -35,28 +36,7 @@ export const transferOwnership = mutation({
 export const updatePermissions = mutation({
   args: {
     roomId: v.id("rooms"),
-    permissions: v.object({
-      revealCards: v.union(
-        v.literal("everyone"),
-        v.literal("facilitators"),
-        v.literal("owner")
-      ),
-      gameFlow: v.union(
-        v.literal("everyone"),
-        v.literal("facilitators"),
-        v.literal("owner")
-      ),
-      issueManagement: v.union(
-        v.literal("everyone"),
-        v.literal("facilitators"),
-        v.literal("owner")
-      ),
-      roomSettings: v.union(
-        v.literal("everyone"),
-        v.literal("facilitators"),
-        v.literal("owner")
-      ),
-    }),
+    permissions: pokerPermissionsValidator,
   },
   handler: async (ctx, args) => {
     await Roles.updatePermissions(ctx, args);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -10,13 +10,48 @@ export const providerValidator = v.union(
   v.literal("github")
 );
 
+/**
+ * A permission level, shared by every configurable category (ADR-0013).
+ */
+export const permissionLevelValidator = v.union(
+  v.literal("everyone"),
+  v.literal("facilitators"),
+  v.literal("owner")
+);
+
+/** The poker room's four configurable categories. */
+export const pokerPermissionsValidator = v.object({
+  revealCards: permissionLevelValidator,
+  gameFlow: permissionLevelValidator,
+  issueManagement: permissionLevelValidator,
+  roomSettings: permissionLevelValidator,
+});
+
+/** The retro room's four configurable categories (ADR-0013). */
+export const retroPermissionsValidator = v.object({
+  stageFlow: permissionLevelValidator,
+  cardManagement: permissionLevelValidator,
+  actionManagement: permissionLevelValidator,
+  retroSettings: permissionLevelValidator,
+});
+
+/** Who may join a room (ADR-0013, spec §4.4). */
+export const joinPolicyValidator = v.union(
+  v.literal("anyone"),
+  v.literal("permanentAccounts"),
+  v.literal("teamMembers")
+);
+
 export default defineSchema({
   rooms: defineTable({
     name: v.string(),
     autoCompleteVoting: v.boolean(),
     autoRevealCountdownStartedAt: v.optional(v.number()), // Timestamp when countdown began
     autoRevealScheduledId: v.optional(v.id("_scheduled_functions")), // Scheduled function ID for auto-reveal
-    roomType: v.optional(v.literal("canvas")), // Optional for backward compatibility
+    // Room type: undefined and "canvas" are poker rooms (legacy rows carry
+    // undefined); "retro" is a retrospective (ADR-0013). Keys the permission
+    // category set in getEffectivePermissions.
+    roomType: v.optional(v.union(v.literal("canvas"), v.literal("retro"))),
     isGameOver: v.boolean(),
     votingScale: v.optional(
       v.object({
@@ -42,30 +77,16 @@ export default defineSchema({
     retained: v.boolean(),
     // Room permissions & ownership
     ownerId: v.optional(v.id("users")),
+    // Stored permissions carry either the poker shape or the retro shape;
+    // getEffectivePermissions picks by roomType and falls back to that type's
+    // defaults. Undefined on legacy rows (ADR-0013).
     permissions: v.optional(
-      v.object({
-        revealCards: v.union(
-          v.literal("everyone"),
-          v.literal("facilitators"),
-          v.literal("owner")
-        ),
-        gameFlow: v.union(
-          v.literal("everyone"),
-          v.literal("facilitators"),
-          v.literal("owner")
-        ),
-        issueManagement: v.union(
-          v.literal("everyone"),
-          v.literal("facilitators"),
-          v.literal("owner")
-        ),
-        roomSettings: v.union(
-          v.literal("everyone"),
-          v.literal("facilitators"),
-          v.literal("owner")
-        ),
-      })
+      v.union(pokerPermissionsValidator, retroPermissionsValidator)
     ),
+    // Admission policy (ADR-0013, spec §4.4). Undefined on poker rooms;
+    // "teamMembers" is only meaningful once the room has a Team. Read by
+    // evaluateJoin; written by nothing yet.
+    joinPolicy: v.optional(joinPolicyValidator),
   })
     .index("by_retention_activity", ["retained", "lastActivityAt"]) // The sweep: non-retained rooms by staleness
     .index("by_created", ["createdAt"]) // For querying recent rooms

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -41,7 +41,7 @@ The authentication system consists of three layers:
 | `convex/schema.ts` | Database schema with `users` and `roomMemberships` tables |
 | `convex/users.ts` | User/membership API (join, leave, edit, queries, linkAccount) |
 | `convex/model/users.ts` | User/membership business logic & account linking logic |
-| `convex/model/auth.ts` | Auth guard helpers (`requireAuth`, `requireAuthUser`, `requireRoomMember`, `getOptionalAuthUser`) |
+| `convex/model/auth.ts` | Auth guard helpers (`requireAuth`, `requireAuthUser`, `requireRoomMember`, `requireRoomReader`, `getOptionalAuthUser`) |
 | `convex/email.ts` | Internal actions to send Magic Link emails via Resend |
 
 ### Frontend (Next.js)
@@ -98,7 +98,8 @@ All Convex mutations must enforce authorization using helpers from `convex/model
 |--------|---------|-------------|
 | `requireAuth(ctx)` | `{ subject }` (auth identity) | You only need to confirm the user is logged in |
 | `requireAuthUser(ctx)` | `{ identity, user }` | You need the app-level `users` record |
-| `requireRoomMember(ctx, roomId)` | `{ identity, user, membership }` | The mutation is scoped to a room |
+| `requireRoomMember(ctx, roomId)` | `{ identity, user, membership }` | The mutation is scoped to a room (room *attendance*) |
+| `requireRoomReader(ctx, roomId)` | `{ identity, user, room }` | A read-only query on room-owned data (room *access*, ADR-0009). Passes a room member; never returns a membership |
 | `getOptionalAuthUser(ctx)` | `user \| null` | Queries that should degrade gracefully for unauthenticated users |
 
 ### Which guard to use
@@ -107,6 +108,7 @@ All Convex mutations must enforce authorization using helpers from `convex/model
 - **Room-scoped mutations without `userId`** (issues, room settings): Use `requireRoomMember`.
 - **Global mutations acting on own data** (editGlobalUser, deleteUser): Use `requireAuth` or `requireAuthUser`.
 - **Admin-style mutations** (users.remove — kick another user): Use `requireRoomMember` to verify the caller is at least in the room.
+- **Read-only queries on room-owned data** (canvas nodes, issue exports, retro contents): Use `requireRoomReader`. It answers "may you read this room?", not "are you in it?", and its return type carries no membership — a reader need not be an attendee (ADR-0009). Every new query on room contents picks `requireRoomReader` or `requireRoomMember` deliberately; one that takes neither is a bug.
 - **Queries**: Use `getOptionalAuthUser` for graceful degradation, or derive `currentUserId` from `ctx.auth.getUserIdentity()` server-side (see `rooms.get` for the pattern).
 
 ### Example: room-scoped mutation with userId

--- a/src/components/room/issue-item.test.tsx
+++ b/src/components/room/issue-item.test.tsx
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { computePermissions } from "@/hooks/usePermissions";
+import { computePokerPermissions as computePermissions } from "@/hooks/usePermissions";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import {

--- a/src/components/room/issues-panel.test.tsx
+++ b/src/components/room/issues-panel.test.tsx
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { computePermissions } from "@/hooks/usePermissions";
+import { computePokerPermissions as computePermissions } from "@/hooks/usePermissions";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import type { Id } from "@/convex/_generated/dataModel";
 import {

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -39,7 +39,7 @@ import {
 } from "./nodes";
 import { DEMO_VIEWER_ID, type CustomNodeType, type PlayerNodeData } from "./types";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
-import { usePermissions } from "@/hooks/usePermissions";
+import { usePokerPermissions } from "@/hooks/usePermissions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -76,7 +76,7 @@ function RoomCanvasInner({ roomData, currentUserId, isEmbedded = false }: RoomCa
   const { fitView } = useReactFlow();
 
   // Permission flags for the current user
-  const permissions = usePermissions(roomData, currentUserId);
+  const permissions = usePokerPermissions(roomData, currentUserId);
 
   const roomId = roomData.room._id as Id<"rooms">;
 

--- a/src/components/room/room-settings-panel.test.tsx
+++ b/src/components/room/room-settings-panel.test.tsx
@@ -19,7 +19,7 @@ import {
   act,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { computePermissions } from "@/hooks/usePermissions";
+import { computePokerPermissions as computePermissions } from "@/hooks/usePermissions";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import type { UserWithPresence } from "@/hooks/useRoomPresence";
 import type { Id } from "@/convex/_generated/dataModel";

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -54,7 +54,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  usePermissions,
+  usePokerPermissions,
   permissionProps,
   permissionInputProps,
   rosterControls,
@@ -64,8 +64,7 @@ import { useRoomSettingsActions } from "./hooks/useRoomSettingsActions";
 import type { Id } from "@/convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
-import type { PermissionLevel, PermissionCategory, RoomPermissions } from "@/convex/permissions";
-import { getEffectivePermissions } from "@/convex/permissions";
+import type { PermissionLevel, PokerPermissionCategory, RoomPermissions } from "@/convex/permissions";
 import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { formatLastSeen } from "./user-presence-avatars";
 
@@ -79,7 +78,7 @@ interface RoomSettingsPanelProps {
   onClose: () => void;
 }
 
-const PERMISSION_CONFIG: Record<PermissionCategory, { label: string; description: string; tooltip: string }> = {
+const PERMISSION_CONFIG: Record<PokerPermissionCategory, { label: string; description: string; tooltip: string }> = {
   revealCards: {
     label: "Reveal cards",
     description: "Reveal votes, cancel auto-reveal",
@@ -133,7 +132,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   // (hide/disable/read-only controls), never write guards.
   const settingsActions = useRoomSettingsActions({ roomId: roomData.room._id });
 
-  const perms = usePermissions(roomData, currentUserId);
+  const perms = usePokerPermissions(roomData, currentUserId);
 
   // Sync room name with prop when it changes externally
   useEffect(() => {
@@ -235,10 +234,9 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
     }
   };
 
-  const handlePermissionChange = async (category: PermissionCategory, value: PermissionLevel) => {
-    const currentPermissions = getEffectivePermissions(roomData.room);
+  const handlePermissionChange = async (category: PokerPermissionCategory, value: PermissionLevel) => {
     const newPermissions: RoomPermissions = {
-      ...currentPermissions,
+      ...perms.permissions,
       [category]: value,
     };
     try {
@@ -249,7 +247,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
     }
   };
 
-  const currentPermissions = getEffectivePermissions(roomData.room);
+  const currentPermissions = perms.permissions;
 
   return (
     <>
@@ -452,7 +450,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                         </span>
                       </div>
                       <div className="space-y-2">
-                        {(Object.keys(PERMISSION_CONFIG) as PermissionCategory[]).map((category) => {
+                        {(Object.keys(PERMISSION_CONFIG) as PokerPermissionCategory[]).map((category) => {
                           const config = PERMISSION_CONFIG[category];
                           return (
                             <div

--- a/src/hooks/permissionProps.test.ts
+++ b/src/hooks/permissionProps.test.ts
@@ -4,7 +4,7 @@ import {
   permissionInputProps,
   denialTooltip,
   rosterControls,
-  computePermissions,
+  computePokerPermissions as computePermissions,
 } from "./usePermissions";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import {

--- a/src/hooks/usePermissions.test.ts
+++ b/src/hooks/usePermissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computePermissions } from "./usePermissions";
+import { computePokerPermissions as computePermissions } from "./usePermissions";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import {
   denialMessage,

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -6,8 +6,8 @@ import {
   type RoomPermissions,
   type RetroPermissions,
   type ResolvedDecision,
-  type PokerPermissionCategory,
-  type RetroPermissionCategory,
+  type PermissionCategory,
+  type PermissionLevel,
   type DecisionContext,
   type EffectivePermissions,
   DEFAULT_PERMISSIONS,
@@ -224,52 +224,54 @@ export function computePermissions(
     ...relationshipDecisions(ctx),
   };
 
-  // Narrow on the ceremony before indexing a category, so each arm resolves
-  // only its own set (ADR-0013).
+  const category = (c: PermissionCategory, level: PermissionLevel): ResolvedDecision =>
+    resolve({ kind: "category", category: c, level }, ctx);
+
+  // Each arm resolves only its own category set (ADR-0013).
   if (effective.ceremony === "retro") {
     const { permissions } = effective;
-    const category = (c: RetroPermissionCategory): ResolvedDecision =>
-      resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
     return {
       ceremony: "retro",
       ...shared,
-      stageFlow: category("stageFlow"),
-      cardManagement: category("cardManagement"),
-      actionManagement: category("actionManagement"),
-      retroSettings: category("retroSettings"),
+      stageFlow: category("stageFlow", permissions.stageFlow),
+      cardManagement: category("cardManagement", permissions.cardManagement),
+      actionManagement: category("actionManagement", permissions.actionManagement),
+      retroSettings: category("retroSettings", permissions.retroSettings),
       permissions,
     };
   }
 
   const { permissions } = effective;
-  const category = (c: PokerPermissionCategory): ResolvedDecision =>
-    resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
   return {
     ceremony: "poker",
     ...shared,
-    revealCards: category("revealCards"),
-    gameFlow: category("gameFlow"),
-    issueManagement: category("issueManagement"),
-    roomSettings: category("roomSettings"),
+    revealCards: category("revealCards", permissions.revealCards),
+    gameFlow: category("gameFlow", permissions.gameFlow),
+    issueManagement: category("issueManagement", permissions.issueManagement),
+    roomSettings: category("roomSettings", permissions.roomSettings),
     permissions,
   };
 }
 
 /**
- * The poker consumers' narrowing of `computePermissions`: the poker arm, or a
- * throw when the room is a retro. A poker surface (the canvas, the settings
- * panel) is never rendered for a retro room, so the throw marks a routing bug
- * rather than a state to handle.
+ * The poker consumers' narrowing: the poker arm, or a throw when the room is
+ * a retro. A poker surface (the canvas, the settings panel) is never rendered
+ * for a retro room, so the throw marks a routing bug rather than a state to
+ * handle.
  */
-export function computePokerPermissions(
-  roomData: RoomWithRelatedData | null | undefined,
-  currentUserId: Id<"users"> | string | undefined
-): PokerPermissionsReturn {
-  const result = computePermissions(roomData, currentUserId);
+function narrowToPoker(result: UsePermissionsReturn): PokerPermissionsReturn {
   if (result.ceremony !== "poker") {
     throw new Error("Poker permissions requested for a non-poker room");
   }
   return result;
+}
+
+/** `computePermissions` narrowed to the poker arm; see `narrowToPoker`. */
+export function computePokerPermissions(
+  roomData: RoomWithRelatedData | null | undefined,
+  currentUserId: Id<"users"> | string | undefined
+): PokerPermissionsReturn {
+  return narrowToPoker(computePermissions(roomData, currentUserId));
 }
 
 /**
@@ -288,15 +290,12 @@ export function usePermissions(
 }
 
 /**
- * `usePermissions` narrowed to the poker arm for the poker surfaces. Same
- * memoization contract; see `computePokerPermissions` for the throw.
+ * `usePermissions` narrowed to the poker arm for the poker surfaces. Reuses
+ * the same memo — narrowing is a type check, not a recompute.
  */
 export function usePokerPermissions(
   roomData: RoomWithRelatedData | null | undefined,
   currentUserId: Id<"users"> | string | undefined
 ): PokerPermissionsReturn {
-  return useMemo(
-    () => computePokerPermissions(roomData, currentUserId),
-    [roomData, currentUserId]
-  );
+  return narrowToPoker(usePermissions(roomData, currentUserId));
 }

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -4,9 +4,12 @@ import type { Id } from "@/convex/_generated/dataModel";
 import {
   type MemberRole,
   type RoomPermissions,
+  type RetroPermissions,
   type ResolvedDecision,
-  type PermissionCategory,
+  type PokerPermissionCategory,
+  type RetroPermissionCategory,
   type DecisionContext,
+  type EffectivePermissions,
   DEFAULT_PERMISSIONS,
   RESOLVED_ALLOWED,
   getEffectivePermissions,
@@ -93,24 +96,50 @@ export function rosterControls(
   };
 }
 
-export interface UsePermissionsReturn {
+/**
+ * What both ceremonies share: the actor's role, the owner flags and the
+ * relationship decisions. Roles and relationship verbs are the same in a
+ * poker room and a retro (ADR-0013).
+ */
+export interface SharedPermissions {
   role: MemberRole;
   isOwner: boolean;
   isFacilitator: boolean;
   isOwnerAbsent: boolean;
-  /** Per-category resolved decisions. Consumers read `.allowed` / `.message`. */
-  revealCards: ResolvedDecision;
-  gameFlow: ResolvedDecision;
-  issueManagement: ResolvedDecision;
-  roomSettings: ResolvedDecision;
   /** Per-target relationship decisions — the target's role refines the verdict. */
   removeTarget: (targetRole: MemberRole) => ResolvedDecision;
   promoteTarget: (targetRole: MemberRole) => ResolvedDecision;
   demoteTarget: (targetRole: MemberRole) => ResolvedDecision;
   transfer: ResolvedDecision;
   changePermissions: ResolvedDecision;
+}
+
+/** The poker arm: the four poker category decisions and the poker shape. */
+export interface PokerPermissionsReturn extends SharedPermissions {
+  ceremony: "poker";
+  /** Per-category resolved decisions. Consumers read `.allowed` / `.message`. */
+  revealCards: ResolvedDecision;
+  gameFlow: ResolvedDecision;
+  issueManagement: ResolvedDecision;
+  roomSettings: ResolvedDecision;
   permissions: RoomPermissions;
 }
+
+/** The retro arm: the four retro category decisions and the retro shape. */
+export interface RetroPermissionsReturn extends SharedPermissions {
+  ceremony: "retro";
+  stageFlow: ResolvedDecision;
+  cardManagement: ResolvedDecision;
+  actionManagement: ResolvedDecision;
+  retroSettings: ResolvedDecision;
+  permissions: RetroPermissions;
+}
+
+/**
+ * The client permissions computation's result, discriminated on the room's
+ * ceremony. Poker consumers narrow via `usePokerPermissions`.
+ */
+export type UsePermissionsReturn = PokerPermissionsReturn | RetroPermissionsReturn;
 
 /**
  * Decision context for the optimistic-defaults branch (before room data loads):
@@ -125,7 +154,27 @@ const OPTIMISTIC_CTX: DecisionContext = {
   actorRole: "participant",
   permissions: DEFAULT_PERMISSIONS,
   ownerAbsent: false,
+  ownerInTeam: false,
 };
+
+/** The relationship decisions every arm carries, resolved against one context. */
+function relationshipDecisions(
+  ctx: DecisionContext
+): Pick<
+  SharedPermissions,
+  "removeTarget" | "promoteTarget" | "demoteTarget" | "transfer" | "changePermissions"
+> {
+  return {
+    removeTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "remove", targetRole }, ctx),
+    promoteTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "promote", targetRole }, ctx),
+    demoteTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "demote", targetRole }, ctx),
+    transfer: resolve({ kind: "relationship", verb: "transfer" }, ctx),
+    changePermissions: resolve({ kind: "relationship", verb: "changePerms" }, ctx),
+  };
+}
 
 /**
  * Maps room data to permission resolved decisions through the shared `resolve`
@@ -139,7 +188,10 @@ export function computePermissions(
   if (!roomData || !currentUserId) {
     // Optimistic defaults before data loads: configurable actions open,
     // relationship actions closed (mirrors prior behaviour).
+    // The ceremony is unknown before data loads; poker is the default
+    // (undefined roomType), so the optimistic arm is poker.
     return {
+      ceremony: "poker",
       role: "participant" as MemberRole,
       isOwner: false,
       isFacilitator: false,
@@ -148,52 +200,76 @@ export function computePermissions(
       gameFlow: RESOLVED_ALLOWED,
       issueManagement: RESOLVED_ALLOWED,
       roomSettings: RESOLVED_ALLOWED,
-      removeTarget: (targetRole) =>
-        resolve({ kind: "relationship", verb: "remove", targetRole }, OPTIMISTIC_CTX),
-      promoteTarget: (targetRole) =>
-        resolve({ kind: "relationship", verb: "promote", targetRole }, OPTIMISTIC_CTX),
-      demoteTarget: (targetRole) =>
-        resolve({ kind: "relationship", verb: "demote", targetRole }, OPTIMISTIC_CTX),
-      transfer: resolve({ kind: "relationship", verb: "transfer" }, OPTIMISTIC_CTX),
-      changePermissions: resolve(
-        { kind: "relationship", verb: "changePerms" },
-        OPTIMISTIC_CTX
-      ),
+      ...relationshipDecisions(OPTIMISTIC_CTX),
       permissions: DEFAULT_PERMISSIONS,
     };
   }
 
   const currentUser = roomData.users.find((u) => u._id === currentUserId);
   const role: MemberRole = currentUser?.role ?? "participant";
-  const permissions = getEffectivePermissions(roomData.room);
+  const effective: EffectivePermissions = getEffectivePermissions(roomData.room);
   const ownerAbsent = roomData.isOwnerAbsent;
-  const ctx = { actorRole: role, permissions, ownerAbsent };
+  const ctx: DecisionContext = {
+    actorRole: role,
+    permissions: effective.permissions,
+    ownerAbsent,
+    ownerInTeam: false,
+  };
 
-  const category = (c: PermissionCategory): ResolvedDecision =>
-    resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
-
-  return {
+  const shared: SharedPermissions = {
     role,
     isOwner: role === "owner",
     isFacilitator: role === "facilitator",
     isOwnerAbsent: ownerAbsent,
+    ...relationshipDecisions(ctx),
+  };
+
+  // Narrow on the ceremony before indexing a category, so each arm resolves
+  // only its own set (ADR-0013).
+  if (effective.ceremony === "retro") {
+    const { permissions } = effective;
+    const category = (c: RetroPermissionCategory): ResolvedDecision =>
+      resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
+    return {
+      ceremony: "retro",
+      ...shared,
+      stageFlow: category("stageFlow"),
+      cardManagement: category("cardManagement"),
+      actionManagement: category("actionManagement"),
+      retroSettings: category("retroSettings"),
+      permissions,
+    };
+  }
+
+  const { permissions } = effective;
+  const category = (c: PokerPermissionCategory): ResolvedDecision =>
+    resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
+  return {
+    ceremony: "poker",
+    ...shared,
     revealCards: category("revealCards"),
     gameFlow: category("gameFlow"),
     issueManagement: category("issueManagement"),
     roomSettings: category("roomSettings"),
-    removeTarget: (targetRole) =>
-      resolve({ kind: "relationship", verb: "remove", targetRole }, ctx),
-    promoteTarget: (targetRole) =>
-      resolve({ kind: "relationship", verb: "promote", targetRole }, ctx),
-    demoteTarget: (targetRole) =>
-      resolve({ kind: "relationship", verb: "demote", targetRole }, ctx),
-    transfer: resolve({ kind: "relationship", verb: "transfer" }, ctx),
-    changePermissions: resolve(
-      { kind: "relationship", verb: "changePerms" },
-      ctx
-    ),
     permissions,
   };
+}
+
+/**
+ * The poker consumers' narrowing of `computePermissions`: the poker arm, or a
+ * throw when the room is a retro. A poker surface (the canvas, the settings
+ * panel) is never rendered for a retro room, so the throw marks a routing bug
+ * rather than a state to handle.
+ */
+export function computePokerPermissions(
+  roomData: RoomWithRelatedData | null | undefined,
+  currentUserId: Id<"users"> | string | undefined
+): PokerPermissionsReturn {
+  const result = computePermissions(roomData, currentUserId);
+  if (result.ceremony !== "poker") {
+    throw new Error("Poker permissions requested for a non-poker room");
+  }
+  return result;
 }
 
 /**
@@ -207,6 +283,20 @@ export function usePermissions(
 ): UsePermissionsReturn {
   return useMemo(
     () => computePermissions(roomData, currentUserId),
+    [roomData, currentUserId]
+  );
+}
+
+/**
+ * `usePermissions` narrowed to the poker arm for the poker surfaces. Same
+ * memoization contract; see `computePokerPermissions` for the throw.
+ */
+export function usePokerPermissions(
+  roomData: RoomWithRelatedData | null | undefined,
+  currentUserId: Id<"users"> | string | undefined
+): PokerPermissionsReturn {
+  return useMemo(
+    () => computePokerPermissions(roomData, currentUserId),
     [roomData, currentUserId]
   );
 }

--- a/src/hooks/usePermissionsRoomType.test.ts
+++ b/src/hooks/usePermissionsRoomType.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { computePermissions, computePokerPermissions } from "./usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import {
+  denialMessage,
+  DEFAULT_PERMISSIONS,
+  DEFAULT_RETRO_PERMISSIONS,
+  RESOLVED_ALLOWED,
+  type MemberRole,
+  type RetroPermissions,
+  type RoomPermissions,
+} from "@/convex/permissions";
+
+// The client permissions computation returns a union discriminated on the
+// ceremony (ADR-0013): the poker arm keeps its four decisions, the retro arm
+// carries the four retro decisions, and role, owner flags and relationship
+// decisions are shared. The poker assertions live in usePermissions.test.ts.
+
+function roomData(opts: {
+  roomType?: "canvas" | "retro";
+  role?: MemberRole;
+  permissions?: RoomPermissions | RetroPermissions;
+  isOwnerAbsent?: boolean;
+}): RoomWithRelatedData {
+  return {
+    room: {
+      ...(opts.roomType ? { roomType: opts.roomType } : {}),
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+    },
+    users: [{ _id: "u1", role: opts.role ?? "participant" }],
+    isOwnerAbsent: opts.isOwnerAbsent ?? false,
+  } as unknown as RoomWithRelatedData;
+}
+
+describe("computePermissions — discriminated on ceremony", () => {
+  it("returns the poker arm for an undefined roomType", () => {
+    const result = computePermissions(roomData({}), "u1");
+    expect(result.ceremony).toBe("poker");
+    if (result.ceremony !== "poker") throw new Error("unreachable");
+    expect(result.permissions).toEqual(DEFAULT_PERMISSIONS);
+    expect(result.revealCards).toBe(RESOLVED_ALLOWED);
+  });
+
+  it("returns the poker arm for roomType canvas", () => {
+    const result = computePermissions(roomData({ roomType: "canvas" }), "u1");
+    expect(result.ceremony).toBe("poker");
+  });
+
+  it("returns the poker arm before data loads (optimistic defaults)", () => {
+    const result = computePermissions(null, undefined);
+    expect(result.ceremony).toBe("poker");
+  });
+
+  it("returns the retro arm for roomType retro, at the retro defaults", () => {
+    const result = computePermissions(roomData({ roomType: "retro" }), "u1");
+    expect(result.ceremony).toBe("retro");
+    if (result.ceremony !== "retro") throw new Error("unreachable");
+    expect(result.permissions).toEqual(DEFAULT_RETRO_PERMISSIONS);
+    expect(result.stageFlow).toEqual({
+      allowed: false,
+      message: denialMessage(
+        { kind: "category", category: "stageFlow", level: "facilitators" },
+        "insufficient-role"
+      ),
+    });
+    expect(result.cardManagement.allowed).toBe(false);
+    expect(result.actionManagement).toBe(RESOLVED_ALLOWED);
+    expect(result.retroSettings.allowed).toBe(false);
+  });
+
+  it("the retro arm honours stored retro permissions", () => {
+    const result = computePermissions(
+      roomData({
+        roomType: "retro",
+        permissions: { ...DEFAULT_RETRO_PERMISSIONS, stageFlow: "everyone" },
+      }),
+      "u1"
+    );
+    if (result.ceremony !== "retro") throw new Error("unreachable");
+    expect(result.stageFlow).toBe(RESOLVED_ALLOWED);
+  });
+
+  it("shares role, owner flags and relationship decisions across both arms", () => {
+    const result = computePermissions(
+      roomData({ roomType: "retro", role: "facilitator" }),
+      "u1"
+    );
+    expect(result.role).toBe("facilitator");
+    expect(result.isFacilitator).toBe(true);
+    expect(result.isOwner).toBe(false);
+    expect(result.isOwnerAbsent).toBe(false);
+    expect(result.promoteTarget("participant")).toBe(RESOLVED_ALLOWED);
+    expect(result.transfer.allowed).toBe(false);
+    expect(result.changePermissions.allowed).toBe(false);
+  });
+
+  it("the retro arm carries no poker decisions and vice versa", () => {
+    const retro = computePermissions(roomData({ roomType: "retro" }), "u1");
+    expect("revealCards" in retro).toBe(false);
+    const poker = computePermissions(roomData({}), "u1");
+    expect("stageFlow" in poker).toBe(false);
+  });
+});
+
+describe("computePokerPermissions — the poker consumers' narrowing", () => {
+  it("returns the poker arm for a poker room", () => {
+    const result = computePokerPermissions(roomData({}), "u1");
+    expect(result.ceremony).toBe("poker");
+    expect(result.gameFlow).toBe(RESOLVED_ALLOWED);
+  });
+
+  it("throws when the room is a retro — a poker surface rendered for the wrong ceremony", () => {
+    expect(() => computePokerPermissions(roomData({ roomType: "retro" }), "u1")).toThrow(
+      /poker/
+    );
+  });
+});


### PR DESCRIPTION
Closes #286. A prefactor with no user-visible change: it opens the two seams every retro ticket stands on (spec `docs/spec/retro.md` §4.1–§4.4, §21.5; ADR-0009, ADR-0013).

## Room access (ADR-0009)

`requireRoomReader(ctx, roomId)` sits beside `requireRoomMember` in `convex/model/auth.ts`. It answers "may you read this room's contents?", returns `{ identity, user, room }` and never a membership row. Today it passes room members only; #287 adds members of the room's Team.

`canvas.getCanvasNodes`, `issues.getForExport` and `issues.getForEnhancedExport` migrate to it. A convex-test net (`convex/requireRoomReader.test.ts`) proves a non-member cannot read any of the three. The guard's denial copy speaks of access, not attendance ("You don't have access to this room").

## Permission decision keyed by ceremony (ADR-0013)

- **Schema**: `roomType` accepts `"retro"`; stored `permissions` accept either the poker or the retro shape; `joinPolicy` added as an optional literal union. Nothing writes `joinPolicy` yet. No data migration.
- **Categories**: `stageFlow`, `cardManagement`, `actionManagement`, `retroSettings` with `DEFAULT_RETRO_PERMISSIONS` (facilitators / facilitators / everyone / facilitators). `PermissionCategory` is the union of both sets. `getEffectivePermissions(room)` returns a result discriminated on `ceremony` (the CONTEXT.md glossary word), and the guard narrows through `categoryLevel` before indexing, refusing a category from the other ceremony. `evaluate`, `resolve`, `denialMessage` keep their shapes.
- **Join decision**: `evaluateJoin(policy, accountType, isTeamMember)` is a pure function beside `evaluate`, with `accountTypeOf(user)` as the server's one derivation of the account input (permanent only when the user row says so).
- **Verbs**: `ratchet` and `delete` are owner-level. `claim` requires `actorTeamRole === "admin"` and an owner who is absent or outside the Team; a present in-team owner yields the new `owner-present` reason. `DecisionContext` gains `actorTeamRole?` and `ownerInTeam`. The guard reads owner absence for `claim` too (`readsOwnerAbsence`).
- **Client**: `computePermissions` returns a union discriminated on `ceremony`. Poker surfaces narrow through `usePokerPermissions`, which throws if rendered for a retro room (unreachable today).

## CI

`ci.yml` runs `npm run test` after `ts:check`; the job is now "Lint, Type Check & Test".

## Cleanup pass (second commit)

A `/simplify` pass over the diff, no behaviour change:

- `categoryLevel` indexes the permissions object directly: the object *is* the ceremony's category set, so an absent key is the narrowing. This removed the two derived category Sets, the `is*Category` predicates and the shape-probe helpers.
- `ceremonyOf` inlined at its one caller; one `assertNever` for both unions.
- `usePokerPermissions` narrows the result of `usePermissions` instead of running a second memo; one hoisted `category` closure serves both arms.
- `requireRoomReader` calls `Users.getMembership`; the reader-guard test uses the shared seeds in `analytics.seeds.ts`.
- `roles.updatePermissions` reuses `pokerPermissionsValidator` from the schema instead of hand-spelling the same object.

Known cost left in on purpose: `requireRoomReader` reads the room doc (the issue specifies the `{ identity, user, room }` return and #287 needs `room.teamId`), which adds the room to the `getCanvasNodes` subscription read set, so room patches now re-run that query server-side.

## Notes for review

- Existing poker assertions are unchanged. Five test files got a one-line import swap to `computePokerPermissions` because `tsc` type-checks tests and the union return would not compile otherwise.
- Two new denial strings were needed because `denialMessage` must return something: "Only a team admin can claim this room." and "This action does not apply to this room type."
- "Participant can delete their own card and form a cluster" has no code seam yet; the test asserts the retro set has exactly four categories and documents why.

## Verification

- `npm run ts:check` clean
- `npm run test`: 58 files, 575 tests pass (re-run after the cleanup commit)
- `npm run lint`: only the 6 pre-existing warnings

https://claude.ai/code/session_01LTuViwbbbictkKbzyZCBaa

