### PR TITLE
feat(retro): teams — team page, join route, sidebar, /dashboard/retros, retro-defaults panel

### DIFF
--- a/src/app/dashboard/retros/page.tsx
+++ b/src/app/dashboard/retros/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from "next";
+import { RetrosContent } from "./retros-content";
+
+export const metadata: Metadata = {
+  title: "Retros | AgileKit",
+  description: "Your teams and retrospectives",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function RetrosPage() {
+  return <RetrosContent />;
+}

--- a/src/app/dashboard/retros/retros-content.test.tsx
+++ b/src/app/dashboard/retros/retros-content.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * RetrosContent — /dashboard/retros (spec §18.1): the person's Teams with
+ * New team. Loading shows a skeleton, no teams shows the empty state with
+ * the same CTA, and each team links to its page with its role.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  teams: undefined as undefined | { _id: string; name: string; role: "admin" | "member" }[],
+  dialogOpen: [] as boolean[],
+}));
+
+vi.mock("convex/react", () => ({ useQuery: () => mocks.teams }));
+vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("@/components/dashboard", () => ({
+  DashboardHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+vi.mock("@/components/team/new-team-dialog", () => ({
+  NewTeamDialog: ({ open }: { open: boolean }) => {
+    mocks.dialogOpen.push(open);
+    return open ? <div role="dialog">New team dialog</div> : null;
+  },
+}));
+
+import { RetrosContent } from "./retros-content";
+
+beforeEach(() => {
+  mocks.teams = undefined;
+  mocks.dialogOpen = [];
+});
+afterEach(cleanup);
+
+describe("RetrosContent", () => {
+  it("shows a skeleton while the teams load", () => {
+    render(<RetrosContent />);
+    expect(screen.getByRole("heading", { name: "Retros" })).toBeTruthy();
+    expect(screen.queryByTestId("team-list")).toBeNull();
+    expect(screen.queryByText("No teams yet")).toBeNull();
+  });
+
+  it("with no teams, shows the empty state and New team opens the dialog", () => {
+    mocks.teams = [];
+    render(<RetrosContent />);
+    expect(screen.getByText("No teams yet")).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getAllByRole("button", { name: "New team" })[0]);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("lists each team as a link to its page with its role", () => {
+    mocks.teams = [
+      { _id: "t1", name: "Acme", role: "admin" },
+      { _id: "t2", name: "Beta", role: "member" },
+    ];
+    render(<RetrosContent />);
+    const acme = screen.getByRole("link", { name: /Acme/ });
+    expect(acme.getAttribute("href")).toBe("/team/t1");
+    expect(acme.textContent).toContain("admin");
+    expect(screen.getByRole("link", { name: /Beta/ }).getAttribute("href")).toBe("/team/t2");
+    expect(screen.getByRole("link", { name: /Beta/ }).textContent).toContain("member");
+  });
+});

--- a/src/app/dashboard/retros/retros-content.tsx
+++ b/src/app/dashboard/retros/retros-content.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "convex/react";
+import { ArrowRight, Crown, Plus, Users } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import { useAuth } from "@/components/auth/auth-provider";
+import { DashboardHeader } from "@/components/dashboard";
+import { NewTeamDialog } from "@/components/team/new-team-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+/**
+ * /dashboard/retros (spec §18.1): the person's Teams with New team, the door
+ * to every team page. Retro history rows arrive with #288/#289.
+ */
+export function RetrosContent() {
+  const { isAuthenticated } = useAuth();
+  const teams = useQuery(api.teams.listMine, isAuthenticated ? {} : "skip");
+  const [newTeamOpen, setNewTeamOpen] = useState(false);
+
+  const isLoading = teams === undefined;
+
+  return (
+    <>
+      <DashboardHeader title="Retros" showDateRange={false} />
+      <div className="flex-1 space-y-6 p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">Teams</h2>
+            <p className="text-sm text-muted-foreground">
+              A team keeps its retros and decides who can read them.
+            </p>
+          </div>
+          <Button onClick={() => setNewTeamOpen(true)} data-testid="new-team-button">
+            <Plus className="size-4" />
+            New team
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-[92px] animate-pulse rounded-2xl border bg-card p-5">
+                <div className="mb-3 h-5 w-2/3 rounded-md bg-muted" />
+                <div className="h-4 w-1/3 rounded-md bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="flex min-h-[260px] flex-col items-center justify-center rounded-2xl border border-dashed bg-muted/20 p-8 text-center">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <Users className="h-6 w-6 text-primary" />
+            </div>
+            <h3 className="mb-2 text-lg font-semibold">No teams yet</h3>
+            <p className="mb-6 max-w-sm text-sm text-muted-foreground">
+              Create a team to keep your retros, or open an invite link a teammate sent you.
+            </p>
+            <Button onClick={() => setNewTeamOpen(true)}>
+              <Plus className="size-4" />
+              New team
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="team-list">
+            {teams.map((team) => (
+              <Link
+                key={team._id}
+                href={`/team/${team._id}`}
+                className="group flex items-center justify-between gap-3 rounded-2xl border bg-card p-5 transition-colors hover:bg-muted/40"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{team.name}</p>
+                  <Badge variant={team.role === "admin" ? "default" : "secondary"} className="mt-2">
+                    {team.role === "admin" && <Crown className="size-3" />}
+                    {team.role}
+                  </Badge>
+                </div>
+                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <NewTeamDialog open={newTeamOpen} onOpenChange={setNewTeamOpen} returnTo="/dashboard/retros" />
+    </>
+  );
+}

--- a/src/app/team/[teamId]/error.tsx
+++ b/src/app/team/[teamId]/error.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
+import { NOT_A_TEAM_MEMBER, TEAM_NOT_FOUND } from "@/convex/teamCopy";
 
 /**
  * The team page is members only: `teams.get` throws for anyone else, and the
@@ -11,7 +12,8 @@ import { Button } from "@/components/ui/button";
  * generic error page.
  */
 export default function TeamError({ error }: { error: Error }) {
-  const notMember = /not a member|Team not found/i.test(error.message);
+  const notMember =
+    error.message.includes(NOT_A_TEAM_MEMBER) || error.message.includes(TEAM_NOT_FOUND);
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />

--- a/src/app/team/[teamId]/error.tsx
+++ b/src/app/team/[teamId]/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The team page is members only: `teams.get` throws for anyone else, and the
+ * Convex client surfaces that during render. Land here rather than on the
+ * generic error page.
+ */
+export default function TeamError({ error }: { error: Error }) {
+  const notMember = /not a member|Team not found/i.test(error.message);
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex flex-1 items-center justify-center p-6">
+        <div className="max-w-md text-center">
+          <h1 className="mb-2 text-2xl font-bold">
+            {notMember ? "This team isn't yours to see" : "Something went wrong"}
+          </h1>
+          <p className="mb-6 text-muted-foreground">
+            {notMember
+              ? "Only members can open a team page. Ask an admin for the invite link."
+              : error.message}
+          </p>
+          <Button render={<Link href="/dashboard/retros" />} nativeButton={false}>Back to Retros</Button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/team/[teamId]/layout.tsx
+++ b/src/app/team/[teamId]/layout.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { isAuthenticated } from "@/lib/auth-server";
+
+/**
+ * The team page is for signed-in accounts: redirect on the server, as the
+ * dashboard does, so a signed-out visitor never renders the client shell.
+ * Membership itself is decided by `teams.get` behind `requireTeamRole`.
+ */
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ teamId: string }>;
+}) {
+  const authenticated = await isAuthenticated();
+  if (!authenticated) {
+    const { teamId } = await params;
+    redirect(`/auth/signin?from=${encodeURIComponent(`/team/${teamId}`)}`);
+  }
+  return children;
+}

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -1,0 +1,14 @@
+import { Metadata } from "next";
+import { TeamContent } from "./team-content";
+
+export const metadata: Metadata = {
+  title: "Team",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function TeamPage() {
+  return <TeamContent />;
+}

--- a/src/app/team/[teamId]/team-content.test.tsx
+++ b/src/app/team/[teamId]/team-content.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * TeamContent — the team page's wiring from the members-only read to the
+ * team mutations (spec §5): an admin gets live rename, role, remove, rotate
+ * and delete controls that reach the right mutation with the right target
+ * and never act on their own row; a member gets none of them; a refused
+ * write (the last-admin rule) surfaces the server's copy and keeps the
+ * confirmation open. Convex, routing, chrome and the Base UI overlays are
+ * mocked at their seams; the retro-defaults panel is real.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, within, waitFor } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+import { LAST_ADMIN_MESSAGE } from "@/convex/teamCopy";
+import { DEFAULT_RETRO_PERMISSIONS } from "@/convex/permissions";
+
+type Team = {
+  _id: string;
+  name: string;
+  inviteToken: string;
+  retroDefaults: { attribution: "named" | "anonymous"; joinPolicy: "anyone" | "permanentAccounts" | "teamMembers"; permissions: typeof DEFAULT_RETRO_PERMISSIONS };
+  createdAt: number;
+  myUserId: string;
+  myRole: "admin" | "member";
+  roomCount: number;
+  members: { userId: string; name: string; role: "admin" | "member"; joinedAt: number }[];
+};
+
+const mocks = vi.hoisted(() => ({
+  team: undefined as Team | undefined,
+  calls: [] as { fn: string; args: unknown }[],
+  fail: {} as Record<string, string>,
+  push: vi.fn(),
+  toasts: [] as { kind: "success" | "error"; message: string }[],
+}));
+
+vi.mock("convex/react", async () => {
+  const { getFunctionName } = await import("convex/server");
+  return {
+    useQuery: () => mocks.team,
+    useMutation: (ref: unknown) => {
+      const fn = getFunctionName(ref as never);
+      return async (args: unknown) => {
+        mocks.calls.push({ fn, args });
+        if (mocks.fail[fn]) throw new Error(mocks.fail[fn]);
+      };
+    },
+  };
+});
+vi.mock("next/navigation", () => {
+  const router = { push: (href: string) => mocks.push(href), replace: vi.fn() };
+  return { useParams: () => ({ teamId: "team-1" }), useRouter: () => router };
+});
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("@/components/auth/auth-provider", () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock("@/components/navbar", () => ({ Navbar: () => null }));
+vi.mock("@/components/footer", () => ({ Footer: () => null }));
+vi.mock("@/components/user-menu/user-avatar", () => ({ UserAvatar: () => null }));
+vi.mock("@/utils/copy-text-to-clipboard", () => ({ copyTextToClipboard: async () => true }));
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (message: string) => mocks.toasts.push({ kind: "success", message }),
+    error: (message: string) => mocks.toasts.push({ kind: "error", message }),
+  },
+}));
+// Base UI overlays need a portal and pointer environment jsdom lacks; their
+// structure is not under test, the wiring through them is.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render: el, children }: { render: ReactElement; children?: ReactNode }) =>
+    cloneElement(el, undefined, children),
+  TooltipContent: () => null,
+}));
+vi.mock("@/components/ui/alert-dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    AlertDialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="dialog">{children}</div> : null,
+    AlertDialogContent: pass,
+    AlertDialogHeader: pass,
+    AlertDialogFooter: pass,
+    AlertDialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    AlertDialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    AlertDialogCancel: ({ children, disabled }: { children?: ReactNode; disabled?: boolean }) => (
+      <button disabled={disabled}>{children}</button>
+    ),
+    AlertDialogAction: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+      <button onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+  };
+});
+
+import { TeamContent } from "./team-content";
+
+function team(myRole: "admin" | "member"): Team {
+  return {
+    _id: "team-1",
+    name: "Acme",
+    inviteToken: "tok",
+    retroDefaults: { attribution: "named", joinPolicy: "anyone", permissions: { ...DEFAULT_RETRO_PERMISSIONS } },
+    createdAt: 0,
+    myUserId: "me",
+    myRole,
+    roomCount: 3,
+    members: [
+      { userId: "me", name: "Me", role: myRole, joinedAt: 0 },
+      { userId: "u2", name: "Bea", role: "admin", joinedAt: 1 },
+      { userId: "u3", name: "Cal", role: "member", joinedAt: 2 },
+    ],
+  };
+}
+
+const calledWith = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c) => c.args);
+const dialog = () => within(screen.getByRole("dialog"));
+
+beforeEach(() => {
+  mocks.team = team("admin");
+  mocks.calls = [];
+  mocks.fail = {};
+  mocks.toasts = [];
+  mocks.push.mockReset();
+});
+afterEach(cleanup);
+
+describe("TeamContent as an admin", () => {
+  it("shows role and remove controls for every other member and none for the caller's own row", () => {
+    render(<TeamContent />);
+    expect(screen.getByRole("button", { name: "Make Bea a member" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Make Cal an admin" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove Cal" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Me an admin|Me a member|Remove Me/ })).toBeNull();
+    expect(screen.getByText("(you)")).toBeTruthy();
+  });
+
+  it("renames on blur with the trimmed name, and skips a no-op", async () => {
+    render(<TeamContent />);
+    const input = screen.getByRole("textbox", { name: "Team name" });
+    fireEvent.change(input, { target: { value: "  Acme  " } });
+    fireEvent.blur(input);
+    expect(calledWith("teams:rename")).toEqual([]);
+
+    fireEvent.change(input, { target: { value: "  Beta Crew " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+    await waitFor(() => expect(calledWith("teams:rename")).toEqual([{ teamId: "team-1", name: "Beta Crew" }]));
+  });
+
+  it("promote and demote reach the mutations with the right target", () => {
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Make Cal an admin" }));
+    fireEvent.click(screen.getByRole("button", { name: "Make Bea a member" }));
+    expect(calledWith("teams:promote")).toEqual([{ teamId: "team-1", targetUserId: "u3" }]);
+    expect(calledWith("teams:demote")).toEqual([{ teamId: "team-1", targetUserId: "u2" }]);
+  });
+
+  it("removal asks first, then removes exactly that member", async () => {
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Remove Cal" }));
+    expect(dialog().getByText("Remove Cal?")).toBeTruthy();
+    expect(calledWith("teams:removeMember")).toEqual([]);
+
+    fireEvent.click(dialog().getByRole("button", { name: "Remove" }));
+    await waitFor(() =>
+      expect(calledWith("teams:removeMember")).toEqual([{ teamId: "team-1", targetUserId: "u3" }])
+    );
+    expect(mocks.toasts.at(-1)?.kind).toBe("success");
+  });
+
+  it("rotates the invite link", async () => {
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Rotate" }));
+    await waitFor(() => expect(calledWith("teams:rotateInvite")).toEqual([{ teamId: "team-1" }]));
+    expect(screen.getByRole("textbox", { name: "Invite link" }).getAttribute("value")).toMatch(/\/team\/join\/tok$/);
+  });
+
+  it("a retro-defaults change writes the whole bundle by value", async () => {
+    render(<TeamContent />);
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: "Attribution" })).getByRole("radio", { name: "Anonymous" }));
+    await waitFor(() =>
+      expect(calledWith("teams:updateRetroDefaults")).toEqual([
+        { teamId: "team-1", retroDefaults: { ...team("admin").retroDefaults, attribution: "anonymous" } },
+      ])
+    );
+  });
+
+  it("deleting shows the spec's confirmation, deletes, and leaves the page", async () => {
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete team" }));
+    expect(dialog().getByText("Delete Acme?")).toBeTruthy();
+    expect(dialog().getByText(/Its 3 retros and their action items are removed permanently\. This cannot be undone\./)).toBeTruthy();
+
+    fireEvent.click(dialog().getByRole("button", { name: "Delete team" }));
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/dashboard/retros"));
+    expect(calledWith("teams:remove")).toEqual([{ teamId: "team-1" }]);
+  });
+
+  it("a refused leave shows the server's copy and keeps the confirmation open", async () => {
+    mocks.fail["teams:leave"] = LAST_ADMIN_MESSAGE;
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Leave team" }));
+    fireEvent.click(dialog().getByRole("button", { name: "Leave" }));
+
+    await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: LAST_ADMIN_MESSAGE }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("a failed delete keeps the confirmation open for another try", async () => {
+    mocks.fail["teams:remove"] = "boom";
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete team" }));
+    fireEvent.click(dialog().getByRole("button", { name: "Delete team" }));
+
+    await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: "boom" }));
+    expect(dialog().getByRole("button", { name: "Delete team" })).toBeTruthy();
+    expect((dialog().getByRole("button", { name: "Delete team" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});
+
+describe("TeamContent as a member", () => {
+  it("shows the roster and invite link but no admin controls", () => {
+    mocks.team = team("member");
+    render(<TeamContent />);
+    expect(screen.getByRole("heading", { name: "Acme" })).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: "Team name" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Make |Remove /})).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rotate" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete team" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Leave team" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy" })).toBeTruthy();
+    for (const radio of screen.getAllByRole("radio")) {
+      expect((radio as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+});

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -119,11 +119,9 @@ export function TeamContent() {
     }
   };
 
-  const handleRole = async (action: "promote" | "demote", userId: Id<"users">) => {
-    await run(
-      () => (action === "promote" ? promote : demote)({ teamId, targetUserId: userId }),
-      "Failed to change role"
-    );
+  const roleMutations = { promote, demote };
+  const handleRole = async (action: keyof typeof roleMutations, userId: Id<"users">) => {
+    await run(() => roleMutations[action]({ teamId, targetUserId: userId }), "Failed to change role");
   };
 
   const handleConfirmRemove = async () => {
@@ -146,6 +144,8 @@ export function TeamContent() {
     }
   };
 
+  // No success toast here on purpose: the control itself shows the new
+  // value, and a failure rolls it back (the panel's contract) with a toast.
   const handleRetroDefaults = (next: RetroDefaults) =>
     run(() => updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
 

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -137,9 +137,11 @@ export function TeamContent() {
     }
   };
 
+  // Confirmations stay open on failure (the last-admin rule, most often),
+  // so the next attempt is one click away.
   const handleLeave = async () => {
-    setConfirmLeave(false);
     if (await run(() => leave({ teamId }), "Failed to leave the team")) {
+      setConfirmLeave(false);
       router.push("/dashboard/retros");
     }
   };
@@ -155,7 +157,6 @@ export function TeamContent() {
       router.push("/dashboard/retros");
     } else {
       setIsDeleting(false);
-      setConfirmDelete(false);
     }
   };
 

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useMutation, useQuery } from "convex/react";
+import { Copy, Crown, RefreshCw, ShieldMinus, ShieldPlus, UserMinus, LogOut, Trash2, Plus } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useAuth } from "@/components/auth/auth-provider";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { UserAvatar } from "@/components/user-menu/user-avatar";
+import { RetroDefaultsPanel, type RetroDefaults } from "@/components/team/retro-defaults-panel";
+import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
+import { toast } from "@/lib/toast";
+
+function Centered({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h2 className="mb-2 text-2xl font-bold">{title}</h2>
+        <p className="text-muted-foreground">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Every write on this page fails the same way: the server's refusal copy
+ * (the last-admin rule, a stale role) or a fallback, in a toast.
+ */
+async function run(fn: () => Promise<unknown>, fallback: string): Promise<boolean> {
+  try {
+    await fn();
+    return true;
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : fallback);
+    return false;
+  }
+}
+
+/**
+ * The team page (spec §5, §18.1), members only: members with roles, the
+ * invite link, the retro-defaults panel, New retro, and admin-only Delete
+ * team. Retro history, action items and export arrive with #288/#289.
+ */
+export function TeamContent() {
+  const params = useParams();
+  const router = useRouter();
+  const teamId = params.teamId as Id<"teams">;
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const team = useQuery(api.teams.get, isAuthenticated ? { teamId } : "skip");
+  const me = useQuery(api.users.getGlobalUser, isAuthenticated ? {} : "skip");
+
+  const rename = useMutation(api.teams.rename);
+  const rotateInvite = useMutation(api.teams.rotateInvite);
+  const promote = useMutation(api.teams.promote);
+  const demote = useMutation(api.teams.demote);
+  const removeMember = useMutation(api.teams.removeMember);
+  const leave = useMutation(api.teams.leave);
+  const updateRetroDefaults = useMutation(api.teams.updateRetroDefaults);
+  const deleteTeam = useMutation(api.teams.remove);
+
+  // The rename draft, keyed to the stored name it was typed over: a query
+  // update that changes the stored name discards the draft, and no effect
+  // is needed to sync the two.
+  const [draft, setDraft] = useState<{ base: string; value: string } | null>(null);
+  const [pendingRemove, setPendingRemove] = useState<{ userId: Id<"users">; name: string } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmLeave, setConfirmLeave] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(`/auth/signin?from=${encodeURIComponent(`/team/${teamId}`)}`);
+    }
+  }, [authLoading, isAuthenticated, router, teamId]);
+
+  if (authLoading || !isAuthenticated || team === undefined) {
+    return <Centered title="Loading…" body="Fetching the team" />;
+  }
+
+  const isAdmin = team.myRole === "admin";
+  const name = draft && draft.base === team.name ? draft.value : team.name;
+  const setName = (value: string) => setDraft({ base: team.name, value });
+  const inviteUrl =
+    typeof window === "undefined" ? "" : `${window.location.origin}/team/join/${team.inviteToken}`;
+
+  const handleRename = async () => {
+    const trimmed = name.trim();
+    setDraft(null);
+    if (!trimmed || trimmed === team.name) return;
+    if (await run(() => rename({ teamId, name: trimmed }), "Failed to rename team")) {
+      toast.success("Team renamed");
+    }
+  };
+
+  const handleCopyInvite = async () => {
+    if (await copyTextToClipboard(inviteUrl)) {
+      toast.success("Invite link copied to clipboard");
+    } else {
+      toast.error("Couldn't copy the link. Copy it from the field instead.");
+    }
+  };
+
+  const handleRotate = async () => {
+    if (await run(() => rotateInvite({ teamId }), "Failed to rotate the invite link")) {
+      toast.success("Invite link rotated", { description: "The old link no longer works." });
+    }
+  };
+
+  const handleRole = async (action: "promote" | "demote", userId: Id<"users">) => {
+    await run(
+      () => (action === "promote" ? promote : demote)({ teamId, targetUserId: userId }),
+      "Failed to change role"
+    );
+  };
+
+  const handleConfirmRemove = async () => {
+    if (!pendingRemove) return;
+    const removed = pendingRemove;
+    setPendingRemove(null);
+    if (await run(() => removeMember({ teamId, targetUserId: removed.userId }), "Failed to remove member")) {
+      toast.success("Member removed", {
+        description: `${removed.name} no longer has access to this team's retros.`,
+      });
+    }
+  };
+
+  const handleLeave = async () => {
+    setConfirmLeave(false);
+    if (await run(() => leave({ teamId }), "Failed to leave the team")) {
+      router.push("/dashboard/retros");
+    }
+  };
+
+  const handleRetroDefaults = async (next: RetroDefaults) => {
+    await run(() => updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    if (await run(() => deleteTeam({ teamId }), "Failed to delete team")) {
+      toast.success(`${team.name} deleted`);
+      router.push("/dashboard/retros");
+    } else {
+      setIsDeleting(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1">
+        <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-8 sm:px-6">
+          {/* Header */}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 flex-1">
+              {isAdmin ? (
+                <Input
+                  aria-label="Team name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  onBlur={handleRename}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                  }}
+                  maxLength={100}
+                  className="h-10 max-w-md text-xl font-semibold"
+                />
+              ) : (
+                <h1 className="truncate text-2xl font-bold tracking-tight">{team.name}</h1>
+              )}
+            </div>
+            <Button render={<Link href={`/retro/new?team=${teamId}`} />} nativeButton={false}>
+              <Plus className="size-4" />
+              New retro
+            </Button>
+          </div>
+
+          {/* Members */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Members</CardTitle>
+              <CardDescription>
+                Members can read every retro this team keeps. Admins manage the team.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              {team.members.map((member) => {
+                const isMe = member.userId === me?._id;
+                return (
+                  <div
+                    key={member.userId}
+                    data-testid="team-member-row"
+                    className="flex items-center justify-between gap-3 rounded-lg px-2 py-2 hover:bg-gray-50 dark:hover:bg-surface-3/50"
+                  >
+                    <div className="flex min-w-0 items-center gap-3">
+                      <UserAvatar name={member.name} avatarUrl={member.avatarUrl} size="md" />
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {member.name}
+                          {isMe && <span className="ml-1 text-muted-foreground">(you)</span>}
+                        </p>
+                      </div>
+                      <Badge variant={member.role === "admin" ? "default" : "secondary"}>
+                        {member.role === "admin" && <Crown className="size-3" />}
+                        {member.role}
+                      </Badge>
+                    </div>
+                    {isAdmin && !isMe && (
+                      <div className="flex shrink-0 items-center gap-1">
+                        {member.role === "member" ? (
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  aria-label={`Make ${member.name} an admin`}
+                                  onClick={() => handleRole("promote", member.userId)}
+                                />
+                              }
+                            >
+                              <ShieldPlus className="size-4" />
+                            </TooltipTrigger>
+                            <TooltipContent>Make admin</TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  aria-label={`Make ${member.name} a member`}
+                                  onClick={() => handleRole("demote", member.userId)}
+                                />
+                              }
+                            >
+                              <ShieldMinus className="size-4" />
+                            </TooltipTrigger>
+                            <TooltipContent>Make member</TooltipContent>
+                          </Tooltip>
+                        )}
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                aria-label={`Remove ${member.name}`}
+                                onClick={() => setPendingRemove({ userId: member.userId, name: member.name })}
+                              />
+                            }
+                          >
+                            <UserMinus className="size-4 text-destructive" />
+                          </TooltipTrigger>
+                          <TooltipContent>Remove from team</TooltipContent>
+                        </Tooltip>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          {/* Invite */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Invite link</CardTitle>
+              <CardDescription>
+                Anyone with a signed-in account who opens this link joins as a member.
+                {isAdmin && " Rotating it stops the old link from working."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input readOnly value={inviteUrl} aria-label="Invite link" className="font-mono text-xs" />
+                <div className="flex gap-2">
+                  <Button variant="outline" onClick={handleCopyInvite}>
+                    <Copy className="size-4" />
+                    Copy
+                  </Button>
+                  {isAdmin && (
+                    <Button variant="outline" onClick={handleRotate}>
+                      <RefreshCw className="size-4" />
+                      Rotate
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Retro defaults */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Retro defaults</CardTitle>
+              <CardDescription>
+                Copied onto every new retro this team creates. Changing them never touches a retro that already exists.
+                {!isAdmin && " Only admins can edit these."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <RetroDefaultsPanel value={team.retroDefaults} canEdit={isAdmin} onChange={handleRetroDefaults} />
+            </CardContent>
+          </Card>
+
+          {/* Leave / delete */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Membership</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => setConfirmLeave(true)}>
+                <LogOut className="size-4" />
+                Leave team
+              </Button>
+              {isAdmin && (
+                <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
+                  <Trash2 className="size-4" />
+                  Delete team
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+      <Footer />
+
+      <AlertDialog open={!!pendingRemove} onOpenChange={(open) => !open && setPendingRemove(null)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {pendingRemove?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              They lose access to this team&apos;s retros. Nothing they wrote is changed, and they keep any retro they already attended.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleConfirmRemove}>
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmLeave} onOpenChange={setConfirmLeave}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Leave {team.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You lose access to this team&apos;s retros. You keep any retro you already attended.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleLeave}>Leave</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmDelete} onOpenChange={(open) => !isDeleting && setConfirmDelete(open)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {team.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Its {team.roomCount} {team.roomCount === 1 ? "retro" : "retros"} and their action items are removed permanently. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting ? "Deleting…" : "Delete team"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
@@ -85,12 +85,6 @@ export function TeamContent() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmLeave, setConfirmLeave] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      router.replace(`/auth/signin?from=${encodeURIComponent(`/team/${teamId}`)}`);
-    }
-  }, [authLoading, isAuthenticated, router, teamId]);
 
   if (authLoading || !isAuthenticated || team === undefined) {
     return <Centered title="Loading…" body="Fetching the team" />;

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -146,9 +146,8 @@ export function TeamContent() {
     }
   };
 
-  const handleRetroDefaults = async (next: RetroDefaults) => {
-    await run(() => updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
-  };
+  const handleRetroDefaults = (next: RetroDefaults) =>
+    run(() => updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
 
   const handleDelete = async () => {
     setIsDeleting(true);

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -67,7 +67,6 @@ export function TeamContent() {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
 
   const team = useQuery(api.teams.get, isAuthenticated ? { teamId } : "skip");
-  const me = useQuery(api.users.getGlobalUser, isAuthenticated ? {} : "skip");
 
   const rename = useMutation(api.teams.rename);
   const rotateInvite = useMutation(api.teams.rotateInvite);
@@ -206,7 +205,7 @@ export function TeamContent() {
             </CardHeader>
             <CardContent className="space-y-1">
               {team.members.map((member) => {
-                const isMe = member.userId === me?._id;
+                const isMe = member.userId === team.myUserId;
                 return (
                   <div
                     key={member.userId}

--- a/src/app/team/join/[inviteToken]/join-content.test.tsx
+++ b/src/app/team/join/[inviteToken]/join-content.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * JoinTeamContent — the invite route's four states (spec §5): a stale link,
+ * an anonymous account shown "Sign in to join {team}" with a return path, a
+ * permanent account joined once and sent to the team page, and a failed join
+ * that "Try again" really retries. Convex, auth, routing and chrome mocked.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  team: undefined as undefined | null | { _id: string; name: string },
+  auth: { isAuthenticated: false, isLoading: false, accountType: null as null | "anonymous" | "permanent" },
+  joinByInvite: vi.fn<(args: { inviteToken: string }) => Promise<string>>(),
+  replace: vi.fn(),
+  // One router object, as Next's useRouter gives — it is an effect dependency.
+  router: { replace: (href: string) => mocks.replace(href), push: vi.fn() },
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => mocks.team,
+  useMutation: () => mocks.joinByInvite,
+}));
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ inviteToken: "tok-1" }),
+  useRouter: () => mocks.router,
+}));
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => mocks.auth }));
+vi.mock("@/components/navbar", () => ({ Navbar: () => null }));
+vi.mock("@/components/footer", () => ({ Footer: () => null }));
+
+import { JoinTeamContent } from "./join-content";
+
+beforeEach(() => {
+  mocks.team = { _id: "team-1", name: "Acme" };
+  mocks.auth = { isAuthenticated: false, isLoading: false, accountType: null };
+  mocks.joinByInvite.mockReset();
+  mocks.replace.mockReset();
+});
+afterEach(cleanup);
+
+describe("JoinTeamContent", () => {
+  it("a stale link says so and offers the way back", () => {
+    mocks.team = null;
+    render(<JoinTeamContent />);
+    expect(screen.getByText(/no longer valid/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Go to Retros" }).getAttribute("href")).toBe("/dashboard/retros");
+    expect(mocks.joinByInvite).not.toHaveBeenCalled();
+  });
+
+  it("an anonymous account is shown Sign in to join {team}, returning here after linking", () => {
+    mocks.auth = { isAuthenticated: true, isLoading: false, accountType: "anonymous" };
+    render(<JoinTeamContent />);
+    const link = screen.getByRole("link", { name: "Sign in to join Acme" });
+    expect(link.getAttribute("href")).toBe(`/auth/signin?from=${encodeURIComponent("/team/join/tok-1")}`);
+    expect(mocks.joinByInvite).not.toHaveBeenCalled();
+  });
+
+  it("nobody signed in gets the same sign-in copy", () => {
+    render(<JoinTeamContent />);
+    expect(screen.getByRole("link", { name: "Sign in to join Acme" })).toBeTruthy();
+  });
+
+  it("a permanent account joins exactly once and lands on the team page", async () => {
+    mocks.auth = { isAuthenticated: true, isLoading: false, accountType: "permanent" };
+    mocks.joinByInvite.mockResolvedValue("team-1");
+    const { rerender } = render(<JoinTeamContent />);
+    rerender(<JoinTeamContent />);
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/team/team-1"));
+    expect(mocks.joinByInvite).toHaveBeenCalledTimes(1);
+    expect(mocks.joinByInvite).toHaveBeenCalledWith({ inviteToken: "tok-1" });
+  });
+
+  it("a failed join shows the server's copy, and Try again really retries", async () => {
+    mocks.auth = { isAuthenticated: true, isLoading: false, accountType: "permanent" };
+    mocks.joinByInvite.mockRejectedValueOnce(new Error("This invite link is no longer valid"));
+    mocks.joinByInvite.mockResolvedValueOnce("team-1");
+    render(<JoinTeamContent />);
+
+    const retry = await screen.findByRole("button", { name: "Try again" });
+    expect(screen.getByText("This invite link is no longer valid")).toBeTruthy();
+    fireEvent.click(retry);
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/team/team-1"));
+    expect(mocks.joinByInvite).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/team/join/[inviteToken]/join-content.tsx
+++ b/src/app/team/join/[inviteToken]/join-content.tsx
@@ -26,6 +26,8 @@ export function JoinTeamContent() {
   const team = useQuery(api.teams.getByInviteToken, { inviteToken });
   const joinByInvite = useMutation(api.teams.joinByInvite);
   const [error, setError] = useState<string | null>(null);
+  // Bumped by "Try again" so the join effect runs once more.
+  const [attempt, setAttempt] = useState(0);
   const attemptedRef = useRef(false);
 
   const isPermanent = isAuthenticated && accountType === "permanent";
@@ -40,7 +42,7 @@ export function JoinTeamContent() {
         attemptedRef.current = false;
         setError(e instanceof Error ? e.message : "Failed to join the team");
       });
-  }, [team, isPermanent, inviteToken, joinByInvite, router]);
+  }, [team, isPermanent, inviteToken, joinByInvite, router, attempt]);
 
   let body: React.ReactNode;
   if (team === undefined || authLoading || (isAuthenticated && accountType === null)) {
@@ -60,7 +62,15 @@ export function JoinTeamContent() {
     body = (
       <>
         <p className="text-sm text-destructive">{error}</p>
-        <Button onClick={() => { setError(null); attemptedRef.current = false; }}>Try again</Button>
+        <Button
+          onClick={() => {
+            setError(null);
+            attemptedRef.current = false;
+            setAttempt((n) => n + 1);
+          }}
+        >
+          Try again
+        </Button>
       </>
     );
   } else if (isPermanent) {

--- a/src/app/team/join/[inviteToken]/join-content.tsx
+++ b/src/app/team/join/[inviteToken]/join-content.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { useAuth } from "@/components/auth/auth-provider";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * The invite route (spec §5): a permanent account becomes a member and lands
+ * on the team page; an anonymous account (or nobody) is shown "Sign in to
+ * join {team}" and returns here after linking. The only writer of a team
+ * membership.
+ */
+export function JoinTeamContent() {
+  const params = useParams();
+  const router = useRouter();
+  const inviteToken = params.inviteToken as string;
+  const { isAuthenticated, isLoading: authLoading, accountType } = useAuth();
+
+  const team = useQuery(api.teams.getByInviteToken, { inviteToken });
+  const joinByInvite = useMutation(api.teams.joinByInvite);
+  const [error, setError] = useState<string | null>(null);
+  const attemptedRef = useRef(false);
+
+  const isPermanent = isAuthenticated && accountType === "permanent";
+  const signInHref = `/auth/signin?from=${encodeURIComponent(`/team/join/${inviteToken}`)}`;
+
+  useEffect(() => {
+    if (!team || !isPermanent || attemptedRef.current) return;
+    attemptedRef.current = true;
+    joinByInvite({ inviteToken })
+      .then((teamId) => router.replace(`/team/${teamId}`))
+      .catch((e: unknown) => {
+        attemptedRef.current = false;
+        setError(e instanceof Error ? e.message : "Failed to join the team");
+      });
+  }, [team, isPermanent, inviteToken, joinByInvite, router]);
+
+  let body: React.ReactNode;
+  if (team === undefined || authLoading || (isAuthenticated && accountType === null)) {
+    body = <p className="text-sm text-muted-foreground">Checking the invite…</p>;
+  } else if (team === null) {
+    body = (
+      <>
+        <p className="text-sm text-muted-foreground">
+          This invite link is no longer valid. Ask a team admin for a new one.
+        </p>
+        <Button variant="outline" render={<Link href="/dashboard/retros" />} nativeButton={false}>
+          Go to Retros
+        </Button>
+      </>
+    );
+  } else if (error) {
+    body = (
+      <>
+        <p className="text-sm text-destructive">{error}</p>
+        <Button onClick={() => { setError(null); attemptedRef.current = false; }}>Try again</Button>
+      </>
+    );
+  } else if (isPermanent) {
+    body = <p className="text-sm text-muted-foreground">Joining {team.name}…</p>;
+  } else {
+    body = (
+      <>
+        <p className="text-sm text-muted-foreground">
+          Team membership needs a signed-in account, so the team knows who can read its retros.
+        </p>
+        <Button render={<Link href={signInHref} />} nativeButton={false}>Sign in to join {team.name}</Button>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex flex-1 items-center justify-center p-6">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>{team ? `Join ${team.name}` : "Join team"}</CardTitle>
+            <CardDescription>
+              {team ? "You've been invited to a team on AgileKit." : "Team invite"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col items-start gap-4">{body}</CardContent>
+        </Card>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/team/join/[inviteToken]/page.tsx
+++ b/src/app/team/join/[inviteToken]/page.tsx
@@ -1,0 +1,14 @@
+import { Metadata } from "next";
+import { JoinTeamContent } from "./join-content";
+
+export const metadata: Metadata = {
+  title: "Join team",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function JoinTeamPage() {
+  return <JoinTeamContent />;
+}

--- a/src/components/dashboard/app-sidebar.tsx
+++ b/src/components/dashboard/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   History,
+  MessagesSquare,
   Settings,
   HelpCircle,
   Home,
@@ -32,9 +33,14 @@ const navMain = [
     icon: LayoutDashboard,
   },
   {
-    title: "Sessions",
+    title: "Planning poker",
     url: "/dashboard/sessions",
     icon: History,
+  },
+  {
+    title: "Retros",
+    url: "/dashboard/retros",
+    icon: MessagesSquare,
   },
 ];
 

--- a/src/components/dashboard/dashboard-header.tsx
+++ b/src/components/dashboard/dashboard-header.tsx
@@ -7,9 +7,11 @@ import { useDateRange } from "./date-range-context";
 
 interface DashboardHeaderProps {
   title: string;
+  /** The analytics pages filter by date; retro surfaces show no time (spec §23). */
+  showDateRange?: boolean;
 }
 
-export function DashboardHeader({ title }: DashboardHeaderProps) {
+export function DashboardHeader({ title, showDateRange = true }: DashboardHeaderProps) {
   const { dateRange, setDateRange } = useDateRange();
 
   return (
@@ -17,7 +19,7 @@ export function DashboardHeader({ title }: DashboardHeaderProps) {
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4 hidden" />
       <h1 className="flex-1 text-sm font-medium">{title}</h1>
-      <DateRangePicker value={dateRange} onChange={setDateRange} />
+      {showDateRange && <DateRangePicker value={dateRange} onChange={setDateRange} />}
     </header>
   );
 }

--- a/src/components/team/new-team-dialog.test.tsx
+++ b/src/components/team/new-team-dialog.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * NewTeamDialog — "New team" (spec §5): a permanent account names the team,
+ * the mutation runs and the router lands on the new team page; an anonymous
+ * account sees "Sign in to create a team" with a sign-in link back to where
+ * it came from, and never reaches the mutation.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  accountType: null as null | "anonymous" | "permanent",
+  create: vi.fn<(args: { name: string }) => Promise<string>>(),
+  push: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({ useMutation: () => mocks.create }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("@/components/auth/auth-provider", () => ({
+  useAuth: () => ({ accountType: mocks.accountType }),
+}));
+vi.mock("@/lib/toast", () => ({ toast: { error: () => {} } }));
+// The Base UI dialog needs a portal and pointer environment jsdom lacks;
+// the dialog's structure is not under test, its content is.
+vi.mock("@/components/ui/dialog", () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Dialog: ({ children, open }: { children?: ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
+    DialogContent: passthrough,
+    DialogDescription: passthrough,
+    DialogFooter: passthrough,
+    DialogHeader: passthrough,
+    DialogTitle: passthrough,
+  };
+});
+
+import { NewTeamDialog } from "./new-team-dialog";
+
+beforeEach(() => {
+  mocks.accountType = "permanent";
+  mocks.create.mockReset();
+  mocks.push.mockReset();
+});
+afterEach(cleanup);
+
+describe("NewTeamDialog", () => {
+  it("a permanent account names the team, the mutation runs and the router lands on it", async () => {
+    mocks.create.mockResolvedValue("team-9");
+    const onOpenChange = vi.fn();
+    render(<NewTeamDialog open onOpenChange={onOpenChange} returnTo="/dashboard/retros" />);
+
+    const submit = screen.getByRole("button", { name: "Create team" }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.change(screen.getByRole("textbox", { name: "Team name" }), { target: { value: "  Acme  " } });
+    expect(submit.disabled).toBe(false);
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/team/team-9"));
+    expect(mocks.create).toHaveBeenCalledWith({ name: "Acme" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("an anonymous account is told to sign in and sent back here afterwards", () => {
+    mocks.accountType = "anonymous";
+    render(<NewTeamDialog open onOpenChange={() => {}} returnTo="/dashboard/retros" />);
+
+    expect(screen.getByText("Sign in to create a team")).toBeTruthy();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByRole("link", { name: "Sign in" }).getAttribute("href")).toBe(
+      "/auth/signin?from=%2Fdashboard%2Fretros"
+    );
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { useMutation } from "convex/react";
 import Link from "next/link";
 import { api } from "@/convex/_generated/api";
-import { SIGN_IN_TO_CREATE } from "@/convex/model/teams";
 import { useAuth } from "@/components/auth/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -92,7 +91,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
           </form>
         ) : (
           <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">{SIGN_IN_TO_CREATE}</p>
+            <p className="text-sm text-muted-foreground">Sign in to create a team</p>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 Cancel

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "convex/react";
+import Link from "next/link";
+import { api } from "@/convex/_generated/api";
+import { SIGN_IN_TO_CREATE } from "@/convex/model/teams";
+import { useAuth } from "@/components/auth/auth-provider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "@/lib/toast";
+
+interface NewTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Where the sign-in link returns to for an anonymous account. */
+  returnTo: string;
+}
+
+/**
+ * "New team" (spec §5): a permanent account names a Team and becomes its
+ * admin; an anonymous account is told to sign in first. The server enforces
+ * the same rule, so this dialog only shapes the copy.
+ */
+export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogProps) {
+  const router = useRouter();
+  const { accountType } = useAuth();
+  const createTeam = useMutation(api.teams.create);
+  const [name, setName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+
+  const isPermanent = accountType === "permanent";
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setIsCreating(true);
+    try {
+      const teamId = await createTeam({ name: trimmed });
+      onOpenChange(false);
+      setName("");
+      router.push(`/team/${teamId}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to create team");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>New team</DialogTitle>
+          <DialogDescription>
+            A team keeps its retros and decides who can read them later.
+          </DialogDescription>
+        </DialogHeader>
+        {isPermanent ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreate();
+            }}
+            className="space-y-4"
+          >
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Team name"
+              maxLength={100}
+              aria-label="Team name"
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!name.trim() || isCreating}>
+                {isCreating ? "Creating…" : "Create team"}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">{SIGN_IN_TO_CREATE}</p>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button render={<Link href={`/auth/signin?from=${encodeURIComponent(returnTo)}`} />} nativeButton={false}>
+                Sign in
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useMutation } from "convex/react";
 import Link from "next/link";
 import { api } from "@/convex/_generated/api";
+import { SIGN_IN_TO_CREATE } from "@/convex/teamCopy";
 import { useAuth } from "@/components/auth/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -91,7 +92,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
           </form>
         ) : (
           <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">Sign in to create a team</p>
+            <p className="text-sm text-muted-foreground">{SIGN_IN_TO_CREATE}</p>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 Cancel

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -40,14 +40,20 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
 
   const isPermanent = accountType === "permanent";
 
+  // Closing for any reason drops the draft, so a cancelled name never
+  // reappears the next time the dialog opens.
+  const close = (next: boolean) => {
+    if (!next) setName("");
+    onOpenChange(next);
+  };
+
   const handleCreate = async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
     setIsCreating(true);
     try {
       const teamId = await createTeam({ name: trimmed });
-      onOpenChange(false);
-      setName("");
+      close(false);
       router.push(`/team/${teamId}`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to create team");
@@ -57,7 +63,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={close}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>New team</DialogTitle>
@@ -82,7 +88,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
               aria-label="Team name"
             />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <Button type="button" variant="outline" onClick={() => close(false)}>
                 Cancel
               </Button>
               <Button type="submit" disabled={!name.trim() || isCreating}>
@@ -94,7 +100,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">{SIGN_IN_TO_CREATE}</p>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <Button type="button" variant="outline" onClick={() => close(false)}>
                 Cancel
               </Button>
               <Button render={<Link href={`/auth/signin?from=${encodeURIComponent(returnTo)}`} />} nativeButton={false}>

--- a/src/components/team/retro-defaults-panel.test.tsx
+++ b/src/components/team/retro-defaults-panel.test.tsx
@@ -83,3 +83,24 @@ describe("RetroDefaultsPanel", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe("RetroDefaultsPanel — keyboard", () => {
+  it("arrow keys move the selection and wrap, writing the bundle each time", () => {
+    const { onChange } = renderPanel();
+    const named = group("Attribution").getByRole("radio", { name: "Named" });
+    expect(named.tabIndex).toBe(0);
+    expect(group("Attribution").getByRole("radio", { name: "Anonymous" }).tabIndex).toBe(-1);
+
+    fireEvent.keyDown(named, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenLastCalledWith({ ...initial, attribution: "anonymous" });
+
+    // Wraps from the first option back to the last.
+    fireEvent.keyDown(named, { key: "ArrowLeft" });
+    expect(onChange).toHaveBeenLastCalledWith({ ...initial, attribution: "anonymous" });
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    // Other keys are ignored.
+    fireEvent.keyDown(named, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/team/retro-defaults-panel.test.tsx
+++ b/src/components/team/retro-defaults-panel.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * RetroDefaultsPanel — the team page's retro-defaults editor. Every change
+ * writes the whole bundle by value (spec §5, ADR-0013): one changed key, the
+ * other five untouched, and never a mutation of the bundle it was given. A
+ * member sees the current values with no live controls.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { DEFAULT_RETRO_PERMISSIONS } from "@/convex/permissions";
+import { RetroDefaultsPanel, type RetroDefaults } from "./retro-defaults-panel";
+
+afterEach(cleanup);
+
+const initial: RetroDefaults = {
+  attribution: "named",
+  joinPolicy: "anyone",
+  permissions: { ...DEFAULT_RETRO_PERMISSIONS },
+};
+
+function renderPanel(canEdit = true) {
+  const onChange = vi.fn(() => Promise.resolve());
+  const value: RetroDefaults = structuredClone(initial);
+  render(<RetroDefaultsPanel value={value} canEdit={canEdit} onChange={onChange} />);
+  return { onChange, value };
+}
+
+function group(name: string) {
+  return within(screen.getByRole("radiogroup", { name }));
+}
+
+// No jest-dom in this project: read the ARIA state directly.
+const checked = (el: HTMLElement) => el.getAttribute("aria-checked") === "true";
+const disabled = (el: HTMLElement) => (el as HTMLButtonElement).disabled;
+
+describe("RetroDefaultsPanel", () => {
+  it("renders the six settings at their current values", () => {
+    renderPanel();
+    expect(checked(group("Attribution").getByRole("radio", { name: "Named" }))).toBe(true);
+    expect(checked(group("Who can join").getByRole("radio", { name: "Anyone with the link" }))).toBe(true);
+    expect(checked(group("Stage flow").getByRole("radio", { name: "Facilitators" }))).toBe(true);
+    expect(checked(group("Card management").getByRole("radio", { name: "Facilitators" }))).toBe(true);
+    expect(checked(group("Action items").getByRole("radio", { name: "Everyone" }))).toBe(true);
+    expect(checked(group("Retro settings").getByRole("radio", { name: "Facilitators" }))).toBe(true);
+  });
+
+  it("changing attribution writes the whole bundle with only that key changed", () => {
+    const { onChange, value } = renderPanel();
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Anonymous" }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ ...initial, attribution: "anonymous" });
+    // By value: the bundle handed in is untouched.
+    expect(value).toEqual(initial);
+  });
+
+  it("changing the join policy and a permission level each write the full bundle", () => {
+    const { onChange } = renderPanel();
+    fireEvent.click(group("Who can join").getByRole("radio", { name: "Team members" }));
+    expect(onChange).toHaveBeenLastCalledWith({ ...initial, joinPolicy: "teamMembers" });
+
+    fireEvent.click(group("Card management").getByRole("radio", { name: "Owner only" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...initial,
+      permissions: { ...initial.permissions, cardManagement: "owner" },
+    });
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-selecting the current value writes nothing", () => {
+    const { onChange } = renderPanel();
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Named" }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("a member sees the values but every control is disabled", () => {
+    const { onChange } = renderPanel(false);
+    const named = group("Attribution").getByRole("radio", { name: "Named" });
+    expect(checked(named)).toBe(true);
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(disabled(radio)).toBe(true);
+    }
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Anonymous" }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/team/retro-defaults-panel.test.tsx
+++ b/src/components/team/retro-defaults-panel.test.tsx
@@ -5,7 +5,7 @@
  * member sees the current values with no live controls.
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within, waitFor } from "@testing-library/react";
 import { DEFAULT_RETRO_PERMISSIONS } from "@/convex/permissions";
 import { RetroDefaultsPanel, type RetroDefaults } from "./retro-defaults-panel";
 
@@ -129,5 +129,34 @@ describe("RetroDefaultsPanel — quick successive changes", () => {
     const pushed: RetroDefaults = { ...initial, attribution: "anonymous" };
     rerender(<RetroDefaultsPanel value={pushed} canEdit onChange={onChange} />);
     expect(checked(group("Who can join").getByRole("radio", { name: "Anyone with the link" }))).toBe(true);
+  });
+});
+
+describe("RetroDefaultsPanel — a write that does not land", () => {
+  it("rolls the control back to the stored bundle when onChange resolves false", async () => {
+    const onChange = vi.fn(() => Promise.resolve(false));
+    render(<RetroDefaultsPanel value={initial} canEdit onChange={onChange} />);
+
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Anonymous" }));
+    expect(checked(group("Attribution").getByRole("radio", { name: "Anonymous" }))).toBe(true);
+
+    await waitFor(() =>
+      expect(checked(group("Attribution").getByRole("radio", { name: "Named" }))).toBe(true)
+    );
+  });
+
+  it("rolls back on a thrown error too, and keeps a later successful draft", async () => {
+    let call = 0;
+    const onChange = vi.fn(() => (++call === 1 ? Promise.reject(new Error("no")) : Promise.resolve()));
+    render(<RetroDefaultsPanel value={initial} canEdit onChange={onChange} />);
+
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Anonymous" }));
+    fireEvent.click(group("Who can join").getByRole("radio", { name: "Team members" }));
+
+    // The first write failed and is rolled back; the second, which built on
+    // it, is the draft that stays.
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(checked(group("Who can join").getByRole("radio", { name: "Team members" }))).toBe(true);
   });
 });

--- a/src/components/team/retro-defaults-panel.test.tsx
+++ b/src/components/team/retro-defaults-panel.test.tsx
@@ -58,9 +58,12 @@ describe("RetroDefaultsPanel", () => {
     fireEvent.click(group("Who can join").getByRole("radio", { name: "Team members" }));
     expect(onChange).toHaveBeenLastCalledWith({ ...initial, joinPolicy: "teamMembers" });
 
+    // The second write carries the first: each write replaces the whole
+    // stored object, so it must build on what was just written.
     fireEvent.click(group("Card management").getByRole("radio", { name: "Owner only" }));
     expect(onChange).toHaveBeenLastCalledWith({
       ...initial,
+      joinPolicy: "teamMembers",
       permissions: { ...initial.permissions, cardManagement: "owner" },
     });
     expect(onChange).toHaveBeenCalledTimes(2);
@@ -102,5 +105,29 @@ describe("RetroDefaultsPanel — keyboard", () => {
     // Other keys are ignored.
     fireEvent.keyDown(named, { key: "Enter" });
     expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("RetroDefaultsPanel — quick successive changes", () => {
+  it("the second write builds on the first, not on the stale prop, until the query catches up", () => {
+    const onChange = vi.fn(() => Promise.resolve());
+    const { rerender } = render(<RetroDefaultsPanel value={initial} canEdit onChange={onChange} />);
+
+    fireEvent.click(group("Attribution").getByRole("radio", { name: "Anonymous" }));
+    fireEvent.click(group("Who can join").getByRole("radio", { name: "Team members" }));
+    expect(onChange).toHaveBeenNthCalledWith(1, { ...initial, attribution: "anonymous" });
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      ...initial,
+      attribution: "anonymous",
+      joinPolicy: "teamMembers",
+    });
+    // The UI shows both changes before the query has pushed anything back.
+    expect(checked(group("Attribution").getByRole("radio", { name: "Anonymous" }))).toBe(true);
+    expect(checked(group("Who can join").getByRole("radio", { name: "Team members" }))).toBe(true);
+
+    // The query pushes a new bundle: it wins over the draft.
+    const pushed: RetroDefaults = { ...initial, attribution: "anonymous" };
+    rerender(<RetroDefaultsPanel value={pushed} canEdit onChange={onChange} />);
+    expect(checked(group("Who can join").getByRole("radio", { name: "Anyone with the link" }))).toBe(true);
   });
 });

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -75,7 +75,7 @@ function SegmentedControl<V extends string>({
       aria-label={label}
       className="inline-flex rounded-lg border border-border bg-white p-0.5 dark:bg-surface-2"
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const selected = option.value === value;
         return (
           <button
@@ -83,10 +83,30 @@ function SegmentedControl<V extends string>({
             type="button"
             role="radio"
             aria-checked={selected}
+            // Roving tabindex: Tab lands on the selected option, arrows move
+            // between the others (the ARIA radio-group pattern).
+            tabIndex={selected ? 0 : -1}
             disabled={disabled}
             onClick={() => {
               if (!selected) onSelect(option.value);
             }}
+            onKeyDown={(e) => {
+              const step =
+                e.key === "ArrowRight" || e.key === "ArrowDown"
+                  ? 1
+                  : e.key === "ArrowLeft" || e.key === "ArrowUp"
+                    ? -1
+                    : 0;
+              if (step === 0) return;
+              e.preventDefault();
+              const next = options[(index + step + options.length) % options.length];
+              onSelect(next.value);
+              const sibling = e.currentTarget.parentElement?.querySelector<HTMLButtonElement>(
+                `[data-value="${next.value}"]`
+              );
+              sibling?.focus();
+            }}
+            data-value={option.value}
             className={cn(
               "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
               "disabled:cursor-default",

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import type { PermissionLevel, RetroPermissionCategory } from "@/convex/permissions";
+import type { RetroDefaults } from "@/convex/model/teams";
+import { cn } from "@/lib/utils";
+
+export type { RetroDefaults };
+
+interface RetroDefaultsPanelProps {
+  value: RetroDefaults;
+  /** Admins edit; members read. */
+  canEdit: boolean;
+  /** Receives the whole bundle, by value, on every change. */
+  onChange: (next: RetroDefaults) => Promise<void> | void;
+}
+
+type Option<V extends string> = { value: V; label: string };
+
+const ATTRIBUTION_OPTIONS: Option<RetroDefaults["attribution"]>[] = [
+  { value: "named", label: "Named" },
+  { value: "anonymous", label: "Anonymous" },
+];
+
+const JOIN_POLICY_OPTIONS: Option<RetroDefaults["joinPolicy"]>[] = [
+  { value: "anyone", label: "Anyone with the link" },
+  { value: "permanentAccounts", label: "Signed-in accounts" },
+  { value: "teamMembers", label: "Team members" },
+];
+
+const LEVEL_OPTIONS: Option<PermissionLevel>[] = [
+  { value: "everyone", label: "Everyone" },
+  { value: "facilitators", label: "Facilitators" },
+  { value: "owner", label: "Owner only" },
+];
+
+const PERMISSION_ROWS: { category: RetroPermissionCategory; label: string; description: string }[] = [
+  {
+    category: "stageFlow",
+    label: "Stage flow",
+    description: "Advance stages, reveal cards, run the timebox and the discussion",
+  },
+  {
+    category: "cardManagement",
+    label: "Card management",
+    description: "Edit, move or delete other people's cards; tidy and manage groups",
+  },
+  {
+    category: "actionManagement",
+    label: "Action items",
+    description: "Edit, reassign or close action items other than your own",
+  },
+  {
+    category: "retroSettings",
+    label: "Retro settings",
+    description: "Rename the retro, edit prompts, stages and the join policy",
+  },
+];
+
+function SegmentedControl<V extends string>({
+  label,
+  options,
+  value,
+  disabled,
+  onSelect,
+}: {
+  label: string;
+  options: Option<V>[];
+  value: V;
+  disabled: boolean;
+  onSelect: (next: V) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className="inline-flex rounded-lg border border-border bg-white p-0.5 dark:bg-surface-2"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => {
+              if (!selected) onSelect(option.value);
+            }}
+            className={cn(
+              "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+              "disabled:cursor-default",
+              selected
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground disabled:hover:text-muted-foreground"
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * The retro-defaults panel (spec §5): attribution, join policy and the four
+ * retro permission levels. Every change hands the parent the whole bundle by
+ * value — the server replaces the stored object, never patches a key, so a
+ * retro created a moment later copies exactly what is shown here.
+ */
+export function RetroDefaultsPanel({ value, canEdit, onChange }: RetroDefaultsPanelProps) {
+  const write = (next: RetroDefaults) => {
+    void onChange(next);
+  };
+
+  return (
+    <div className="divide-y divide-border">
+      <Row label="Attribution" description="Whether cards carry their author. A retro can be made anonymous later, never named again.">
+        <SegmentedControl
+          label="Attribution"
+          options={ATTRIBUTION_OPTIONS}
+          value={value.attribution}
+          disabled={!canEdit}
+          onSelect={(attribution) => write({ ...value, permissions: { ...value.permissions }, attribution })}
+        />
+      </Row>
+      <Row label="Who can join" description="Who may become an attendee of a new retro. Team members always can.">
+        <SegmentedControl
+          label="Who can join"
+          options={JOIN_POLICY_OPTIONS}
+          value={value.joinPolicy}
+          disabled={!canEdit}
+          onSelect={(joinPolicy) => write({ ...value, permissions: { ...value.permissions }, joinPolicy })}
+        />
+      </Row>
+      {PERMISSION_ROWS.map((row) => (
+        <Row key={row.category} label={row.label} description={row.description}>
+          <SegmentedControl
+            label={row.label}
+            options={LEVEL_OPTIONS}
+            value={value.permissions[row.category]}
+            disabled={!canEdit}
+            onSelect={(level) =>
+              write({ ...value, permissions: { ...value.permissions, [row.category]: level } })
+            }
+          />
+        </Row>
+      ))}
+    </div>
+  );
+}

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { PermissionLevel, RetroPermissionCategory } from "@/convex/permissions";
-import type { RetroDefaults } from "@/convex/model/teams";
+import type { PermissionLevel, RetroDefaults, RetroPermissionCategory } from "@/convex/permissions";
 import { cn } from "@/lib/utils";
 
 export type { RetroDefaults };
@@ -11,8 +10,12 @@ interface RetroDefaultsPanelProps {
   value: RetroDefaults;
   /** Admins edit; members read. */
   canEdit: boolean;
-  /** Receives the whole bundle, by value, on every change. */
-  onChange: (next: RetroDefaults) => Promise<void> | void;
+  /**
+   * Receives the whole bundle, by value, on every change. Resolving `false`
+   * or throwing means the write did not land: the panel drops its draft and
+   * shows the stored bundle again.
+   */
+  onChange: (next: RetroDefaults) => Promise<boolean | void> | boolean | void;
 }
 
 type Option<V extends string> = { value: V; label: string };
@@ -153,14 +156,26 @@ function Row({
 export function RetroDefaultsPanel({ value: stored, canEdit, onChange }: RetroDefaultsPanelProps) {
   // Each write replaces the whole stored object, so two quick changes must
   // build on each other rather than both on the prop the query last pushed.
-  // The draft is keyed to the stored bundle it was written over: once the
-  // query pushes a new one (carrying the writes), the draft is dropped.
+  // The draft is keyed by identity to the stored bundle it was written over:
+  // Convex's useQuery hands back the same object until the result changes,
+  // so a new reference means the query pushed a new bundle (carrying the
+  // writes) and the draft is dropped.
   const [draft, setDraft] = useState<{ base: RetroDefaults; value: RetroDefaults } | null>(null);
   const value = draft && draft.base === stored ? draft.value : stored;
 
-  const write = (next: RetroDefaults) => {
+  const write = async (next: RetroDefaults) => {
     setDraft({ base: stored, value: next });
-    void onChange(next);
+    let landed: boolean;
+    try {
+      landed = (await onChange(next)) !== false;
+    } catch {
+      landed = false;
+    }
+    if (!landed) {
+      // Roll back to what the server holds — but only if no later write has
+      // replaced this draft in the meantime.
+      setDraft((current) => (current?.value === next ? null : current));
+    }
   };
 
   return (
@@ -171,7 +186,7 @@ export function RetroDefaultsPanel({ value: stored, canEdit, onChange }: RetroDe
           options={ATTRIBUTION_OPTIONS}
           value={value.attribution}
           disabled={!canEdit}
-          onSelect={(attribution) => write({ ...value, attribution })}
+          onSelect={(attribution) => void write({ ...value, attribution })}
         />
       </Row>
       <Row label="Who can join" description="Who may become an attendee of a new retro. Team members always can.">
@@ -180,7 +195,7 @@ export function RetroDefaultsPanel({ value: stored, canEdit, onChange }: RetroDe
           options={JOIN_POLICY_OPTIONS}
           value={value.joinPolicy}
           disabled={!canEdit}
-          onSelect={(joinPolicy) => write({ ...value, joinPolicy })}
+          onSelect={(joinPolicy) => void write({ ...value, joinPolicy })}
         />
       </Row>
       {PERMISSION_ROWS.map((row) => (
@@ -191,7 +206,7 @@ export function RetroDefaultsPanel({ value: stored, canEdit, onChange }: RetroDe
             value={value.permissions[row.category]}
             disabled={!canEdit}
             onSelect={(level) =>
-              write({ ...value, permissions: { ...value.permissions, [row.category]: level } })
+              void write({ ...value, permissions: { ...value.permissions, [row.category]: level } })
             }
           />
         </Row>

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -162,7 +162,7 @@ export function RetroDefaultsPanel({ value, canEdit, onChange }: RetroDefaultsPa
           options={ATTRIBUTION_OPTIONS}
           value={value.attribution}
           disabled={!canEdit}
-          onSelect={(attribution) => write({ ...value, permissions: { ...value.permissions }, attribution })}
+          onSelect={(attribution) => write({ ...value, attribution })}
         />
       </Row>
       <Row label="Who can join" description="Who may become an attendee of a new retro. Team members always can.">
@@ -171,7 +171,7 @@ export function RetroDefaultsPanel({ value, canEdit, onChange }: RetroDefaultsPa
           options={JOIN_POLICY_OPTIONS}
           value={value.joinPolicy}
           disabled={!canEdit}
-          onSelect={(joinPolicy) => write({ ...value, permissions: { ...value.permissions }, joinPolicy })}
+          onSelect={(joinPolicy) => write({ ...value, joinPolicy })}
         />
       </Row>
       {PERMISSION_ROWS.map((row) => (

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { PermissionLevel, RetroPermissionCategory } from "@/convex/permissions";
 import type { RetroDefaults } from "@/convex/model/teams";
 import { cn } from "@/lib/utils";
@@ -149,8 +150,16 @@ function Row({
  * value — the server replaces the stored object, never patches a key, so a
  * retro created a moment later copies exactly what is shown here.
  */
-export function RetroDefaultsPanel({ value, canEdit, onChange }: RetroDefaultsPanelProps) {
+export function RetroDefaultsPanel({ value: stored, canEdit, onChange }: RetroDefaultsPanelProps) {
+  // Each write replaces the whole stored object, so two quick changes must
+  // build on each other rather than both on the prop the query last pushed.
+  // The draft is keyed to the stored bundle it was written over: once the
+  // query pushes a new one (carrying the writes), the draft is dropped.
+  const [draft, setDraft] = useState<{ base: RetroDefaults; value: RetroDefaults } | null>(null);
+  const value = draft && draft.base === stored ? draft.value : stored;
+
   const write = (next: RetroDefaults) => {
+    setDraft({ base: stored, value: next });
     void onChange(next);
   };
 

--- a/src/components/user-menu/user-menu.tsx
+++ b/src/components/user-menu/user-menu.tsx
@@ -25,7 +25,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
-import { Moon, Sun, LogOut, UserPen, Monitor, Eye, LayoutDashboard, LogIn, History } from "lucide-react";
+import { Moon, Sun, LogOut, UserPen, Monitor, Eye, LayoutDashboard, LogIn, History, MessagesSquare, Users } from "lucide-react";
 import Link from "next/link";
 import type { Id } from "@/convex/_generated/dataModel";
 import { toast } from "@/lib/toast";
@@ -52,6 +52,9 @@ export function UserMenu() {
       ? { roomId }
       : "skip"
   );
+
+  // The person's Teams (ADR-0008): the menu links to each team page.
+  const teams = useQuery(api.teams.listMine, isAuthenticated ? {} : "skip");
 
   const editGlobalUser = useMutation(api.users.editGlobalUser);
   const editUser = useMutation(api.users.edit);
@@ -120,11 +123,30 @@ export function UserMenu() {
             Dashboard
           </DropdownMenuItem>
 
-          {/* Sessions link */}
+          {/* Planning poker sessions */}
           <DropdownMenuItem render={<Link href="/dashboard/sessions" />}>
             <History className="mr-2 size-4" />
-            Sessions
+            Planning poker
           </DropdownMenuItem>
+
+          {/* Retros */}
+          <DropdownMenuItem render={<Link href="/dashboard/retros" />}>
+            <MessagesSquare className="mr-2 size-4" />
+            Retros
+          </DropdownMenuItem>
+
+          {/* The person's team pages */}
+          {teams && teams.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              {teams.map((team) => (
+                <DropdownMenuItem key={team._id} render={<Link href={`/team/${team._id}`} />}>
+                  <Users className="mr-2 size-4" />
+                  <span className="truncate">{team.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </>
+          )}
 
           <DropdownMenuSeparator />
 


### PR DESCRIPTION
Closes #287. Part (b), the UI, stacked on the backend PR (spec `docs/spec/retro.md` §5, §18.1, §19). Merge the backend PR first; this one then rebases to a single commit on main.

## Routes

- **`/team/[teamId]`**, members only: members with roles and admin-only promote / demote / remove, inline rename, the invite link with copy and admin-only rotate, the retro-defaults panel, *New retro* (links to `/retro/new?team=…`, the route #288 creates — 404 until then, as the issue allows), *Leave*, and admin-only *Delete team* behind "Delete {team}? Its {n} retros and their action items are removed permanently. This cannot be undone." A route-level `error.tsx` turns the guard's throw for a non-member into a friendly page instead of the generic error screen.
- **`/team/join/[inviteToken]`**: a permanent account joins on load and lands on the team page; an anonymous account (or nobody) sees "Sign in to join {team}" and returns here after linking via the existing `from=` flow; a stale token says so.
- **`/dashboard/retros`**: the person's Teams with *New team*. The dialog shows "Sign in to create a team" to an anonymous account. Retro history rows arrive with #288/#289.

## Navigation

Sidebar is Overview / Planning poker / Retros / Settings; the `/dashboard/sessions` URL is unchanged. The user menu's "Sessions" becomes "Planning poker", gains "Retros", and links to each of the person's team pages. `DashboardHeader` gains `showDateRange` so retro surfaces show no time (spec §23).

## Retro-defaults panel

`RetroDefaultsPanel` renders attribution, join policy and the four retro permission levels as segmented controls and hands the parent the whole bundle by value on every change (ADR-0013: the server replaces the stored object). A member sees the values with every control disabled. The jsdom test pins the by-value write, that re-selecting the current value writes nothing, and the disabled state. The control is hand-rolled (`role="radiogroup"`) rather than a Base UI toggle group so the test can drive it in jsdom.

## Notes for review

- Every `Button` rendered as a `Link` passes `nativeButton={false}`. Without it Base UI logs a console error that neither `tsc` nor `eslint` catches; a dev-server smoke test found it.
- The rename input keeps a draft keyed to the stored name, so a query update mid-edit discards the draft without an effect (the `react-hooks/set-state-in-effect` rule is an error here).
- The permanent-account paths (team page, join) were exercised through the convex-test suite; the browser smoke test covered the stale-invite page and the guest flow only.

## Verification

- `npm run ts:check` clean
- `npm run test`: 60 files, 613 tests pass
- `npm run lint`: only the 6 pre-existing warnings

https://claude.ai/code/session_01LTuViwbbbictkKbzyZCBaa
