### PR TITLE
feat(retro): team retro — defaults copy, adoption, claim, delete, listings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,7 @@ _Avoid_: retrospective (in UI), retro room (a retro *is* a room), meeting
 
 ### Teams
 
-Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253); the Team itself (create, invite, roles, deletion, the reader guard's Team half) is built, retros in it are not yet. See [ADR-0008](docs/adr/0008-a-team-is-the-permanent-visibility-boundary.md) and [ADR-0009](docs/adr/0009-room-access-and-room-attendance-are-separate-guards.md).
+Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253); the Team itself (create, invite, roles, deletion, the reader guard's Team half) and the team retro (defaults copied by value, adoption, **claim**, deletion, the two listings) are built. See [ADR-0008](docs/adr/0008-a-team-is-the-permanent-visibility-boundary.md) and [ADR-0009](docs/adr/0009-room-access-and-room-attendance-are-separate-guards.md).
 
 **Team**:
 The permanent boundary that owns retro history and fixes who may read it. Deliberately minimal — it exists to give retros continuity and a knowable set of readers, nothing else (no seats, billing, SSO or org roles). A room names its team through a set-once `teamId`, and the team *is* the series: its history is its rooms in creation order, with no separate series entity.
@@ -218,7 +218,7 @@ _Avoid_: reveal cards (that is the poker **permission category**), unblur, show 
 
 ### Retro permissions
 
-Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253) and not yet built. See [ADR-0013](docs/adr/0013-retro-permissions-extend-the-one-decision.md).
+Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253); the join policy, the retro defaults bundle and **claim** are built, the retro categories gate nothing yet. See [ADR-0013](docs/adr/0013-retro-permissions-extend-the-one-decision.md).
 
 **Join policy**:
 A room's admission rule — `anyone`, `permanentAccounts`, or `teamMembers` (offered only when the room has a **Team**). Decides who may *become* an attendee; it says nothing about **room access**, and a **Team membership** satisfies every value because reading the archive is the stronger claim. Stamped at creation by copy from the Team's **retro defaults**; a teamless room is `anyone`. Edited through the **retro settings** category.
@@ -258,7 +258,7 @@ _Avoid_: import, roll over, transfer, parking lot
 
 ### Retro retention
 
-Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253) and not yet built. See [ADR-0019](docs/adr/0019-retention-follows-the-team-and-export-never-widens-access.md).
+Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253); the flag, the sweep, adoption and retro deletion are built, export is not. See [ADR-0019](docs/adr/0019-retention-follows-the-team-and-export-never-widens-access.md).
 
 **Retained**:
 A room the five-day sweep leaves alone — true exactly when the room belongs to a **Team**, and for no other reason. Set when the room is created or adopted into a team; a teamless retro is a throwaway whoever created it, and keeping one means giving it a team. Stored as its own flag rather than derived, so it is the one field a future retention policy would flip. Retention is not visibility: what a retained retro's readers can see is fixed by **room access**, disclosed before the first card is written.

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -301,6 +301,9 @@ async function rowsOf(ctx: QueryCtx, rooms: Doc<"rooms">[]): Promise<RetroListRo
 /** How many of a Team's retros a listing shows; the history row (#299) pages. */
 const MAX_LISTED_ROOMS = 200;
 
+/** How many memberships the dashboard walks looking for retros. */
+const MAX_SCANNED_MEMBERSHIPS = 1000;
+
 /**
  * The team page's listing (spec §5): the Team's retros in creation order.
  * The bound keeps the newest, so a long history drops its oldest rows.
@@ -347,16 +350,19 @@ export async function listMine(
   userId: Id<"users">
 ): Promise<RetroListGroup[]> {
   // Walk the person's memberships newest first and keep the retro rooms
-  // among them, up to the bound: poker memberships share the index and
-  // must not use up the budget before a retro is reached.
+  // among them, up to the listing bound: poker memberships share the index
+  // and must not use up the budget before a retro is reached. The scan has
+  // its own bound so a heavy poker player's dashboard degrades to "not
+  // every retro" rather than to a read-limit failure.
   const rooms: Doc<"rooms">[] = [];
+  let scanned = 0;
   for await (const membership of ctx.db
     .query("roomMemberships")
     .withIndex("by_user", (q) => q.eq("userId", userId))
     .order("desc")) {
     const room = await ctx.db.get(membership.roomId);
     if (room?.roomType === "retro") rooms.push(room);
-    if (rooms.length >= MAX_LISTED_ROOMS) break;
+    if (rooms.length >= MAX_LISTED_ROOMS || ++scanned >= MAX_SCANNED_MEMBERSHIPS) break;
   }
   const rows = await rowsOf(ctx, rooms);
   const roomById = new Map(rooms.map((room) => [room._id, room]));

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -201,11 +201,18 @@ export async function claim(
  */
 export async function deleteRetro(
   ctx: MutationCtx,
-  roomId: Id<"rooms">
+  room: Doc<"rooms">
 ): Promise<void> {
-  const step = await deleteRoomAggregateChunk(ctx, roomId);
+  // The retro API deletes retros; a poker room has no delete verb yet and
+  // must not gain one through this door.
+  if (room.roomType !== "retro") {
+    throw refusal("missing", NOT_A_RETRO);
+  }
+  const step = await deleteRoomAggregateChunk(ctx, room._id);
   if (!step.done) {
-    await ctx.scheduler.runAfter(0, internal.maintenance.deleteRoomAggregateChunk, { roomId });
+    await ctx.scheduler.runAfter(0, internal.maintenance.deleteRoomAggregateChunk, {
+      roomId: room._id,
+    });
   }
 }
 
@@ -264,9 +271,15 @@ export interface RetroListRow {
   createdAt: number;
 }
 
+/** The entry the shared pointer names; the first entry if the pointer dangles. */
+export function currentStageOf(
+  retro: Pick<Doc<"retros">, "stages" | "currentStageId">
+): Doc<"retros">["stages"][number] {
+  return retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
+}
+
 function toRow(room: Doc<"rooms">, retro: Doc<"retros">): RetroListRow {
-  const current =
-    retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
+  const current = currentStageOf(retro);
   return {
     roomId: room._id,
     name: room.name,
@@ -288,7 +301,10 @@ async function rowsOf(ctx: QueryCtx, rooms: Doc<"rooms">[]): Promise<RetroListRo
 /** How many of a Team's retros a listing shows; the history row (#299) pages. */
 const MAX_LISTED_ROOMS = 200;
 
-/** The team page's listing (spec §5): the Team's retros in creation order. */
+/**
+ * The team page's listing (spec §5): the Team's retros in creation order.
+ * The bound keeps the newest, so a long history drops its oldest rows.
+ */
 export async function listForTeam(
   ctx: QueryCtx,
   teamId: Id<"teams">
@@ -296,8 +312,9 @@ export async function listForTeam(
   const rooms = await ctx.db
     .query("rooms")
     .withIndex("by_team", (q) => q.eq("teamId", teamId))
+    .order("desc")
     .take(MAX_LISTED_ROOMS);
-  return rowsOf(ctx, rooms);
+  return rowsOf(ctx, rooms.reverse());
 }
 
 /**
@@ -313,7 +330,7 @@ export function orderForDashboard(rows: RetroListRow[]): RetroListRow[] {
 }
 
 export interface RetroListGroup {
-  /** Undefined for the "No team" group. */
+  /** The door to the team page; only when the person is still a member. */
   teamId?: Id<"teams">;
   teamName: string;
   retros: RetroListRow[];
@@ -329,13 +346,18 @@ export async function listMine(
   ctx: QueryCtx,
   userId: Id<"users">
 ): Promise<RetroListGroup[]> {
-  const memberships = await ctx.db
+  // Walk the person's memberships newest first and keep the retro rooms
+  // among them, up to the bound: poker memberships share the index and
+  // must not use up the budget before a retro is reached.
+  const rooms: Doc<"rooms">[] = [];
+  for await (const membership of ctx.db
     .query("roomMemberships")
     .withIndex("by_user", (q) => q.eq("userId", userId))
-    .take(MAX_LISTED_ROOMS);
-  const rooms = (await Promise.all(memberships.map((m) => ctx.db.get(m.roomId)))).filter(
-    (room): room is Doc<"rooms"> => room !== null && room.roomType === "retro"
-  );
+    .order("desc")) {
+    const room = await ctx.db.get(membership.roomId);
+    if (room?.roomType === "retro") rooms.push(room);
+    if (rooms.length >= MAX_LISTED_ROOMS) break;
+  }
   const rows = await rowsOf(ctx, rooms);
   const roomById = new Map(rooms.map((room) => [room._id, room]));
 
@@ -353,20 +375,21 @@ export async function listMine(
       byTeam.delete(team._id);
     }
   }
-  // Retros of a Team the person has since left, or whose Team is gone, are
-  // still theirs by attendance; they list under the Team's name when it
-  // still exists.
+  // Retros of a Team the person has since left are still theirs by
+  // attendance: they list under the Team's name, without the door to a
+  // team page they can no longer open. A Team mid-cascade lists its rooms
+  // under "No team" until the cascade takes them.
+  const teamless = byTeam.get(undefined) ?? [];
   for (const [teamId, retros] of byTeam) {
     if (teamId === undefined) continue;
     const team = await ctx.db.get(teamId);
-    groups.push({
-      teamId,
-      teamName: team?.name ?? NO_TEAM_GROUP,
-      retros: orderForDashboard(retros),
-    });
+    if (team) {
+      groups.push({ teamName: team.name, retros: orderForDashboard(retros) });
+    } else {
+      teamless.push(...retros);
+    }
   }
-  const teamless = byTeam.get(undefined);
-  if (teamless) {
+  if (teamless.length > 0) {
     groups.push({ teamName: NO_TEAM_GROUP, retros: orderForDashboard(teamless) });
   }
   return groups;

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -179,6 +179,9 @@ export async function claim(
   args: { room: Doc<"rooms">; actorMembership: Doc<"roomMemberships"> }
 ): Promise<void> {
   const { room, actorMembership } = args;
+  if (room.roomType !== "retro") {
+    throw refusal("missing", NOT_A_RETRO);
+  }
   if (room.ownerId && room.ownerId !== actorMembership.userId) {
     const previous = await ctx.db
       .query("roomMemberships")

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -1,15 +1,31 @@
 import { MutationCtx, QueryCtx } from "../_generated/server";
 import { Doc, Id } from "../_generated/dataModel";
+import { internal } from "../_generated/api";
 import { DEFAULT_RETRO_PERMISSIONS } from "../permissions";
-import { validateRoomName } from "./rooms";
-import { findFormat, seedStages, stampFormat } from "./retroFormats";
-import { NOT_A_RETRO, UNKNOWN_FORMAT } from "../retroCopy";
+import { validateRoomName, updateRoomActivity } from "./rooms";
+import { deleteRoomAggregateChunk } from "./roomAggregate";
+import { listTeamsForUser } from "./teams";
+import {
+  findFormat,
+  seedStages,
+  stampFormat,
+  type StageKind,
+  type StampedFormat,
+} from "./retroFormats";
+import {
+  ALREADY_KEPT_BY_TEAM,
+  NO_TEAM_GROUP,
+  NOT_A_RETRO,
+  ONLY_OWNER_CAN_ADOPT,
+  UNKNOWN_FORMAT,
+} from "../retroCopy";
 import { refusal } from "./refusal";
 
 /**
  * The retro (ADR-0016): one room with its ceremony state in a `retros` row
- * beside it. This module holds creation and the board read; cards, clusters,
- * dots and the walk arrive with their own tickets.
+ * beside it. This module holds creation, the board read, the Team's side of
+ * a retro's life (adoption, claim, deletion) and the two listings; cards,
+ * clusters, dots and the walk arrive with their own tickets.
  */
 
 export interface CreateRetroArgs {
@@ -19,16 +35,21 @@ export interface CreateRetroArgs {
   formatName: string;
   /** Advisory cards-due date (ADR-0020). */
   collectUntil?: number;
+  /**
+   * The Team that keeps the retro, already guarded (the caller ran
+   * `requireTeamRole`). Its retro defaults are copied by value (ADR-0013).
+   */
+  team?: Doc<"teams">;
 }
 
 /**
- * Creates a teamless retro: the room (`roomType: "retro"`, always owned,
- * `joinPolicy: "anyone"`, the retro permission defaults, not retained) and
- * the `retros` row (attribution `named`, the format copied whole, the stamped
- * stage list with the first entry current) in one mutation, then the
- * creator's owner membership. Its own function rather than a branch of
- * `Rooms.createRoom`, which hard-codes the canvas type and seeds canvas
- * nodes a retro never has.
+ * Creates a retro: the room (`roomType: "retro"`, always owned, the join
+ * policy and permissions from the Team's defaults or the teamless values,
+ * `retained` iff a Team keeps it) and the `retros` row (the attribution from
+ * the same defaults, the format copied whole, the stamped stage list with
+ * the first entry current) in one mutation, then the creator's owner
+ * membership. Its own function rather than a branch of `Rooms.createRoom`,
+ * which hard-codes the canvas type and seeds canvas nodes a retro never has.
  */
 export async function createRetro(
   ctx: MutationCtx,
@@ -40,6 +61,9 @@ export async function createRetro(
   }
   const name = validateRoomName(args.name);
   const now = Date.now();
+  // Copied by value, whole (ADR-0008): the room's stored values are
+  // authoritative from here on, whatever the Team's defaults become.
+  const defaults = args.team?.retroDefaults;
 
   const roomId = await ctx.db.insert("rooms", {
     name,
@@ -48,16 +72,17 @@ export async function createRetro(
     isGameOver: false,
     createdAt: now,
     lastActivityAt: now,
-    retained: false,
+    retained: args.team !== undefined,
     ownerId: args.ownerId,
-    joinPolicy: "anyone",
-    permissions: { ...DEFAULT_RETRO_PERMISSIONS },
+    ...(args.team ? { teamId: args.team._id } : {}),
+    joinPolicy: defaults?.joinPolicy ?? "anyone",
+    permissions: { ...(defaults?.permissions ?? DEFAULT_RETRO_PERMISSIONS) },
   });
 
-  const stages = seedStages(format, { hasTeam: false });
+  const stages = seedStages(format, { hasTeam: args.team !== undefined });
   await ctx.db.insert("retros", {
     roomId,
-    attribution: "named",
+    attribution: defaults?.attribution ?? "named",
     format: stampFormat(format),
     stages,
     currentStageId: stages[0].id,
@@ -101,4 +126,248 @@ export async function getBoard(
     throw refusal("missing", NOT_A_RETRO);
   }
   return retro;
+}
+
+/**
+ * Adoption (spec §5, ADR-0019): the room owner gives a teamless retro to a
+ * Team they belong to. Sets the set-once `teamId`, flips `retained`, and
+ * stamps `teamId` onto the room's existing action items so they reach the
+ * team page. Nothing else is rewritten — not the stage list (no `review`
+ * comes back), not the join policy, attribution or permissions.
+ *
+ * The caller has already guarded attendance (`requireRoomMember`) and Team
+ * membership (`requireTeamRole`); the ownership rule is an identity rule and
+ * lives here, after the guards, like `transferOwnership`'s.
+ */
+export async function adoptIntoTeam(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actorUserId: Id<"users">; teamId: Id<"teams"> }
+): Promise<void> {
+  const { room } = args;
+  if (room.roomType !== "retro") {
+    throw refusal("missing", NOT_A_RETRO);
+  }
+  if (room.ownerId !== args.actorUserId) {
+    throw refusal("forbidden", ONLY_OWNER_CAN_ADOPT);
+  }
+  if (room.teamId !== undefined) {
+    throw refusal("forbidden", ALREADY_KEPT_BY_TEAM);
+  }
+
+  await ctx.db.patch(room._id, { teamId: args.teamId, retained: true });
+
+  // A retro's action items are a handful (ADR-0017: one home each), so one
+  // indexed read stamps them all inside the adoption transaction.
+  const actions = await ctx.db
+    .query("retroActions")
+    .withIndex("by_room", (q) => q.eq("roomId", room._id))
+    .collect();
+  await Promise.all(actions.map((action) => ctx.db.patch(action._id, { teamId: args.teamId })));
+
+  await updateRoomActivity(ctx, room._id);
+}
+
+/**
+ * `claim` (ADR-0013): the guard has already decided the actor may (a team
+ * admin, attending, the owner absent or out of the Team). The actor becomes
+ * `ownerId` and their membership `owner`; the previous owner's membership,
+ * if present, becomes `participant`, keeping exactly one owner-role
+ * membership in the room (ADR-0001).
+ */
+export async function claim(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actorMembership: Doc<"roomMemberships"> }
+): Promise<void> {
+  const { room, actorMembership } = args;
+  if (room.ownerId && room.ownerId !== actorMembership.userId) {
+    const previous = await ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room_user", (q) => q.eq("roomId", room._id).eq("userId", room.ownerId!))
+      .unique();
+    if (previous) {
+      await ctx.db.patch(previous._id, { role: "participant" });
+    }
+  }
+  await ctx.db.patch(actorMembership._id, { role: "owner" });
+  await ctx.db.patch(room._id, { ownerId: actorMembership.userId });
+  await updateRoomActivity(ctx, room._id);
+}
+
+/**
+ * `delete` (ADR-0019): hard delete through the room cascade. The first
+ * bounded step runs inside this mutation, so a retro of ordinary size is
+ * gone when the call returns; a continuation is scheduled only when a full
+ * batch remains.
+ */
+export async function deleteRetro(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">
+): Promise<void> {
+  const step = await deleteRoomAggregateChunk(ctx, roomId);
+  if (!step.done) {
+    await ctx.scheduler.runAfter(0, internal.maintenance.deleteRoomAggregateChunk, { roomId });
+  }
+}
+
+/**
+ * The counts the delete confirmation names (spec §19), read from the card
+ * and action tables. Bounded reads: the copy needs a number, and a retro
+ * never approaches the bound.
+ */
+const MAX_COUNTED_ROWS = 1000;
+
+export async function deleteCounts(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">
+): Promise<{ cards: number; openActions: number }> {
+  const [cards, actions] = await Promise.all([
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(MAX_COUNTED_ROWS),
+    ctx.db
+      .query("retroActions")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(MAX_COUNTED_ROWS),
+  ]);
+  return {
+    cards: cards.length,
+    openActions: actions.filter((action) => action.status === "open").length,
+  };
+}
+
+/**
+ * The create form's pre-selection (spec §6.1): the Team's newest retro's
+ * format, edited or not, or null for a Team with no retros yet.
+ */
+export async function lastFormat(
+  ctx: QueryCtx,
+  teamId: Id<"teams">
+): Promise<StampedFormat | null> {
+  const newest = await ctx.db
+    .query("rooms")
+    .withIndex("by_team", (q) => q.eq("teamId", teamId))
+    .order("desc")
+    .first();
+  if (!newest) return null;
+  const retro = await getRetro(ctx, newest._id);
+  return retro ? retro.format : null;
+}
+
+/** One listing row (spec §16.5): the minimal row until #299's history row. */
+export interface RetroListRow {
+  roomId: Id<"rooms">;
+  name: string;
+  /** The resting stage's kind: the shared pointer. */
+  stageKind: StageKind;
+  collectUntil?: number;
+  createdAt: number;
+}
+
+function toRow(room: Doc<"rooms">, retro: Doc<"retros">): RetroListRow {
+  const current =
+    retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
+  return {
+    roomId: room._id,
+    name: room.name,
+    stageKind: current.kind,
+    ...(retro.collectUntil !== undefined ? { collectUntil: retro.collectUntil } : {}),
+    createdAt: room.createdAt,
+  };
+}
+
+/** Rows for the retro rooms among `rooms`, in the order given; poker rooms drop out. */
+async function rowsOf(ctx: QueryCtx, rooms: Doc<"rooms">[]): Promise<RetroListRow[]> {
+  const retros = await Promise.all(rooms.map((room) => getRetro(ctx, room._id)));
+  return rooms.flatMap((room, i) => {
+    const retro = retros[i];
+    return retro ? [toRow(room, retro)] : [];
+  });
+}
+
+/** How many of a Team's retros a listing shows; the history row (#299) pages. */
+const MAX_LISTED_ROOMS = 200;
+
+/** The team page's listing (spec §5): the Team's retros in creation order. */
+export async function listForTeam(
+  ctx: QueryCtx,
+  teamId: Id<"teams">
+): Promise<RetroListRow[]> {
+  const rooms = await ctx.db
+    .query("rooms")
+    .withIndex("by_team", (q) => q.eq("teamId", teamId))
+    .take(MAX_LISTED_ROOMS);
+  return rowsOf(ctx, rooms);
+}
+
+/**
+ * The dashboard's ordering (spec §16.5): retros whose shared stage is
+ * `collect` first, newest first within each half.
+ */
+export function orderForDashboard(rows: RetroListRow[]): RetroListRow[] {
+  return [...rows].sort((a, b) => {
+    const aCollect = a.stageKind === "collect" ? 0 : 1;
+    const bCollect = b.stageKind === "collect" ? 0 : 1;
+    return aCollect - bCollect || b.createdAt - a.createdAt;
+  });
+}
+
+export interface RetroListGroup {
+  /** Undefined for the "No team" group. */
+  teamId?: Id<"teams">;
+  teamName: string;
+  retros: RetroListRow[];
+}
+
+/**
+ * `/dashboard/retros` (spec §18.1): the retros the person attended, grouped
+ * by Team in the order they joined their Teams, teamless ones last under
+ * "No team", `collect` first within each group. A group with no retros is
+ * left out; the person's Teams have their own list beside this one.
+ */
+export async function listMine(
+  ctx: QueryCtx,
+  userId: Id<"users">
+): Promise<RetroListGroup[]> {
+  const memberships = await ctx.db
+    .query("roomMemberships")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .take(MAX_LISTED_ROOMS);
+  const rooms = (await Promise.all(memberships.map((m) => ctx.db.get(m.roomId)))).filter(
+    (room): room is Doc<"rooms"> => room !== null && room.roomType === "retro"
+  );
+  const rows = await rowsOf(ctx, rooms);
+  const roomById = new Map(rooms.map((room) => [room._id, room]));
+
+  const byTeam = new Map<Id<"teams"> | undefined, RetroListRow[]>();
+  for (const row of rows) {
+    const teamId = roomById.get(row.roomId)?.teamId;
+    byTeam.set(teamId, [...(byTeam.get(teamId) ?? []), row]);
+  }
+
+  const groups: RetroListGroup[] = [];
+  for (const team of await listTeamsForUser(ctx, userId)) {
+    const retros = byTeam.get(team._id);
+    if (retros) {
+      groups.push({ teamId: team._id, teamName: team.name, retros: orderForDashboard(retros) });
+      byTeam.delete(team._id);
+    }
+  }
+  // Retros of a Team the person has since left, or whose Team is gone, are
+  // still theirs by attendance; they list under the Team's name when it
+  // still exists.
+  for (const [teamId, retros] of byTeam) {
+    if (teamId === undefined) continue;
+    const team = await ctx.db.get(teamId);
+    groups.push({
+      teamId,
+      teamName: team?.name ?? NO_TEAM_GROUP,
+      retros: orderForDashboard(retros),
+    });
+  }
+  const teamless = byTeam.get(undefined);
+  if (teamless) {
+    groups.push({ teamName: NO_TEAM_GROUP, retros: orderForDashboard(teamless) });
+  }
+  return groups;
 }

--- a/convex/model/rooms.ts
+++ b/convex/model/rooms.ts
@@ -39,6 +39,8 @@ export interface RoomWithRelatedData {
   users: Users.RoomUserData[];
   votes: SanitizedVote[];
   isOwnerAbsent: boolean;
+  /** The owning Team's name (ADR-0008); undefined for a teamless room. */
+  teamName?: string;
 }
 
 /**
@@ -119,13 +121,14 @@ export async function getRoomWithRelatedData(
   if (!room) return null;
 
   // Get users (via memberships), votes, and owner-absent status in parallel
-  const [users, votes, ownerAbsent] = await Promise.all([
+  const [users, votes, ownerAbsent, team] = await Promise.all([
     Users.getRoomUsers(ctx, roomId),
     ctx.db
       .query("votes")
       .withIndex("by_room", (q) => q.eq("roomId", roomId))
       .collect(),
     room.ownerId ? isRoomOwnerAbsent(ctx, room) : Promise.resolve(false),
+    room.teamId ? ctx.db.get(room.teamId) : Promise.resolve(null),
   ]);
 
   // Sanitize votes based on game state
@@ -136,6 +139,10 @@ export async function getRoomWithRelatedData(
     users,
     votes: sanitizedVotes,
     isOwnerAbsent: ownerAbsent,
+    // The owning Team's name is readable by anyone with the link, on
+    // purpose (ADR-0008): the write-time disclosure needs it before the
+    // first card is typed. The Team's roster and history stay guarded.
+    ...(team ? { teamName: team.name } : {}),
   };
 }
 

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -1,6 +1,8 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import * as Retro from "./model/retro";
+import { refusal } from "./model/refusal";
+import { ROOM_NOT_FOUND } from "./retroCopy";
 import {
   getOptionalAuthUser,
   requireAuthUser,
@@ -54,7 +56,7 @@ export const adoptIntoTeam = mutation({
     await requireTeamRole(ctx, args.teamId, "member");
     const room = await ctx.db.get(args.roomId);
     if (!room) {
-      throw new Error("Room not found");
+      throw refusal("missing", ROOM_NOT_FOUND);
     }
     await Retro.adoptIntoTeam(ctx, { room, actorUserId: user._id, teamId: args.teamId });
   },

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -76,8 +76,8 @@ export const claim = mutation({
 export const remove = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "relationship", verb: "delete" });
-    await Retro.deleteRetro(ctx, args.roomId);
+    const { room } = await requireCan(ctx, args.roomId, { kind: "relationship", verb: "delete" });
+    await Retro.deleteRetro(ctx, room);
   },
 });
 

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -1,21 +1,32 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import * as Retro from "./model/retro";
-import { requireAuthUser, requireRoomReader } from "./model/auth";
+import {
+  getOptionalAuthUser,
+  requireAuthUser,
+  requireCan,
+  requireRoomMember,
+  requireRoomReader,
+  requireTeamRole,
+} from "./model/auth";
 
 /**
- * Create a teamless retro (spec §6.1): anyone, anonymous included. Returns
- * the room id; the creator holds the owner membership already.
+ * Create a retro (spec §6.1): anyone, anonymous included, creates a teamless
+ * one; any Team member creates one the Team keeps. Returns the room id; the
+ * creator holds the owner membership already.
  */
 export const create = mutation({
   args: {
     name: v.string(),
     formatName: v.string(),
     collectUntil: v.optional(v.number()),
+    teamId: v.optional(v.id("teams")),
   },
   handler: async (ctx, args) => {
     const { user } = await requireAuthUser(ctx);
-    return await Retro.createRetro(ctx, { ...args, ownerId: user._id });
+    const { teamId, ...rest } = args;
+    const team = teamId ? (await requireTeamRole(ctx, teamId, "member")).team : undefined;
+    return await Retro.createRetro(ctx, { ...rest, ownerId: user._id, team });
   },
 });
 
@@ -28,5 +39,84 @@ export const board = query({
   handler: async (ctx, args) => {
     await requireRoomReader(ctx, args.roomId);
     return await Retro.getBoard(ctx, args.roomId);
+  },
+});
+
+/**
+ * Give a teamless retro to a Team (spec §5): the room owner, who must also
+ * be a member of the Team. Attendance and Team membership are guarded here;
+ * ownership is the model's identity rule.
+ */
+export const adoptIntoTeam = mutation({
+  args: { roomId: v.id("rooms"), teamId: v.id("teams") },
+  handler: async (ctx, args) => {
+    const { user } = await requireRoomMember(ctx, args.roomId);
+    await requireTeamRole(ctx, args.teamId, "member");
+    const room = await ctx.db.get(args.roomId);
+    if (!room) {
+      throw new Error("Room not found");
+    }
+    await Retro.adoptIntoTeam(ctx, { room, actorUserId: user._id, teamId: args.teamId });
+  },
+});
+
+/** A team admin takes ownership of a team retro whose owner is gone (ADR-0013). */
+export const claim = mutation({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { room, membership } = await requireCan(ctx, args.roomId, {
+      kind: "relationship",
+      verb: "claim",
+    });
+    await Retro.claim(ctx, { room, actorMembership: membership });
+  },
+});
+
+/** Owner-level hard delete through the room cascade (ADR-0019). */
+export const remove = mutation({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "relationship", verb: "delete" });
+    await Retro.deleteRetro(ctx, args.roomId);
+  },
+});
+
+/** The counts the delete confirmation names (spec §19). Room access. */
+export const deleteCounts = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    await requireRoomReader(ctx, args.roomId);
+    return await Retro.deleteCounts(ctx, args.roomId);
+  },
+});
+
+/** The create form's pre-selection: the Team's newest retro's format, or null. */
+export const lastFormat = query({
+  args: { teamId: v.id("teams") },
+  handler: async (ctx, args) => {
+    await requireTeamRole(ctx, args.teamId, "member");
+    return await Retro.lastFormat(ctx, args.teamId);
+  },
+});
+
+/** The team page's listing: the Team's retros in creation order (members only). */
+export const listForTeam = query({
+  args: { teamId: v.id("teams") },
+  handler: async (ctx, args) => {
+    await requireTeamRole(ctx, args.teamId, "member");
+    return await Retro.listForTeam(ctx, args.teamId);
+  },
+});
+
+/**
+ * `/dashboard/retros`: the retros the caller attended, grouped by Team with
+ * teamless ones under "No team"; empty for a visitor without an account.
+ */
+export const listMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getOptionalAuthUser(ctx);
+    if (!user) return [];
+    return await Retro.listMine(ctx, user._id);
   },
 });

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -20,43 +20,6 @@ export const keptByTeam = (teamName: string) =>
 export const readingAsTeamMember = (teamName: string) =>
   `You're reading this as a member of ${teamName}. Join to take part.`;
 
-// --- Team (spec §5) ---
-
-export const TEAM_LABEL = "Team";
-export const NO_TEAM_OPTION = "No team";
-export const NEW_TEAM_OPTION = "New team…";
-export const TEAM_DESCRIPTION = "A team keeps the retro and decides who can read it later.";
-
-/** `adoptIntoTeam` by an attendee who does not own the room. */
-export const ONLY_OWNER_CAN_ADOPT = "Only the room owner can give this retro to a team.";
-
-/** `adoptIntoTeam` on a room whose `teamId` is already set (set once, ADR-0008). */
-export const ALREADY_KEPT_BY_TEAM = "This retro already belongs to a team.";
-
-export const ADOPT_MENU_ITEM = "Keep with a team…";
-export const ADOPT_TITLE = "Keep this retro with a team";
-export const ADOPT_DESCRIPTION =
-  "The team's members can read it later, and it no longer disappears after 5 quiet days. This cannot be undone.";
-export const ADOPT_BUTTON = "Keep with team";
-export const ADOPT_FAILED = "Failed to give this retro to the team";
-
-// --- Claim, delete (spec §4.3, §15.2) ---
-
-export const CLAIM_MENU_ITEM = "Claim ownership";
-export const CLAIM_FAILED = "Failed to claim this retro";
-export const CLAIMED = "You now own this retro";
-
-export const DELETE_MENU_ITEM = "Delete retro";
-export const DELETE_TITLE = "Delete this retro?";
-export const deleteRetroConfirm = (cards: number, openActions: number) =>
-  `${cards} ${cards === 1 ? "card" : "cards"}, ${openActions} open ${
-    openActions === 1 ? "action item" : "action items"
-  } and its history are removed permanently. This cannot be undone.`;
-export const DELETE_BUTTON = "Delete retro";
-export const DELETING_BUTTON = "Deleting…";
-export const DELETE_FAILED = "Failed to delete this retro";
-export const RETRO_DELETED = "Retro deleted";
-
 // --- Listings (spec §16.5, §18.1) ---
 
 export const NO_TEAM_GROUP = "No team";
@@ -129,3 +92,43 @@ export const collectUntilLine = (date: string) => `Cards due ${date}`;
 export const LOADING_TITLE = "Loading...";
 export const CHECKING_SESSION = "Checking session";
 export const LOADING_BOARD = "Opening the board...";
+
+// --- Team (spec §5) ---
+
+export const TEAM_LABEL = "Team";
+export const NO_TEAM_OPTION = NO_TEAM_GROUP;
+export const NEW_TEAM_OPTION = "New team…";
+export const TEAM_DESCRIPTION = "A team keeps the retro and decides who can read it later.";
+
+/** `adoptIntoTeam` by an attendee who does not own the room. */
+export const ONLY_OWNER_CAN_ADOPT = "Only the room owner can give this retro to a team.";
+
+/** `adoptIntoTeam` on a room whose `teamId` is already set (set once, ADR-0008). */
+export const ALREADY_KEPT_BY_TEAM = "This retro already belongs to a team.";
+
+export const ADOPT_MENU_ITEM = "Keep with a team…";
+export const ADOPT_TITLE = "Keep this retro with a team";
+export const ADOPT_DESCRIPTION =
+  "The team's members can read it later, and it no longer disappears after 5 quiet days. This cannot be undone.";
+export const ADOPT_BUTTON = "Keep with team";
+export const ADOPT_CHOOSE_TEAM = "Choose a team";
+export const ADOPT_FAILED = "Failed to give this retro to the team";
+
+// --- Claim, delete (spec §4.3, §15.2) ---
+
+export const CLAIM_MENU_ITEM = "Claim ownership";
+export const CLAIM_FAILED = "Failed to claim this retro";
+export const CLAIMED = "You now own this retro";
+
+export const DELETE_MENU_ITEM = "Delete retro";
+export const DELETE_TITLE = "Delete this retro?";
+export const deleteRetroConfirm = (cards: number, openActions: number) =>
+  `${cards} ${cards === 1 ? "card" : "cards"}, ${openActions} open ${
+    openActions === 1 ? "action item" : "action items"
+  } and its history are removed permanently. This cannot be undone.`;
+export const DELETE_COUNTING = "Counting…";
+export const DELETE_BUTTON = "Delete retro";
+export const DELETING_BUTTON = "Deleting…";
+export const DELETE_FAILED = "Failed to delete this retro";
+export const RETRO_DELETED = "Retro deleted";
+

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -8,9 +8,62 @@
 
 // --- Board header disclosures (ADR-0008, ADR-0019) ---
 
-/** Board header, teamless retro. The team line arrives with #289. */
+/** Board header and create form, teamless retro. */
 export const TEAMLESS_DISCLOSURE =
   "Not kept by a team. This retro disappears after 5 quiet days.";
+
+/** Board header and create form, team retro. Doubles as the team-page link. */
+export const keptByTeam = (teamName: string) =>
+  `Kept by ${teamName}. Its members can read this later, until the retro or the team is deleted.`;
+
+/** A Team member reading a retro they never joined (ADR-0009). */
+export const readingAsTeamMember = (teamName: string) =>
+  `You're reading this as a member of ${teamName}. Join to take part.`;
+
+// --- Team (spec §5) ---
+
+export const TEAM_LABEL = "Team";
+export const NO_TEAM_OPTION = "No team";
+export const NEW_TEAM_OPTION = "New team…";
+export const TEAM_DESCRIPTION = "A team keeps the retro and decides who can read it later.";
+
+/** `adoptIntoTeam` by an attendee who does not own the room. */
+export const ONLY_OWNER_CAN_ADOPT = "Only the room owner can give this retro to a team.";
+
+/** `adoptIntoTeam` on a room whose `teamId` is already set (set once, ADR-0008). */
+export const ALREADY_KEPT_BY_TEAM = "This retro already belongs to a team.";
+
+export const ADOPT_MENU_ITEM = "Keep with a team…";
+export const ADOPT_TITLE = "Keep this retro with a team";
+export const ADOPT_DESCRIPTION =
+  "The team's members can read it later, and it no longer disappears after 5 quiet days. This cannot be undone.";
+export const ADOPT_BUTTON = "Keep with team";
+export const ADOPT_FAILED = "Failed to give this retro to the team";
+
+// --- Claim, delete (spec §4.3, §15.2) ---
+
+export const CLAIM_MENU_ITEM = "Claim ownership";
+export const CLAIM_FAILED = "Failed to claim this retro";
+export const CLAIMED = "You now own this retro";
+
+export const DELETE_MENU_ITEM = "Delete retro";
+export const DELETE_TITLE = "Delete this retro?";
+export const deleteRetroConfirm = (cards: number, openActions: number) =>
+  `${cards} ${cards === 1 ? "card" : "cards"}, ${openActions} open ${
+    openActions === 1 ? "action item" : "action items"
+  } and its history are removed permanently. This cannot be undone.`;
+export const DELETE_BUTTON = "Delete retro";
+export const DELETING_BUTTON = "Deleting…";
+export const DELETE_FAILED = "Failed to delete this retro";
+export const RETRO_DELETED = "Retro deleted";
+
+// --- Listings (spec §16.5, §18.1) ---
+
+export const NO_TEAM_GROUP = "No team";
+export const TEAM_RETROS_TITLE = "Retros";
+export const TEAM_RETROS_EMPTY = "No retros yet. Start one and this team keeps it.";
+export const MY_RETROS_TITLE = "Your retros";
+export const MY_RETROS_EMPTY = "Retros you take part in show up here.";
 
 // --- Join (spec §4.4) ---
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -69,6 +69,9 @@ export const UNKNOWN_FORMAT = "Unknown retro format";
 /** `retro.board` on a room that has no retros row. */
 export const NOT_A_RETRO = "This room is not a retro";
 
+/** A retro mutation whose room row is gone. */
+export const ROOM_NOT_FOUND = "Room not found";
+
 // --- Stages (spec §7) ---
 
 /** The stage pill's label per kind. */

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -499,3 +499,57 @@ describe("room activity — the chokepoint owns the clock's precision (ADR-0018)
     expect(await lastActivityAt(t, roomId)).toBeGreaterThanOrEqual(before);
   });
 });
+
+describe("room activity — the Team's side of a retro bumps (spec §14)", () => {
+  const HOUR = Rooms.RETRO_ACTIVITY_GRANULARITY_MS;
+  const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+  async function seedPermanent(t: T, authUserId: string): Promise<Id<"users">> {
+    return t.run((ctx) =>
+      ctx.db.insert("users", {
+        authUserId,
+        name: authUserId,
+        createdAt: Date.now(),
+        accountType: "permanent",
+      })
+    );
+  }
+
+  /** A Team with an admin and a member, and a retro by the member, seeded over an hour stale. */
+  async function seedTeamRetro(t: T, teamed: boolean) {
+    await seedPermanent(t, "auth-admin");
+    const memberId = await seedPermanent(t, "auth-member");
+    const teamId = await as(t, "auth-admin").mutation(api.teams.create, { name: "T" });
+    const team = (await t.run((ctx) => ctx.db.get(teamId)))!;
+    await as(t, "auth-member").mutation(api.teams.joinByInvite, { inviteToken: team.inviteToken });
+    const roomId = await as(t, "auth-member").mutation(api.retro.create, {
+      name: "R",
+      formatName: "Went well, Do differently, Ideas",
+      ...(teamed ? { teamId } : {}),
+    });
+    const stale = Date.now() - HOUR - 60_000;
+    await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+    return { teamId, roomId, memberId, stale };
+  }
+
+  it("adoptIntoTeam bumps", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, roomId, stale } = await seedTeamRetro(t, false);
+
+    await as(t, "auth-member").mutation(api.retro.adoptIntoTeam, { roomId, teamId });
+
+    await expectBumped(t, roomId, stale);
+  });
+
+  it("claim bumps", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, memberId, stale } = await seedTeamRetro(t, true);
+    await as(t, "auth-admin").mutation(api.users.join, { roomId, name: "A", authUserId: "auth-admin" });
+    await as(t, "auth-member").mutation(api.users.leave, { roomId, userId: memberId });
+    await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+
+    await as(t, "auth-admin").mutation(api.retro.claim, { roomId });
+
+    await expectBumped(t, roomId, stale);
+  });
+});

--- a/convex/teamRetro.test.ts
+++ b/convex/teamRetro.test.ts
@@ -408,6 +408,18 @@ describe("retro.remove — delete through the cascade (ADR-0019)", () => {
     expect(await membershipsOf(t, roomId)).toEqual([]);
   });
 
+  it("refuses to delete a poker room through the retro door", async () => {
+    const t = convexTest(schema, modules);
+    await seedUser(t, "owner");
+    const pokerId = await as(t, "owner").mutation(api.rooms.create, { name: "P" });
+    await joinRoom(t, pokerId, "owner");
+
+    await expect(as(t, "owner").mutation(api.retro.remove, { roomId: pokerId })).rejects.toThrow(
+      "This room is not a retro"
+    );
+    expect(await t.run((ctx) => ctx.db.get(pokerId))).not.toBeNull();
+  });
+
   it("a non-owner cannot delete; a team admin cannot while the owner is present, and can after claim", async () => {
     const t = convexTest(schema, modules);
     const { teamId, memberId } = await seedTeam(t);
@@ -571,6 +583,19 @@ describe("listings (spec §16.5, §18.1)", () => {
     expect(groups[2].teamId).toBeUndefined();
     expect(groups[2].retros.map((r) => r.roomId)).toEqual([teamless]);
     expect(groups.flatMap((g) => g.retros.map((r) => r.roomId))).not.toContain(notAttended);
+  });
+
+  it("a retro of a Team the person left keeps its Team's name but loses the door to the team page", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    await as(t, "admin").mutation(api.teams.removeMember, { teamId, targetUserId: memberId });
+
+    const groups = await as(t, "member").query(api.retro.listMine, {});
+    expect(groups).toHaveLength(1);
+    expect(groups[0].teamName).toBe("Acme Squad");
+    expect(groups[0].teamId).toBeUndefined();
+    expect(groups[0].retros.map((r) => r.roomId)).toEqual([roomId]);
   });
 
   it("the dashboard is empty for an anonymous visitor and for someone who attended nothing", async () => {

--- a/convex/teamRetro.test.ts
+++ b/convex/teamRetro.test.ts
@@ -1,0 +1,582 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_PERMISSIONS } from "./permissions";
+import { DEFAULT_RETRO_FORMAT, RETRO_FORMATS } from "./model/retroFormats";
+import { RETRO_TABLES } from "./model/roomAggregate";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+
+// A team retro (spec §5, §6.1, §4.3, §15.2; ADR-0008, ADR-0013, ADR-0019):
+// created with the Team's defaults copied by value and `retained: true`;
+// adoptable once; recoverable by `claim`; deletable through the cascade;
+// readable by the Team without attendance; listed on the team page and
+// the dashboard.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string, accountType?: "anonymous" | "permanent") =>
+  seedNamedUser(t, authUserId, authUserId, accountType);
+
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function createTeam(t: T, subject: string, name = "Acme"): Promise<Id<"teams">> {
+  return as(t, subject).mutation(api.teams.create, { name });
+}
+
+async function joinTeam(t: T, teamId: Id<"teams">, subject: string): Promise<void> {
+  const team = await t.run((ctx) => ctx.db.get(teamId));
+  await as(t, subject).mutation(api.teams.joinByInvite, { inviteToken: team!.inviteToken });
+}
+
+const CUSTOM_DEFAULTS = {
+  attribution: "anonymous" as const,
+  joinPolicy: "teamMembers" as const,
+  permissions: { ...DEFAULT_RETRO_PERMISSIONS, actionManagement: "facilitators" as const },
+};
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  );
+}
+
+async function membershipsOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function membershipOf(t: T, roomId: Id<"rooms">, userId: Id<"users">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room_user", (q) => q.eq("roomId", roomId).eq("userId", userId))
+      .unique()
+  );
+}
+
+const createRetro = (t: T, subject: string, args: { teamId?: Id<"teams">; name?: string; formatName?: string } = {}) =>
+  as(t, subject).mutation(api.retro.create, {
+    name: args.name ?? "R",
+    formatName: args.formatName ?? DEFAULT_RETRO_FORMAT.name,
+    ...(args.teamId ? { teamId: args.teamId } : {}),
+  });
+
+const joinRoom = (t: T, roomId: Id<"rooms">, subject: string) =>
+  as(t, subject).mutation(api.users.join, { roomId, name: subject, authUserId: subject });
+
+/**
+ * Lets any runAfter(0) continuation of the room cascade fire: convex-test
+ * dispatches it through a real 0ms setTimeout.
+ */
+async function drainScheduled(t: T): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+    await t.finishInProgressScheduledFunctions();
+    const jobs = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    if (!jobs.some((j) => j.state.kind === "pending")) return;
+  }
+  throw new Error("scheduled functions did not drain");
+}
+
+/** A Team with an admin and a member, the admin's defaults customised. */
+async function seedTeam(t: T) {
+  const adminId = await seedUser(t, "admin", "permanent");
+  const memberId = await seedUser(t, "member", "permanent");
+  const teamId = await createTeam(t, "admin", "Acme Squad");
+  await joinTeam(t, teamId, "member");
+  await as(t, "admin").mutation(api.teams.updateRetroDefaults, {
+    teamId,
+    retroDefaults: CUSTOM_DEFAULTS,
+  });
+  return { teamId, adminId, memberId };
+}
+
+describe("retro.create — a team retro", () => {
+  it("copies the Team's defaults by value, sets teamId and retained, and keeps review", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+
+    const roomId = await createRetro(t, "member", { teamId, name: "Sprint 12" });
+
+    const room = (await t.run((ctx) => ctx.db.get(roomId)))!;
+    expect(room).toMatchObject({
+      roomType: "retro",
+      ownerId: memberId,
+      teamId,
+      retained: true,
+      joinPolicy: "teamMembers",
+      permissions: CUSTOM_DEFAULTS.permissions,
+    });
+    const retro = (await retroRow(t, roomId))!;
+    expect(retro.attribution).toBe("anonymous");
+    expect(retro.stages.map((s) => s.kind)).toEqual([
+      "collect", "review", "group", "vote", "discuss", "close",
+    ]);
+    expect((await membershipsOf(t, roomId))[0]).toMatchObject({ userId: memberId, role: "owner" });
+  });
+
+  it("editing the Team's defaults afterwards changes nothing on the retro", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+
+    await as(t, "admin").mutation(api.teams.updateRetroDefaults, {
+      teamId,
+      retroDefaults: {
+        attribution: "named",
+        joinPolicy: "anyone",
+        permissions: { ...DEFAULT_RETRO_PERMISSIONS, stageFlow: "everyone" },
+      },
+    });
+
+    const room = (await t.run((ctx) => ctx.db.get(roomId)))!;
+    expect(room.joinPolicy).toBe("teamMembers");
+    expect(room.permissions).toEqual(CUSTOM_DEFAULTS.permissions);
+    expect((await retroRow(t, roomId))!.attribution).toBe("anonymous");
+  });
+
+  it("is refused for someone outside the Team, and no room is written", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    await seedUser(t, "stranger", "permanent");
+
+    await expect(createRetro(t, "stranger", { teamId })).rejects.toThrow(
+      "You are not a member of this team"
+    );
+    expect(await t.run((ctx) => ctx.db.query("rooms").collect())).toEqual([]);
+  });
+});
+
+describe("retro.adoptIntoTeam", () => {
+  async function seedTeamlessRetroWithActions(t: T) {
+    const { teamId, adminId, memberId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member");
+    const actionIds = await t.run(async (ctx) => {
+      const now = Date.now();
+      const ids: Id<"retroActions">[] = [];
+      for (const text of ["a", "b"]) {
+        ids.push(
+          await ctx.db.insert("retroActions", {
+            roomId,
+            text,
+            status: "open",
+            createdBy: memberId,
+            createdAt: now,
+            updatedAt: now,
+          })
+        );
+      }
+      return ids;
+    });
+    return { teamId, adminId, memberId, roomId, actionIds };
+  }
+
+  it("the owner who is in the Team sets teamId and retained and stamps the action rows", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, roomId, actionIds } = await seedTeamlessRetroWithActions(t);
+    const before = (await t.run((ctx) => ctx.db.get(roomId)))!;
+    const retroBefore = (await retroRow(t, roomId))!;
+
+    await as(t, "member").mutation(api.retro.adoptIntoTeam, { roomId, teamId });
+
+    const room = (await t.run((ctx) => ctx.db.get(roomId)))!;
+    expect(room.teamId).toBe(teamId);
+    expect(room.retained).toBe(true);
+    // Never rewritten: join policy, permissions (the teamless values stay).
+    expect(room.joinPolicy).toBe(before.joinPolicy);
+    expect(room.permissions).toEqual(before.permissions);
+    const retro = (await retroRow(t, roomId))!;
+    expect(retro.attribution).toBe(retroBefore.attribution);
+    expect(retro.stages).toEqual(retroBefore.stages);
+    expect(retro.stages.some((s) => s.kind === "review")).toBe(false);
+    for (const id of actionIds) {
+      expect((await t.run((ctx) => ctx.db.get(id)))?.teamId).toBe(teamId);
+    }
+  });
+
+  it("is refused for a non-owner attendee, for an owner outside the Team, and a second time", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, roomId } = await seedTeamlessRetroWithActions(t);
+    await seedUser(t, "outsider", "permanent");
+    const outsiderRoomId = await createRetro(t, "outsider");
+    await joinRoom(t, roomId, "admin");
+
+    await expect(
+      as(t, "admin").mutation(api.retro.adoptIntoTeam, { roomId, teamId })
+    ).rejects.toThrow("Only the room owner can give this retro to a team.");
+    await expect(
+      as(t, "outsider").mutation(api.retro.adoptIntoTeam, { roomId: outsiderRoomId, teamId })
+    ).rejects.toThrow("You are not a member of this team");
+
+    await as(t, "member").mutation(api.retro.adoptIntoTeam, { roomId, teamId });
+    const otherTeam = await createTeam(t, "member", "Beta");
+    await expect(
+      as(t, "member").mutation(api.retro.adoptIntoTeam, { roomId, teamId: otherTeam })
+    ).rejects.toThrow("This retro already belongs to a team.");
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.teamId).toBe(teamId);
+  });
+
+  it("an adopted retro survives the sweep a teamless one falls to", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, roomId } = await seedTeamlessRetroWithActions(t);
+    const loose = await createRetro(t, "member");
+    await as(t, "member").mutation(api.retro.adoptIntoTeam, { roomId, teamId });
+    const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    await t.run(async (ctx) => {
+      await ctx.db.patch(roomId, { lastActivityAt: tenDaysAgo });
+      await ctx.db.patch(loose, { lastActivityAt: tenDaysAgo });
+    });
+
+    expect((await t.mutation(internal.cleanup.removeInactiveRooms, {})).roomsScheduled).toBe(1);
+    const jobs = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    expect(jobs.map((j) => (j.args as [{ roomId: string }])[0].roomId)).toEqual([loose]);
+  });
+});
+
+describe("retro.claim (ADR-0013)", () => {
+  async function seedTeamRetro(t: T) {
+    const seeded = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId: seeded.teamId });
+    await joinRoom(t, roomId, "admin");
+    return { ...seeded, roomId };
+  }
+
+  it("is denied with owner-present while the owner is here and in the Team", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t);
+
+    await expect(as(t, "admin").mutation(api.retro.claim, { roomId })).rejects.toThrow(
+      "The owner is still here — ask them to transfer ownership."
+    );
+  });
+
+  it("succeeds once the owner has left the room: the admin owns it", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, adminId, memberId } = await seedTeamRetro(t);
+    await as(t, "member").mutation(api.users.leave, { roomId, userId: memberId });
+
+    await as(t, "admin").mutation(api.retro.claim, { roomId });
+
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.ownerId).toBe(adminId);
+    expect((await membershipOf(t, roomId, adminId))?.role).toBe("owner");
+  });
+
+  it("succeeds once the owner has left the Team: the previous owner becomes a participant", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, adminId, memberId, teamId } = await seedTeamRetro(t);
+    await as(t, "admin").mutation(api.teams.removeMember, { teamId, targetUserId: memberId });
+
+    await as(t, "admin").mutation(api.retro.claim, { roomId });
+
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.ownerId).toBe(adminId);
+    expect((await membershipOf(t, roomId, adminId))?.role).toBe("owner");
+    expect((await membershipOf(t, roomId, memberId))?.role).toBe("participant");
+    const owners = (await membershipsOf(t, roomId)).filter((m) => m.role === "owner");
+    expect(owners).toHaveLength(1);
+  });
+
+  it("is denied to a team member who is not an admin, and to anyone in a teamless retro", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, teamId, memberId } = await seedTeamRetro(t);
+    await seedUser(t, "second", "permanent");
+    await joinTeam(t, teamId, "second");
+    await joinRoom(t, roomId, "second");
+    await as(t, "member").mutation(api.users.leave, { roomId, userId: memberId });
+
+    await expect(as(t, "second").mutation(api.retro.claim, { roomId })).rejects.toThrow(
+      "Only a team admin can claim this room."
+    );
+
+    const teamless = await createRetro(t, "member");
+    await joinRoom(t, teamless, "admin");
+    await as(t, "member").mutation(api.users.leave, { roomId: teamless, userId: memberId });
+    await expect(as(t, "admin").mutation(api.retro.claim, { roomId: teamless })).rejects.toThrow(
+      "Only a team admin can claim this room."
+    );
+  });
+
+  it("requires attendance: an admin who never joined cannot claim", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    await as(t, "member").mutation(api.users.leave, { roomId, userId: memberId });
+
+    await expect(as(t, "admin").mutation(api.retro.claim, { roomId })).rejects.toThrow(
+      "Not a member of this room"
+    );
+  });
+});
+
+describe("retro.remove — delete through the cascade (ADR-0019)", () => {
+  async function seedRetroWithContent(t: T, teamId?: Id<"teams">) {
+    const roomId = await createRetro(t, "member", teamId ? { teamId } : {});
+    const memberId = (await t.run((ctx) => ctx.db.get(roomId)))!.ownerId!;
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      const clusterId = await ctx.db.insert("retroClusters", { roomId, name: "c", createdAt: now });
+      const cardId = await ctx.db.insert("retroCards", {
+        roomId,
+        clientId: "k1",
+        text: "hi",
+        promptId: "p1",
+        position: { x: 0, y: 0 },
+        authorId: memberId,
+        clusterId,
+        createdAt: now,
+        updatedAt: now,
+        committedAt: now,
+      });
+      await ctx.db.insert("retroCards", {
+        roomId,
+        clientId: "k2",
+        text: "hey",
+        promptId: "p1",
+        position: { x: 1, y: 1 },
+        authorId: memberId,
+        createdAt: now,
+        updatedAt: now,
+        committedAt: now,
+      });
+      await ctx.db.insert("retroVotes", {
+        roomId,
+        stageEntryId: "s",
+        voterId: memberId,
+        target: { kind: "card", id: cardId },
+      });
+      for (const status of ["open", "open", "done"] as const) {
+        await ctx.db.insert("retroActions", {
+          roomId,
+          text: status,
+          status,
+          createdBy: memberId,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    });
+    return { roomId, memberId };
+  }
+
+  async function retroRowCounts(t: T, roomId: Id<"rooms">) {
+    return t.run(async (ctx) => {
+      const counts: Record<string, number> = {};
+      for (const table of RETRO_TABLES) {
+        counts[table] = (
+          await ctx.db.query(table).withIndex("by_room", (q) => q.eq("roomId", roomId)).collect()
+        ).length;
+      }
+      return counts;
+    });
+  }
+
+  it("deleteCounts reads the card and open-action counts for the confirmation", async () => {
+    const t = convexTest(schema, modules);
+    await seedTeam(t);
+    const { roomId } = await seedRetroWithContent(t);
+
+    expect(await as(t, "member").query(api.retro.deleteCounts, { roomId })).toEqual({
+      cards: 2,
+      openActions: 2,
+    });
+    await seedUser(t, "stranger");
+    await expect(as(t, "stranger").query(api.retro.deleteCounts, { roomId })).rejects.toThrow(
+      "You don't have access to this room"
+    );
+  });
+
+  it("the owner deletes; every retro table and the room are emptied", async () => {
+    const t = convexTest(schema, modules);
+    await seedTeam(t);
+    const { roomId } = await seedRetroWithContent(t);
+    expect((await retroRowCounts(t, roomId)).retroCards).toBe(2);
+
+    await as(t, "member").mutation(api.retro.remove, { roomId });
+    await drainScheduled(t);
+
+    expect(await t.run((ctx) => ctx.db.get(roomId))).toBeNull();
+    expect(Object.values(await retroRowCounts(t, roomId)).every((n) => n === 0)).toBe(true);
+    expect(await membershipsOf(t, roomId)).toEqual([]);
+  });
+
+  it("a non-owner cannot delete; a team admin cannot while the owner is present, and can after claim", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    const { roomId } = await seedRetroWithContent(t, teamId);
+    await joinRoom(t, roomId, "admin");
+
+    await expect(as(t, "admin").mutation(api.retro.remove, { roomId })).rejects.toThrow(
+      "Only the owner can do this."
+    );
+    await as(t, "member").mutation(api.users.leave, { roomId, userId: memberId });
+    await expect(as(t, "admin").mutation(api.retro.remove, { roomId })).rejects.toThrow(
+      "Room owner has left."
+    );
+
+    await as(t, "admin").mutation(api.retro.claim, { roomId });
+    await as(t, "admin").mutation(api.retro.remove, { roomId });
+    await drainScheduled(t);
+    expect(await t.run((ctx) => ctx.db.get(roomId))).toBeNull();
+  });
+});
+
+describe("joining a team retro (spec §4.4)", () => {
+  it("teamMembers refuses a permanent non-member with the team's name, and admits a Team member", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    await seedUser(t, "perm", "permanent");
+
+    await expect(joinRoom(t, roomId, "perm")).rejects.toThrow(
+      "This retro is for members of Acme Squad. Ask an admin for the invite link."
+    );
+    expect(await membershipsOf(t, roomId)).toHaveLength(1);
+
+    await joinRoom(t, roomId, "admin");
+    expect(await membershipsOf(t, roomId)).toHaveLength(2);
+  });
+
+  it("permanentAccounts refuses an anonymous account on a team retro too", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    await t.run((ctx) => ctx.db.patch(roomId, { joinPolicy: "permanentAccounts" }));
+    await seedUser(t, "anon", "anonymous");
+
+    await expect(joinRoom(t, roomId, "anon")).rejects.toThrow(
+      "This retro is for signed-in accounts. Sign in to join."
+    );
+  });
+});
+
+describe("reading a team retro without attendance (ADR-0009)", () => {
+  it("a Team member who never joined reads the board and no membership row is written", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+
+    const board = await as(t, "admin").query(api.retro.board, { roomId });
+    expect(board.roomId).toBe(roomId);
+    expect(await membershipOf(t, roomId, adminId)).toBeNull();
+    expect(await as(t, "admin").query(api.users.getMyMembership, { roomId })).toBeNull();
+  });
+
+  it("remove ends attendance, not access: a removed Team member still reads", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    await joinRoom(t, roomId, "admin");
+
+    await as(t, "member").mutation(api.users.remove, { roomId, userId: adminId });
+
+    expect(await membershipOf(t, roomId, adminId)).toBeNull();
+    expect((await as(t, "admin").query(api.retro.board, { roomId })).roomId).toBe(roomId);
+  });
+
+  it("the room shell names the owning Team for anyone with the link", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const roomId = await createRetro(t, "member", { teamId });
+    const teamless = await createRetro(t, "member");
+
+    const shell = (await t.query(api.rooms.get, { roomId }))!;
+    expect(shell.teamName).toBe("Acme Squad");
+    expect(shell.room.joinPolicy).toBe("teamMembers");
+    expect((await t.query(api.rooms.get, { roomId: teamless }))!.teamName).toBeUndefined();
+  });
+});
+
+describe("retro.lastFormat — the create form's pre-selection", () => {
+  it("is null for a Team without retros, then the newest retro's format", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+
+    expect(await as(t, "member").query(api.retro.lastFormat, { teamId })).toBeNull();
+
+    await createRetro(t, "member", { teamId, formatName: "Sailboat" });
+    await createRetro(t, "admin", { teamId, formatName: "Lean Coffee" });
+
+    const format = await as(t, "member").query(api.retro.lastFormat, { teamId });
+    expect(format?.name).toBe("Lean Coffee");
+    expect(format?.prompts).toEqual(RETRO_FORMATS.find((f) => f.name === "Lean Coffee")!.prompts);
+
+    await seedUser(t, "stranger", "permanent");
+    await expect(as(t, "stranger").query(api.retro.lastFormat, { teamId })).rejects.toThrow(
+      "You are not a member of this team"
+    );
+  });
+});
+
+describe("listings (spec §16.5, §18.1)", () => {
+  async function advanceTo(t: T, roomId: Id<"rooms">, kind: "group" | "close") {
+    await t.run(async (ctx) => {
+      const retro = (await ctx.db
+        .query("retros")
+        .withIndex("by_room", (q) => q.eq("roomId", roomId))
+        .unique())!;
+      await ctx.db.patch(retro._id, {
+        currentStageId: retro.stages.find((s) => s.kind === kind)!.id,
+      });
+    });
+  }
+
+  it("the team page lists the Team's retros in creation order with their resting stage", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const first = await createRetro(t, "member", { teamId, name: "First" });
+    const second = await createRetro(t, "admin", { teamId, name: "Second" });
+    await createRetro(t, "member", { name: "Teamless" });
+    await advanceTo(t, first, "close");
+
+    const rows = await as(t, "member").query(api.retro.listForTeam, { teamId });
+    expect(rows.map((r) => [r.roomId, r.name, r.stageKind])).toEqual([
+      [first, "First", "close"],
+      [second, "Second", "collect"],
+    ]);
+    await seedUser(t, "stranger", "permanent");
+    await expect(as(t, "stranger").query(api.retro.listForTeam, { teamId })).rejects.toThrow(
+      "You are not a member of this team"
+    );
+  });
+
+  it("the dashboard lists attended retros, collect first, grouped by Team, teamless under No team", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const beta = await createTeam(t, "member", "Beta");
+    const acmeOld = await createRetro(t, "member", { teamId, name: "Acme old" });
+    const acmeCollecting = await createRetro(t, "member", { teamId, name: "Acme collecting" });
+    const betaRetro = await createRetro(t, "member", { teamId: beta, name: "Beta one" });
+    const teamless = await createRetro(t, "member", { name: "Loose" });
+    const notAttended = await createRetro(t, "admin", { teamId, name: "Not mine" });
+    await createRetro(t, "admin", { name: "Poker-less" });
+    await as(t, "member").mutation(api.rooms.create, { name: "Poker" });
+    await advanceTo(t, acmeOld, "group");
+    await advanceTo(t, betaRetro, "close");
+
+    const groups = await as(t, "member").query(api.retro.listMine, {});
+    expect(groups.map((g) => g.teamName)).toEqual(["Acme Squad", "Beta", "No team"]);
+    expect(groups[0].teamId).toBe(teamId);
+    expect(groups[0].retros.map((r) => r.roomId)).toEqual([acmeCollecting, acmeOld]);
+    expect(groups[0].retros.map((r) => r.stageKind)).toEqual(["collect", "group"]);
+    expect(groups[1].retros.map((r) => r.roomId)).toEqual([betaRetro]);
+    expect(groups[2].teamId).toBeUndefined();
+    expect(groups[2].retros.map((r) => r.roomId)).toEqual([teamless]);
+    expect(groups.flatMap((g) => g.retros.map((r) => r.roomId))).not.toContain(notAttended);
+  });
+
+  it("the dashboard is empty for an anonymous visitor and for someone who attended nothing", async () => {
+    const t = convexTest(schema, modules);
+    await seedUser(t, "nobody");
+    expect(await t.query(api.retro.listMine, {})).toEqual([]);
+    expect(await as(t, "nobody").query(api.retro.listMine, {})).toEqual([]);
+  });
+});

--- a/src/app/dashboard/retros/retros-content.test.tsx
+++ b/src/app/dashboard/retros/retros-content.test.tsx
@@ -1,18 +1,29 @@
 /**
- * RetrosContent — /dashboard/retros (spec §18.1): the person's Teams with
- * New team. Loading shows a skeleton, no teams shows the empty state with
- * the same CTA, and each team links to its page with its role.
+ * RetrosContent — /dashboard/retros (spec §18.1): the retros the person
+ * attended, grouped as the listing query returns them (by Team, teamless
+ * under "No team"), each group heading a door to its team page; then the
+ * person's Teams with New team. Loading shows skeletons, no teams shows the
+ * empty state with the same CTA, and each team links to its page with its
+ * role.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import type { ReactNode } from "react";
+
+type Group = { teamId?: string; teamName: string; retros: { roomId: string; name: string }[] };
 
 const mocks = vi.hoisted(() => ({
   teams: undefined as undefined | { _id: string; name: string; role: "admin" | "member" }[],
+  groups: undefined as undefined | Group[],
   dialogOpen: [] as boolean[],
 }));
 
-vi.mock("convex/react", () => ({ useQuery: () => mocks.teams }));
+vi.mock("@/convex/_generated/api", () => ({
+  api: { retro: { listMine: "retro.listMine" }, teams: { listMine: "teams.listMine" } },
+}));
+vi.mock("convex/react", () => ({
+  useQuery: (ref: string) => (ref === "retro.listMine" ? mocks.groups : mocks.teams),
+}));
 vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock("next/link", () => ({
   default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
@@ -26,16 +37,53 @@ vi.mock("@/components/team/new-team-dialog", () => ({
     return open ? <div role="dialog">New team dialog</div> : null;
   },
 }));
+vi.mock("@/components/retro/retro-list", () => ({
+  RetroRows: ({ rows }: { rows: { roomId: string; name: string }[] }) => (
+    <ul data-testid="retro-rows">
+      {rows.map((row) => (
+        <li key={row.roomId}>{row.name}</li>
+      ))}
+    </ul>
+  ),
+}));
 
 import { RetrosContent } from "./retros-content";
 
 beforeEach(() => {
   mocks.teams = undefined;
+  mocks.groups = undefined;
   mocks.dialogOpen = [];
 });
 afterEach(cleanup);
 
-describe("RetrosContent", () => {
+describe("RetrosContent — attended retros", () => {
+  it("renders the groups in the query's order, team headings linking to the team page", () => {
+    mocks.groups = [
+      { teamId: "t1", teamName: "Acme", retros: [{ roomId: "r1", name: "Collecting" }, { roomId: "r2", name: "Older" }] },
+      { teamName: "No team", retros: [{ roomId: "r3", name: "Loose" }] },
+    ];
+    mocks.teams = [];
+    render(<RetrosContent />);
+    const groups = screen.getAllByTestId("retro-group");
+    expect(groups).toHaveLength(2);
+    expect(within(groups[0]).getByRole("link", { name: "Acme" }).getAttribute("href")).toBe("/team/t1");
+    expect(within(groups[0]).getAllByRole("listitem").map((li) => li.textContent)).toEqual(["Collecting", "Older"]);
+    expect(within(groups[1]).getByRole("heading", { name: "No team" })).toBeTruthy();
+    expect(within(groups[1]).queryByRole("link")).toBeNull();
+    expect(within(groups[1]).getAllByRole("listitem").map((li) => li.textContent)).toEqual(["Loose"]);
+    expect(screen.getByRole("link", { name: /New retro/ }).getAttribute("href")).toBe("/retro/new");
+  });
+
+  it("shows the empty line when nothing was attended", () => {
+    mocks.groups = [];
+    mocks.teams = [];
+    render(<RetrosContent />);
+    expect(screen.getByText("Retros you take part in show up here.")).toBeTruthy();
+    expect(screen.queryByTestId("retro-group")).toBeNull();
+  });
+});
+
+describe("RetrosContent — teams", () => {
   it("shows a skeleton while the teams load", () => {
     render(<RetrosContent />);
     expect(screen.getByRole("heading", { name: "Retros" })).toBeTruthy();

--- a/src/app/dashboard/retros/retros-content.tsx
+++ b/src/app/dashboard/retros/retros-content.tsx
@@ -8,80 +8,125 @@ import { api } from "@/convex/_generated/api";
 import { useAuth } from "@/components/auth/auth-provider";
 import { DashboardHeader } from "@/components/dashboard";
 import { NewTeamDialog } from "@/components/team/new-team-dialog";
+import { RetroRows } from "@/components/retro/retro-list";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { MY_RETROS_EMPTY, MY_RETROS_TITLE } from "@/convex/retroCopy";
 
 /**
- * /dashboard/retros (spec §18.1): the person's Teams with New team, the door
- * to every team page. Retro history rows arrive with #288/#289.
+ * /dashboard/retros (spec §18.1): the retros the person attended, grouped
+ * by Team with teamless ones under "No team" and `collect` retros first
+ * (the minimal row until #299's history row); then the person's Teams with
+ * New team, the door to every team page.
  */
 export function RetrosContent() {
   const { isAuthenticated } = useAuth();
+  const groups = useQuery(api.retro.listMine, isAuthenticated ? {} : "skip");
   const teams = useQuery(api.teams.listMine, isAuthenticated ? {} : "skip");
   const [newTeamOpen, setNewTeamOpen] = useState(false);
-
-  const isLoading = teams === undefined;
 
   return (
     <>
       <DashboardHeader title="Retros" showDateRange={false} />
-      <div className="flex-1 space-y-6 p-6">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-semibold tracking-tight">Teams</h2>
-            <p className="text-sm text-muted-foreground">
-              A team keeps its retros and decides who can read them.
-            </p>
-          </div>
-          <Button onClick={() => setNewTeamOpen(true)} data-testid="new-team-button">
-            <Plus className="size-4" />
-            New team
-          </Button>
-        </div>
-
-        {isLoading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="h-[92px] animate-pulse rounded-2xl border bg-card p-5">
-                <div className="mb-3 h-5 w-2/3 rounded-md bg-muted" />
-                <div className="h-4 w-1/3 rounded-md bg-muted" />
-              </div>
-            ))}
-          </div>
-        ) : teams.length === 0 ? (
-          <div className="flex min-h-[260px] flex-col items-center justify-center rounded-2xl border border-dashed bg-muted/20 p-8 text-center">
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-              <Users className="h-6 w-6 text-primary" />
+      <div className="flex-1 space-y-10 p-6">
+        <section className="space-y-6" data-testid="my-retros">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight">{MY_RETROS_TITLE}</h2>
+              <p className="text-sm text-muted-foreground">
+                Every retro you have taken part in, kept by its team.
+              </p>
             </div>
-            <h3 className="mb-2 text-lg font-semibold">No teams yet</h3>
-            <p className="mb-6 max-w-sm text-sm text-muted-foreground">
-              Create a team to keep your retros, or open an invite link a teammate sent you.
+            <Button render={<Link href="/retro/new" />} nativeButton={false}>
+              <Plus className="size-4" />
+              New retro
+            </Button>
+          </div>
+
+          {groups === undefined ? (
+            <div className="h-24 animate-pulse rounded-2xl border bg-card" />
+          ) : groups.length === 0 ? (
+            <p className="rounded-2xl border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+              {MY_RETROS_EMPTY}
             </p>
-            <Button onClick={() => setNewTeamOpen(true)}>
+          ) : (
+            <div className="space-y-6">
+              {groups.map((group) => (
+                <div key={group.teamId ?? "none"} className="space-y-2" data-testid="retro-group">
+                  <h3 className="text-sm font-medium text-muted-foreground">
+                    {group.teamId ? (
+                      <Link href={`/team/${group.teamId}`} className="hover:text-foreground">
+                        {group.teamName}
+                      </Link>
+                    ) : (
+                      group.teamName
+                    )}
+                  </h3>
+                  <RetroRows rows={group.retros} />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight">Teams</h2>
+              <p className="text-sm text-muted-foreground">
+                A team keeps its retros and decides who can read them.
+              </p>
+            </div>
+            <Button onClick={() => setNewTeamOpen(true)} data-testid="new-team-button">
               <Plus className="size-4" />
               New team
             </Button>
           </div>
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="team-list">
-            {teams.map((team) => (
-              <Link
-                key={team._id}
-                href={`/team/${team._id}`}
-                className="group flex items-center justify-between gap-3 rounded-2xl border bg-card p-5 transition-colors hover:bg-muted/40"
-              >
-                <div className="min-w-0">
-                  <p className="truncate font-medium">{team.name}</p>
-                  <Badge variant={team.role === "admin" ? "default" : "secondary"} className="mt-2">
-                    {team.role === "admin" && <Crown className="size-3" />}
-                    {team.role}
-                  </Badge>
+
+          {teams === undefined ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-[92px] animate-pulse rounded-2xl border bg-card p-5">
+                  <div className="mb-3 h-5 w-2/3 rounded-md bg-muted" />
+                  <div className="h-4 w-1/3 rounded-md bg-muted" />
                 </div>
-                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-              </Link>
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          ) : teams.length === 0 ? (
+            <div className="flex min-h-[260px] flex-col items-center justify-center rounded-2xl border border-dashed bg-muted/20 p-8 text-center">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                <Users className="h-6 w-6 text-primary" />
+              </div>
+              <h3 className="mb-2 text-lg font-semibold">No teams yet</h3>
+              <p className="mb-6 max-w-sm text-sm text-muted-foreground">
+                Create a team to keep your retros, or open an invite link a teammate sent you.
+              </p>
+              <Button onClick={() => setNewTeamOpen(true)}>
+                <Plus className="size-4" />
+                New team
+              </Button>
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="team-list">
+              {teams.map((team) => (
+                <Link
+                  key={team._id}
+                  href={`/team/${team._id}`}
+                  className="group flex items-center justify-between gap-3 rounded-2xl border bg-card p-5 transition-colors hover:bg-muted/40"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{team.name}</p>
+                    <Badge variant={team.role === "admin" ? "default" : "secondary"} className="mt-2">
+                      {team.role === "admin" && <Crown className="size-3" />}
+                      {team.role}
+                    </Badge>
+                  </div>
+                  <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
 
       <NewTeamDialog open={newTeamOpen} onOpenChange={setNewTeamOpen} returnTo="/dashboard/retros" />

--- a/src/app/retro/new/create-content.test.tsx
+++ b/src/app/retro/new/create-content.test.tsx
@@ -1,36 +1,69 @@
 /**
- * `/retro/new` (spec §6.1): the format is pre-selected and collapsed to one
- * line, expandable to the six-format library with picker lines and prompts;
- * create sends the chosen format's name and the optional cards-due date.
+ * `/retro/new` (spec §6.1): the team picker lists the person's Teams with
+ * New team and is hidden for an anonymous account; `?team=` pre-selects;
+ * the format is pre-selected — the Team's last format, listed first in the
+ * library — and collapsed to one line; the disclosure reads the team or
+ * teamless line before the retro exists; create sends the Team, the format
+ * name and the optional cards-due date.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor, within, act } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   ensureSession: vi.fn(async () => "auth-1"),
   push: vi.fn(),
-  auth: { isAuthenticated: true, isLoading: false },
+  auth: { isAuthenticated: true, isLoading: false, accountType: "anonymous" as "anonymous" | "permanent" | null },
+  searchParams: new URLSearchParams(),
+  queries: {} as Record<string, unknown>,
+  dialog: { open: false, onCreated: undefined as undefined | ((id: string) => void) },
 }));
 
-vi.mock("@/convex/_generated/api", () => ({ api: { retro: { create: "retro.create" } } }));
-vi.mock("convex/react", () => ({ useMutation: () => mocks.create }));
+vi.mock("@/convex/_generated/api", () => ({
+  api: {
+    retro: { create: "retro.create", lastFormat: "retro.lastFormat" },
+    teams: { listMine: "teams.listMine" },
+  },
+}));
+vi.mock("convex/react", () => ({
+  useMutation: () => mocks.create,
+  useQuery: (ref: string, args: unknown) => (args === "skip" ? undefined : mocks.queries[ref]),
+}));
 vi.mock("@/hooks/useEnsureSession", () => ({ useEnsureSession: () => mocks.ensureSession }));
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => mocks.searchParams,
+}));
 vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => mocks.auth }));
 vi.mock("@/components/navbar", () => ({ Navbar: () => null }));
 vi.mock("@/components/footer", () => ({ Footer: () => null }));
+vi.mock("@/components/team/new-team-dialog", () => ({
+  NewTeamDialog: ({ open, onCreated }: { open: boolean; onCreated?: (id: string) => void }) => {
+    mocks.dialog = { open, onCreated };
+    return open ? <div role="dialog">New team dialog</div> : null;
+  },
+}));
 
 import { CreateRetroContent } from "./create-content";
 import { RETRO_FORMATS, DEFAULT_RETRO_FORMAT } from "@/convex/model/retroFormats";
+import { TEAMLESS_DISCLOSURE, keptByTeam } from "@/convex/retroCopy";
+
+const teams = [
+  { _id: "team-1", name: "Acme Squad", role: "member" },
+  { _id: "team-2", name: "Beta", role: "admin" },
+];
 
 beforeEach(() => {
   mocks.create.mockReset().mockResolvedValue("room1");
   mocks.push.mockReset();
+  mocks.auth.accountType = "anonymous";
+  mocks.searchParams = new URLSearchParams();
+  mocks.queries = { "teams.listMine": teams, "retro.lastFormat": null };
+  mocks.dialog = { open: false, onCreated: undefined };
 });
 afterEach(cleanup);
 
-describe("CreateRetroContent", () => {
+describe("CreateRetroContent — format", () => {
   it("pre-selects the default format, collapsed to one line", () => {
     render(<CreateRetroContent />);
     expect(screen.getByTestId("format-selected").textContent).toContain(DEFAULT_RETRO_FORMAT.name);
@@ -64,6 +97,7 @@ describe("CreateRetroContent", () => {
     expect(args.name).toBe("Sprint 12");
     expect(args.formatName).toBe(DEFAULT_RETRO_FORMAT.name);
     expect(new Date(args.collectUntil).toISOString().slice(0, 10)).toBe("2026-09-10");
+    expect("teamId" in args).toBe(false);
     await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/room/room1"));
   });
 
@@ -73,5 +107,97 @@ describe("CreateRetroContent", () => {
     await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1));
     expect("collectUntil" in mocks.create.mock.calls[0][0]).toBe(false);
     expect(mocks.create.mock.calls[0][0].name).toMatch(/^Retro /);
+  });
+});
+
+describe("CreateRetroContent — team", () => {
+  it("hides the team picker entirely for an anonymous account and reads the teamless line", () => {
+    render(<CreateRetroContent />);
+    expect(screen.queryByLabelText("Team")).toBeNull();
+    expect(screen.getByTestId("disclosure").textContent).toBe(TEAMLESS_DISCLOSURE);
+  });
+
+  it("lists the person's Teams with No team and New team for a permanent account", () => {
+    mocks.auth.accountType = "permanent";
+    render(<CreateRetroContent />);
+    const picker = screen.getByLabelText("Team") as HTMLSelectElement;
+    expect(Array.from(picker.options).map((o) => o.textContent)).toEqual([
+      "No team", "Acme Squad", "Beta", "New team…",
+    ]);
+    expect(picker.value).toBe("");
+    expect(screen.getByTestId("disclosure").textContent).toBe(TEAMLESS_DISCLOSURE);
+  });
+
+  it("choosing a Team switches the disclosure to the team line and sends teamId", async () => {
+    mocks.auth.accountType = "permanent";
+    render(<CreateRetroContent />);
+    fireEvent.change(screen.getByLabelText("Team"), { target: { value: "team-1" } });
+    expect(screen.getByTestId("disclosure").textContent).toBe(keptByTeam("Acme Squad"));
+    expect(screen.getByTestId("disclosure").getAttribute("data-kept")).toBe("team");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start retro" }));
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1));
+    expect(mocks.create.mock.calls[0][0].teamId).toBe("team-1");
+  });
+
+  it("?team= pre-selects the Team; an id that is not one of the person's Teams is ignored", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-2");
+    render(<CreateRetroContent />);
+    expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("team-2");
+    expect(screen.getByTestId("disclosure").textContent).toBe(keptByTeam("Beta"));
+    cleanup();
+
+    mocks.searchParams = new URLSearchParams("team=team-9");
+    render(<CreateRetroContent />);
+    expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("");
+    expect(screen.getByTestId("disclosure").textContent).toBe(TEAMLESS_DISCLOSURE);
+  });
+
+  it("holds the button while a URL-named Team is still loading", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-2");
+    mocks.queries["teams.listMine"] = undefined;
+    render(<CreateRetroContent />);
+    expect((screen.getByRole("button", { name: "Start retro" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("pre-selects the Team's last format and lists it first in the library, until the person picks", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-1");
+    mocks.queries["retro.lastFormat"] = { name: "Sailboat", prompts: [] };
+    render(<CreateRetroContent />);
+    expect(screen.getByTestId("format-selected").textContent).toContain("Sailboat");
+
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    const radios = within(screen.getByTestId("format-library")).getAllByRole("radio");
+    expect(radios[0].getAttribute("aria-label")).toBe("Sailboat");
+    expect((radios[0] as HTMLInputElement).checked).toBe(true);
+    expect(radios).toHaveLength(RETRO_FORMATS.length);
+
+    fireEvent.click(screen.getByLabelText("4Ls"));
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByTestId("format-selected").textContent).toContain("4Ls");
+  });
+
+  it("falls back to the default when the last format's name is not in the library", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-1");
+    mocks.queries["retro.lastFormat"] = { name: "Our own", prompts: [] };
+    render(<CreateRetroContent />);
+    expect(screen.getByTestId("format-selected").textContent).toContain(DEFAULT_RETRO_FORMAT.name);
+  });
+
+  it("New team opens the dialog and selects the Team it creates", () => {
+    mocks.auth.accountType = "permanent";
+    render(<CreateRetroContent />);
+    fireEvent.change(screen.getByLabelText("Team"), { target: { value: "__new" } });
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("");
+
+    mocks.queries["teams.listMine"] = [...teams, { _id: "team-3", name: "Gamma", role: "admin" }];
+    act(() => mocks.dialog.onCreated?.("team-3"));
+    expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("team-3");
+    expect(screen.getByTestId("disclosure").textContent).toBe(keptByTeam("Gamma"));
   });
 });

--- a/src/app/retro/new/create-content.test.tsx
+++ b/src/app/retro/new/create-content.test.tsx
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   auth: { isAuthenticated: true, isLoading: false, accountType: "anonymous" as "anonymous" | "permanent" | null },
   searchParams: new URLSearchParams(),
   queries: {} as Record<string, unknown>,
-  dialog: { open: false, onCreated: undefined as undefined | ((id: string) => void) },
+  dialog: { open: false, onCreated: undefined as undefined | ((team: { _id: string; name: string }) => void) },
 }));
 
 vi.mock("@/convex/_generated/api", () => ({
@@ -38,7 +38,7 @@ vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => mocks.auth })
 vi.mock("@/components/navbar", () => ({ Navbar: () => null }));
 vi.mock("@/components/footer", () => ({ Footer: () => null }));
 vi.mock("@/components/team/new-team-dialog", () => ({
-  NewTeamDialog: ({ open, onCreated }: { open: boolean; onCreated?: (id: string) => void }) => {
+  NewTeamDialog: ({ open, onCreated }: { open: boolean; onCreated?: (team: { _id: string; name: string }) => void }) => {
     mocks.dialog = { open, onCreated };
     return open ? <div role="dialog">New team dialog</div> : null;
   },
@@ -188,16 +188,26 @@ describe("CreateRetroContent — team", () => {
     expect(screen.getByTestId("format-selected").textContent).toContain(DEFAULT_RETRO_FORMAT.name);
   });
 
-  it("New team opens the dialog and selects the Team it creates", () => {
+  it("New team opens the dialog and selects the Team it creates before the Teams read catches up", async () => {
     mocks.auth.accountType = "permanent";
     render(<CreateRetroContent />);
     fireEvent.change(screen.getByLabelText("Team"), { target: { value: "__new" } });
     expect(screen.getByRole("dialog")).toBeTruthy();
     expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("");
 
-    mocks.queries["teams.listMine"] = [...teams, { _id: "team-3", name: "Gamma", role: "admin" }];
-    act(() => mocks.dialog.onCreated?.("team-3"));
-    expect((screen.getByLabelText("Team") as HTMLSelectElement).value).toBe("team-3");
+    // The Teams read still lists the old Teams; the created one is known locally.
+    act(() => mocks.dialog.onCreated?.({ _id: "team-3", name: "Gamma" }));
     expect(screen.getByTestId("disclosure").textContent).toBe(keptByTeam("Gamma"));
+    fireEvent.click(screen.getByRole("button", { name: "Start retro" }));
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1));
+    expect(mocks.create.mock.calls[0][0].teamId).toBe("team-3");
+  });
+
+  it("holds the button while the chosen Team's last format is still loading", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-1");
+    mocks.queries["retro.lastFormat"] = undefined;
+    render(<CreateRetroContent />);
+    expect((screen.getByRole("button", { name: "Start retro" }) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/src/app/retro/new/create-content.tsx
+++ b/src/app/retro/new/create-content.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { useRouter } from "next/navigation";
-import { useMutation } from "convex/react";
+import { useCallback, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
 import { ArrowRight } from "lucide-react";
 
 import { useAuth } from "@/components/auth/auth-provider";
@@ -21,12 +22,14 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { NewTeamDialog } from "@/components/team/new-team-dialog";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { tintClasses } from "@/components/retro/tints";
 import {
   DEFAULT_RETRO_FORMAT,
   RETRO_FORMATS,
+  findFormat,
   type RetroFormat,
 } from "@/convex/model/retroFormats";
 import {
@@ -40,10 +43,16 @@ import {
   FORMAT_LABEL,
   NEW_RETRO_DESCRIPTION,
   NEW_RETRO_TITLE,
+  NEW_TEAM_OPTION,
+  NO_TEAM_OPTION,
   RETRO_NAME_DESCRIPTION,
   RETRO_NAME_LABEL,
   RETRO_NAME_PLACEHOLDER,
+  TEAMLESS_DISCLOSURE,
+  TEAM_DESCRIPTION,
+  TEAM_LABEL,
   defaultRetroName,
+  keptByTeam,
 } from "@/convex/retroCopy";
 
 /** A `<input type="date">` value as the end of that local day, or undefined. */
@@ -53,6 +62,9 @@ function parseCollectUntil(value: string): number | undefined {
   if (!y || !m || !d) return undefined;
   return new Date(y, m - 1, d, 23, 59, 59).getTime();
 }
+
+/** The picker's "New team" option value; never a Team id. */
+const NEW_TEAM_VALUE = "__new";
 
 function PromptList({ format }: { format: RetroFormat }) {
   return (
@@ -73,23 +85,62 @@ function PromptList({ format }: { format: RetroFormat }) {
 }
 
 /**
- * `/retro/new` (spec §6.1): name, format and an optional cards-due date.
- * The format opens pre-selected and collapsed to one line; expanding shows
- * the six-format library with its picker lines and prompts. Editing a format
- * before stamping is #290; the team picker is #289. Anyone, anonymous
- * included, creates a teamless retro.
+ * `/retro/new` (spec §6.1): name, team, format and an optional cards-due
+ * date. The team picker lists the person's Teams with *New team* and is
+ * hidden entirely for an anonymous account, who can only create a teamless
+ * retro; `?team=` pre-selects one. The format opens pre-selected — the
+ * chosen Team's newest retro's format, else the default — and collapsed to
+ * one line; expanding shows the six-format library with the pre-selected
+ * format first. The write-time disclosure shows before the retro exists.
+ * Editing a format before stamping is #290.
  */
 export function CreateRetroContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isLoading: authLoading, accountType } = useAuth();
+  const ensureSession = useEnsureSession();
+  const createRetro = useMutation(api.retro.create);
+
   const [name, setName] = useState("");
-  const [format, setFormat] = useState<RetroFormat>(DEFAULT_RETRO_FORMAT);
+  const [teamId, setTeamId] = useState<string>(searchParams.get("team") ?? "");
+  /** The person's explicit pick; null means "the pre-selection". */
+  const [chosenFormat, setChosenFormat] = useState<RetroFormat | null>(null);
   const [libraryOpen, setLibraryOpen] = useState(false);
   const [collectUntil, setCollectUntil] = useState("");
   const [isCreating, setIsCreating] = useState(false);
+  const [newTeamOpen, setNewTeamOpen] = useState(false);
 
-  const router = useRouter();
-  const { isLoading: authLoading } = useAuth();
-  const ensureSession = useEnsureSession();
-  const createRetro = useMutation(api.retro.create);
+  const isPermanent = accountType === "permanent";
+  const myTeams = useQuery(api.teams.listMine, isPermanent ? {} : "skip");
+  const selectedTeam = myTeams?.find((team) => team._id === teamId);
+  const lastFormat = useQuery(
+    api.retro.lastFormat,
+    selectedTeam ? { teamId: selectedTeam._id } : "skip"
+  );
+
+  // Pre-selection (spec §6.1): the Team's newest retro's format when it is
+  // one the library carries, else the default. The edited-copy case (#290)
+  // widens this to the stamped format itself.
+  const preselected = useMemo(
+    () => (lastFormat ? findFormat(lastFormat.name) : undefined) ?? DEFAULT_RETRO_FORMAT,
+    [lastFormat]
+  );
+  const format = chosenFormat ?? preselected;
+  const library = useMemo(
+    () => [preselected, ...RETRO_FORMATS.filter((entry) => entry.name !== preselected.name)],
+    [preselected]
+  );
+
+  const handleTeamChange = (value: string) => {
+    if (value === NEW_TEAM_VALUE) {
+      setNewTeamOpen(true);
+      return;
+    }
+    setTeamId(value);
+    // A new Team brings its own pre-selection; a pick made for the old one
+    // does not carry over.
+    setChosenFormat(null);
+  };
 
   const handleCreate = useCallback(async () => {
     setIsCreating(true);
@@ -110,6 +161,7 @@ export function CreateRetroContent() {
         name: name.trim() || defaultRetroName(new Date()),
         formatName: format.name,
         ...(due !== undefined ? { collectUntil: due } : {}),
+        ...(selectedTeam ? { teamId: selectedTeam._id } : {}),
       });
       router.push(`/room/${roomId}`);
     } catch (error) {
@@ -117,7 +169,11 @@ export function CreateRetroContent() {
       toast.error(CREATE_RETRO_FAILED);
       setIsCreating(false);
     }
-  }, [ensureSession, collectUntil, createRetro, name, format, router]);
+  }, [ensureSession, collectUntil, createRetro, name, format, selectedTeam, router]);
+
+  // A Team named in the URL that the reads have not confirmed yet would be
+  // silently dropped; hold the button until they have.
+  const teamPending = isPermanent && teamId !== "" && myTeams === undefined;
 
   return (
     <div className="flex min-h-screen flex-col bg-white dark:bg-black">
@@ -146,11 +202,32 @@ export function CreateRetroContent() {
                     <FieldDescription>{RETRO_NAME_DESCRIPTION}</FieldDescription>
                   </Field>
 
+                  {isPermanent && (
+                    <Field>
+                      <FieldLabel htmlFor="retro-team">{TEAM_LABEL}</FieldLabel>
+                      <select
+                        id="retro-team"
+                        value={selectedTeam ? selectedTeam._id : ""}
+                        onChange={(e) => handleTeamChange(e.target.value)}
+                        className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+                      >
+                        <option value="">{NO_TEAM_OPTION}</option>
+                        {(myTeams ?? []).map((team) => (
+                          <option key={team._id} value={team._id}>
+                            {team.name}
+                          </option>
+                        ))}
+                        <option value={NEW_TEAM_VALUE}>{NEW_TEAM_OPTION}</option>
+                      </select>
+                      <FieldDescription>{TEAM_DESCRIPTION}</FieldDescription>
+                    </Field>
+                  )}
+
                   <Field>
                     <FieldLabel>{FORMAT_LABEL}</FieldLabel>
                     {libraryOpen ? (
                       <div data-testid="format-library" className="space-y-2">
-                        {RETRO_FORMATS.map((entry) => {
+                        {library.map((entry) => {
                           const id = `format-${entry.name.replace(/\W+/g, "-").toLowerCase()}`;
                           const selected = entry.name === format.name;
                           return (
@@ -171,7 +248,7 @@ export function CreateRetroContent() {
                                   name="format"
                                   value={entry.name}
                                   checked={selected}
-                                  onChange={() => setFormat(entry)}
+                                  onChange={() => setChosenFormat(entry)}
                                   aria-label={entry.name}
                                   className="mt-0.5 accent-primary"
                                 />
@@ -228,6 +305,14 @@ export function CreateRetroContent() {
                     />
                     <FieldDescription>{COLLECT_UNTIL_DESCRIPTION}</FieldDescription>
                   </Field>
+
+                  <p
+                    data-testid="disclosure"
+                    data-kept={selectedTeam ? "team" : "none"}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {selectedTeam ? keptByTeam(selectedTeam.name) : TEAMLESS_DISCLOSURE}
+                  </p>
                 </FieldGroup>
               </CardContent>
 
@@ -241,7 +326,7 @@ export function CreateRetroContent() {
                   // Wait until the auth state is known: creating while it is
                   // still resolving would trigger a second anonymous sign-in
                   // for a user who already has a session.
-                  disabled={isCreating || authLoading}
+                  disabled={isCreating || authLoading || teamPending}
                 >
                   {isCreating ? CREATING_RETRO_BUTTON : CREATE_RETRO_BUTTON}
                   {!isCreating && <ArrowRight className="ml-2 h-4 w-4" />}
@@ -253,6 +338,13 @@ export function CreateRetroContent() {
       </main>
 
       <Footer />
+
+      <NewTeamDialog
+        open={newTeamOpen}
+        onOpenChange={setNewTeamOpen}
+        returnTo="/retro/new"
+        onCreated={(id: Id<"teams">) => handleTeamChange(id)}
+      />
     </div>
   );
 }

--- a/src/app/retro/new/create-content.tsx
+++ b/src/app/retro/new/create-content.tsx
@@ -103,6 +103,11 @@ export function CreateRetroContent() {
 
   const [name, setName] = useState("");
   const [teamId, setTeamId] = useState<string>(searchParams.get("team") ?? "");
+  /**
+   * A Team created from the picker, known here before the Teams read
+   * reflects it, so a quick Start never creates a teamless retro.
+   */
+  const [createdTeam, setCreatedTeam] = useState<{ _id: Id<"teams">; name: string } | null>(null);
   /** The person's explicit pick; null means "the pre-selection". */
   const [chosenFormat, setChosenFormat] = useState<RetroFormat | null>(null);
   const [libraryOpen, setLibraryOpen] = useState(false);
@@ -112,7 +117,9 @@ export function CreateRetroContent() {
 
   const isPermanent = accountType === "permanent";
   const myTeams = useQuery(api.teams.listMine, isPermanent ? {} : "skip");
-  const selectedTeam = myTeams?.find((team) => team._id === teamId);
+  const selectedTeam =
+    myTeams?.find((team) => team._id === teamId) ??
+    (createdTeam && createdTeam._id === teamId ? createdTeam : undefined);
   const lastFormat = useQuery(
     api.retro.lastFormat,
     selectedTeam ? { teamId: selectedTeam._id } : "skip"
@@ -172,8 +179,12 @@ export function CreateRetroContent() {
   }, [ensureSession, collectUntil, createRetro, name, format, selectedTeam, router]);
 
   // A Team named in the URL that the reads have not confirmed yet would be
-  // silently dropped; hold the button until they have.
-  const teamPending = isPermanent && teamId !== "" && myTeams === undefined;
+  // silently dropped, and a Team whose last format is still loading would
+  // stamp the default; hold the button until both have settled.
+  const teamPending =
+    isPermanent &&
+    teamId !== "" &&
+    (myTeams === undefined || (selectedTeam !== undefined && lastFormat === undefined));
 
   return (
     <div className="flex min-h-screen flex-col bg-white dark:bg-black">
@@ -343,7 +354,10 @@ export function CreateRetroContent() {
         open={newTeamOpen}
         onOpenChange={setNewTeamOpen}
         returnTo="/retro/new"
-        onCreated={(id: Id<"teams">) => handleTeamChange(id)}
+        onCreated={(team) => {
+          setCreatedTeam(team);
+          handleTeamChange(team._id);
+        }}
       />
     </div>
   );

--- a/src/app/retro/new/page.tsx
+++ b/src/app/retro/new/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { Suspense } from "react";
 import { CreateRetroContent } from "./create-content";
 
 export const metadata: Metadata = {
@@ -16,5 +17,11 @@ export const metadata: Metadata = {
 };
 
 export default function NewRetroPage() {
-  return <CreateRetroContent />;
+  // The team picker reads `?team=` (useSearchParams), which needs a
+  // Suspense boundary for the static shell.
+  return (
+    <Suspense fallback={null}>
+      <CreateRetroContent />
+    </Suspense>
+  );
 }

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -11,7 +11,7 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 const mocks = vi.hoisted(() => ({
   queries: {} as Record<string, unknown>,
   join: vi.fn(),
-  auth: { authUserId: "auth-1", isLoading: false, isAuthenticated: true, accountType: "anonymous" },
+  auth: { authUserId: "auth-1", isLoading: false, isAuthenticated: true, accountType: "anonymous" as string },
 }));
 
 vi.mock("@/convex/_generated/api", () => ({
@@ -62,6 +62,7 @@ const teamed = {
 
 beforeEach(() => {
   mocks.join.mockReset();
+  mocks.auth.accountType = "anonymous";
   mocks.queries = { "retro.board": { currentStageId: "collect" }, "teams.listMine": [] };
 });
 afterEach(cleanup);
@@ -75,7 +76,8 @@ describe("RetroRoomContent", () => {
     expect(screen.queryByTestId("board")).toBeNull();
   });
 
-  it("hands the join form the Team's name and whether the visitor is in it", () => {
+  it("hands the join form the Team's name and whether the visitor is in it; an anonymous visitor never reads Teams", () => {
+    mocks.queries["teams.listMine"] = undefined;
     render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
     const form = screen.getByTestId("join-form");
     expect(form.getAttribute("data-team")).toBe("Acme Squad");
@@ -91,6 +93,7 @@ describe("RetroRoomContent", () => {
   });
 
   it("a Team member who never joined reads the board with no menu, and joins only on their own click", async () => {
+    mocks.auth.accountType = "permanent";
     mocks.queries["teams.listMine"] = [{ _id: "team-1", name: "Acme Squad", role: "member" }];
     render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
     const board = screen.getByTestId("board");
@@ -105,7 +108,8 @@ describe("RetroRoomContent", () => {
     expect(screen.getByTestId("join-form").getAttribute("data-team-member")).toBe("true");
   });
 
-  it("waits for the Teams read before deciding a signed-in visitor is not a Team member", () => {
+  it("waits for the Teams read before deciding a permanent account is not a Team member", () => {
+    mocks.auth.accountType = "permanent";
     mocks.queries["teams.listMine"] = undefined;
     render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
     expect(screen.queryByTestId("join-form")).toBeNull();

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -1,10 +1,12 @@
 /**
- * The room page's retro branch (spec §18.1): never auto-joins (it holds no
- * join mutation at all), shows the retro join form to a visitor without a
- * membership, and mounts the board once a membership exists.
+ * The room page's retro branch (spec §18.1, ADR-0009): never auto-joins (it
+ * holds no join mutation at all); shows the retro join form to a visitor
+ * without a membership or Team access, with the Team's name for the copy;
+ * lets a Team member who never joined read the board with a line offering
+ * to join; mounts the board with its menu for an attendee.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   queries: {} as Record<string, unknown>,
@@ -13,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/convex/_generated/api", () => ({
-  api: { retro: { board: "retro.board" } },
+  api: { retro: { board: "retro.board" }, teams: { listMine: "teams.listMine" } },
 }));
 vi.mock("convex/react", () => ({
   useQuery: (ref: string, args: unknown) => (args === "skip" ? undefined : mocks.queries[ref]),
@@ -21,45 +23,92 @@ vi.mock("convex/react", () => ({
 }));
 vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => mocks.auth }));
 vi.mock("@/components/retro/retro-join-form", () => ({
-  RetroJoinForm: ({ roomName }: { roomName: string }) => <div data-testid="join-form">{roomName}</div>,
+  RetroJoinForm: ({ roomName, teamName, isTeamMember }: { roomName: string; teamName?: string; isTeamMember: boolean }) => (
+    <div data-testid="join-form" data-team={teamName} data-team-member={String(isTeamMember)}>
+      {roomName}
+    </div>
+  ),
 }));
 vi.mock("@/components/retro/retro-board", () => ({
-  RetroBoard: ({ retro }: { retro: { currentStageId: string } }) => (
-    <div data-testid="board">{retro.currentStageId}</div>
+  RetroBoard: ({ retro, team, menu, banner }: { retro: { currentStageId: string }; team?: { name: string }; menu?: React.ReactNode; banner?: React.ReactNode }) => (
+    <div data-testid="board" data-team={team?.name}>
+      {retro.currentStageId}
+      {menu}
+      {banner}
+    </div>
   ),
+}));
+vi.mock("@/components/retro/retro-menu", () => ({
+  RetroMenu: ({ role }: { role: string }) => <div data-testid="menu">{role}</div>,
 }));
 
 import { RetroRoomContent } from "./retro-room-content";
 import type { Id } from "@/convex/_generated/dataModel";
 
 const roomId = "room1" as Id<"rooms">;
-const roomData = {
+const teamless = {
   room: { _id: roomId, name: "Sprint 12", roomType: "retro", joinPolicy: "anyone" },
+  users: [{ _id: "user1", role: "owner" }],
+  votes: [],
+  isOwnerAbsent: false,
+} as never;
+const teamed = {
+  room: { _id: roomId, name: "Sprint 12", roomType: "retro", joinPolicy: "teamMembers", teamId: "team-1" },
   users: [],
   votes: [],
   isOwnerAbsent: false,
+  teamName: "Acme Squad",
 } as never;
 
 beforeEach(() => {
   mocks.join.mockReset();
-  mocks.queries = { "retro.board": { currentStageId: "collect" } };
+  mocks.queries = { "retro.board": { currentStageId: "collect" }, "teams.listMine": [] };
 });
 afterEach(cleanup);
 
 describe("RetroRoomContent", () => {
   it("shows the join form to a visitor without a membership, and never auto-joins", async () => {
-    render(<RetroRoomContent roomId={roomId} roomData={roomData} membership={null} />);
+    render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={null} />);
     expect(screen.getByTestId("join-form").textContent).toBe("Sprint 12");
     await new Promise((r) => setTimeout(r, 0));
     expect(mocks.join).not.toHaveBeenCalled();
     expect(screen.queryByTestId("board")).toBeNull();
   });
 
-  it("mounts the board once a membership exists", () => {
-    render(
-      <RetroRoomContent roomId={roomId} roomData={roomData} membership={{ _id: "user1" as never }} />
-    );
-    expect(screen.getByTestId("board").textContent).toBe("collect");
+  it("hands the join form the Team's name and whether the visitor is in it", () => {
+    render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
+    const form = screen.getByTestId("join-form");
+    expect(form.getAttribute("data-team")).toBe("Acme Squad");
+    expect(form.getAttribute("data-team-member")).toBe("false");
+  });
+
+  it("mounts the board with the menu and the viewer's role once a membership exists", () => {
+    render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
+    expect(screen.getByTestId("board").textContent).toContain("collect");
+    expect(screen.getByTestId("menu").textContent).toBe("owner");
     expect(screen.queryByTestId("join-form")).toBeNull();
+    expect(screen.queryByTestId("team-reader-banner")).toBeNull();
+  });
+
+  it("a Team member who never joined reads the board with no menu, and joins only on their own click", async () => {
+    mocks.queries["teams.listMine"] = [{ _id: "team-1", name: "Acme Squad", role: "member" }];
+    render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
+    const board = screen.getByTestId("board");
+    expect(board.getAttribute("data-team")).toBe("Acme Squad");
+    expect(screen.queryByTestId("menu")).toBeNull();
+    expect(screen.queryByTestId("join-form")).toBeNull();
+    expect(screen.getByTestId("team-reader-banner").textContent).toContain("member of Acme Squad");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.join).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Join retro" }));
+    expect(screen.getByTestId("join-form").getAttribute("data-team-member")).toBe("true");
+  });
+
+  it("waits for the Teams read before deciding a signed-in visitor is not a Team member", () => {
+    mocks.queries["teams.listMine"] = undefined;
+    render(<RetroRoomContent roomId={roomId} roomData={teamed} membership={null} />);
+    expect(screen.queryByTestId("join-form")).toBeNull();
+    expect(screen.queryByTestId("board")).toBeNull();
   });
 });

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -72,7 +72,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     return <CenteredMessage title={LOADING_TITLE} body={LOADING_BOARD} />;
   }
 
-  if (!isMember) {
+  if (!isMember && team) {
     return (
       <RetroBoard
         name={room.name}
@@ -84,7 +84,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
             className="flex flex-wrap items-center justify-between gap-2 border-b bg-blue-50 px-4 py-2 text-sm dark:bg-status-info-bg"
           >
             <span className="text-blue-800 dark:text-status-info-fg">
-              {readingAsTeamMember(team!.name)}
+              {readingAsTeamMember(team.name)}
             </span>
             <Button size="sm" onClick={() => setWantsToJoin(true)}>
               {JOIN_RETRO_BUTTON}
@@ -95,7 +95,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     );
   }
 
-  const role = roomData.users.find((u) => u._id === membership._id)?.role ?? "participant";
+  const role = roomData.users.find((u) => u._id === membership?._id)?.role ?? "participant";
   return (
     <RetroBoard
       name={room.name}

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -39,9 +39,12 @@ interface RetroRoomContentProps {
  * written until they take it. An attendee gets the board and its menu.
  */
 export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomContentProps) {
-  const { isLoading: authLoading, isAuthenticated } = useAuth();
+  const { isLoading: authLoading, isAuthenticated, accountType } = useAuth();
   const isMember = membership !== null && membership !== undefined;
-  const myTeams = useQuery(api.teams.listMine, isAuthenticated ? {} : "skip");
+  // Only a permanent account can hold a Team membership (ADR-0008), so an
+  // anonymous visitor never opens the read.
+  const isPermanent = accountType === "permanent";
+  const myTeams = useQuery(api.teams.listMine, isPermanent ? {} : "skip");
   const [wantsToJoin, setWantsToJoin] = useState(false);
 
   const { room } = roomData;
@@ -52,7 +55,11 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   // The board read takes the reader guard; never subscribe before it passes.
   const retro = useQuery(api.retro.board, canRead ? { roomId } : "skip");
 
-  if (authLoading || (isAuthenticated && (membership === undefined || myTeams === undefined))) {
+  if (
+    authLoading ||
+    (isAuthenticated && membership === undefined) ||
+    (isPermanent && myTeams === undefined)
+  ) {
     return <CenteredMessage title={LOADING_TITLE} body={CHECKING_SESSION} />;
   }
 

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -1,14 +1,24 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { useAuth } from "@/components/auth/auth-provider";
 import { CenteredMessage } from "@/components/centered-message";
+import { Button } from "@/components/ui/button";
 import { RetroJoinForm } from "@/components/retro/retro-join-form";
 import { RetroBoard } from "@/components/retro/retro-board";
+import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
+import type { RetroTeam } from "@/components/retro/retro-header";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
-import { CHECKING_SESSION, LOADING_BOARD, LOADING_TITLE } from "@/convex/retroCopy";
+import {
+  CHECKING_SESSION,
+  JOIN_RETRO_BUTTON,
+  LOADING_BOARD,
+  LOADING_TITLE,
+  readingAsTeamMember,
+} from "@/convex/retroCopy";
 
 /** What `api.users.getMyMembership` returns for a member. */
 export type MyMembership = { _id: Id<"users"> };
@@ -22,31 +32,38 @@ interface RetroRoomContentProps {
 
 /**
  * The room page's retro branch (spec §18.1). Joining a retro is always a
- * deliberate act: nothing here auto-joins, whoever the visitor is. Without a
- * membership the retro join form shows, with the join decision resolved
- * first; with one, the board mounts.
+ * deliberate act: nothing here auto-joins, whoever the visitor is. A
+ * visitor with neither attendance nor Team access sees the join form, with
+ * the join decision resolved first. A Team member who never joined reads
+ * the board (ADR-0009) with a line offering to join, and no membership is
+ * written until they take it. An attendee gets the board and its menu.
  */
 export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomContentProps) {
   const { isLoading: authLoading, isAuthenticated } = useAuth();
   const isMember = membership !== null && membership !== undefined;
-  // The board read takes the reader guard; never subscribe before it passes.
-  const retro = useQuery(api.retro.board, isMember ? { roomId } : "skip");
+  const myTeams = useQuery(api.teams.listMine, isAuthenticated ? {} : "skip");
+  const [wantsToJoin, setWantsToJoin] = useState(false);
 
   const { room } = roomData;
+  const team: RetroTeam | undefined =
+    room.teamId && roomData.teamName ? { _id: room.teamId, name: roomData.teamName } : undefined;
+  const isTeamMember = team !== undefined && (myTeams ?? []).some((t) => t._id === team._id);
+  const canRead = isMember || isTeamMember;
+  // The board read takes the reader guard; never subscribe before it passes.
+  const retro = useQuery(api.retro.board, canRead ? { roomId } : "skip");
 
-  if (authLoading || (isAuthenticated && membership === undefined)) {
+  if (authLoading || (isAuthenticated && (membership === undefined || myTeams === undefined))) {
     return <CenteredMessage title={LOADING_TITLE} body={CHECKING_SESSION} />;
   }
 
-  if (!isMember) {
+  if (!isMember && (!isTeamMember || wantsToJoin)) {
     return (
       <RetroJoinForm
         roomId={roomId}
         roomName={room.name}
         joinPolicy={room.joinPolicy ?? "anyone"}
-        // Team membership reaches the client with team retros (#289); a
-        // teamless retro has no Team to be a member of.
-        isTeamMember={false}
+        isTeamMember={isTeamMember}
+        teamName={roomData.teamName}
       />
     );
   }
@@ -55,5 +72,44 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     return <CenteredMessage title={LOADING_TITLE} body={LOADING_BOARD} />;
   }
 
-  return <RetroBoard name={room.name} retro={retro} />;
+  if (!isMember) {
+    return (
+      <RetroBoard
+        name={room.name}
+        retro={retro}
+        team={team}
+        banner={
+          <div
+            data-testid="team-reader-banner"
+            className="flex flex-wrap items-center justify-between gap-2 border-b bg-blue-50 px-4 py-2 text-sm dark:bg-status-info-bg"
+          >
+            <span className="text-blue-800 dark:text-status-info-fg">
+              {readingAsTeamMember(team!.name)}
+            </span>
+            <Button size="sm" onClick={() => setWantsToJoin(true)}>
+              {JOIN_RETRO_BUTTON}
+            </Button>
+          </div>
+        }
+      />
+    );
+  }
+
+  const role = roomData.users.find((u) => u._id === membership._id)?.role ?? "participant";
+  return (
+    <RetroBoard
+      name={room.name}
+      retro={retro}
+      team={team}
+      menu={
+        <RetroMenu
+          roomId={roomId}
+          team={team}
+          role={role}
+          isOwnerAbsent={roomData.isOwnerAbsent}
+          myTeams={(myTeams ?? []) as MyTeam[]}
+        />
+      }
+    />
+  );
 }

--- a/src/app/team/[teamId]/team-content.test.tsx
+++ b/src/app/team/[teamId]/team-content.test.tsx
@@ -27,6 +27,7 @@ type Team = {
 
 const mocks = vi.hoisted(() => ({
   team: undefined as Team | undefined,
+  retros: [] as unknown[] | undefined,
   calls: [] as { fn: string; args: unknown }[],
   fail: {} as Record<string, string>,
   push: vi.fn(),
@@ -36,7 +37,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("convex/react", async () => {
   const { getFunctionName } = await import("convex/server");
   return {
-    useQuery: () => mocks.team,
+    useQuery: (ref: unknown) =>
+      getFunctionName(ref as never) === "retro:listForTeam" ? mocks.retros : mocks.team,
     useMutation: (ref: unknown) => {
       const fn = getFunctionName(ref as never);
       return async (args: unknown) => {
@@ -59,6 +61,15 @@ vi.mock("@/components/auth/auth-provider", () => ({
 vi.mock("@/components/navbar", () => ({ Navbar: () => null }));
 vi.mock("@/components/footer", () => ({ Footer: () => null }));
 vi.mock("@/components/user-menu/user-avatar", () => ({ UserAvatar: () => null }));
+vi.mock("@/components/retro/retro-list", () => ({
+  RetroRows: ({ rows }: { rows: { roomId: string; name: string }[] }) => (
+    <ul data-testid="retro-rows">
+      {rows.map((row) => (
+        <li key={row.roomId}>{row.name}</li>
+      ))}
+    </ul>
+  ),
+}));
 vi.mock("@/utils/copy-text-to-clipboard", () => ({ copyTextToClipboard: async () => true }));
 vi.mock("@/lib/toast", () => ({
   toast: {
@@ -118,6 +129,7 @@ const dialog = () => within(screen.getByRole("dialog"));
 
 beforeEach(() => {
   mocks.team = team("admin");
+  mocks.retros = [];
   mocks.calls = [];
   mocks.fail = {};
   mocks.toasts = [];
@@ -217,6 +229,26 @@ describe("TeamContent as an admin", () => {
     await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: "boom" }));
     expect(dialog().getByRole("button", { name: "Delete team" })).toBeTruthy();
     expect((dialog().getByRole("button", { name: "Delete team" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});
+
+describe("TeamContent — the Team's retros", () => {
+  it("lists the rows the listing query returns, in its order, and New retro pre-selects the Team", () => {
+    mocks.retros = [
+      { roomId: "r1", name: "First", stageKind: "close", createdAt: 1 },
+      { roomId: "r2", name: "Second", stageKind: "collect", createdAt: 2 },
+    ];
+    render(<TeamContent />);
+    const rows = within(screen.getByTestId("retro-rows")).getAllByRole("listitem");
+    expect(rows.map((row) => row.textContent)).toEqual(["First", "Second"]);
+    expect(screen.getByRole("link", { name: /New retro/ }).getAttribute("href")).toBe("/retro/new?team=team-1");
+  });
+
+  it("shows the empty line when the Team has no retros yet", () => {
+    mocks.retros = [];
+    render(<TeamContent />);
+    expect(screen.getByText("No retros yet. Start one and this team keeps it.")).toBeTruthy();
+    expect(screen.queryByTestId("retro-rows")).toBeNull();
   });
 });
 

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -27,6 +27,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { RetroDefaultsPanel, type RetroDefaults } from "@/components/team/retro-defaults-panel";
+import { RetroRows } from "@/components/retro/retro-list";
+import { TEAM_RETROS_EMPTY, TEAM_RETROS_TITLE } from "@/convex/retroCopy";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
 import { toast } from "@/lib/toast";
 
@@ -56,9 +58,10 @@ async function run(fn: () => Promise<unknown>, fallback: string): Promise<boolea
 }
 
 /**
- * The team page (spec §5, §18.1), members only: members with roles, the
- * invite link, the retro-defaults panel, New retro, and admin-only Delete
- * team. Retro history, action items and export arrive with #288/#289.
+ * The team page (spec §5, §18.1), members only: the Team's retros in
+ * creation order, members with roles, the invite link, the retro-defaults
+ * panel, New retro, and admin-only Delete team. The history row, action
+ * items and export arrive with #299.
  */
 export function TeamContent() {
   const params = useParams();
@@ -67,6 +70,7 @@ export function TeamContent() {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
 
   const team = useQuery(api.teams.get, isAuthenticated ? { teamId } : "skip");
+  const retros = useQuery(api.retro.listForTeam, isAuthenticated ? { teamId } : "skip");
 
   const rename = useMutation(api.teams.rename);
   const rotateInvite = useMutation(api.teams.rotateInvite);
@@ -188,6 +192,22 @@ export function TeamContent() {
               New retro
             </Button>
           </div>
+
+          {/* Retros (spec §5): the Team's history in creation order */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{TEAM_RETROS_TITLE}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {retros === undefined ? (
+                <div className="h-10 animate-pulse rounded-lg bg-muted" />
+              ) : retros.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{TEAM_RETROS_EMPTY}</p>
+              ) : (
+                <RetroRows rows={retros} />
+              )}
+            </CardContent>
+          </Card>
 
           {/* Members */}
           <Card>

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -5,6 +5,7 @@ import { ReactFlow, ReactFlowProvider, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
+import { currentStageOf } from "@/convex/model/retro";
 import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
 import { layoutZones } from "./zones";
@@ -33,8 +34,7 @@ const nodeTypes: NodeTypes = { zone: PromptZoneNodeView };
  * their tickets.
  */
 export function RetroBoard({ name, retro, team, menu, banner }: RetroBoardProps) {
-  const currentStage =
-    retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
+  const currentStage = currentStageOf(retro);
 
   // The page is titled by the retro's name (spec §18.1). Set here rather than
   // in the route's metadata, which would have to fetch the room server-side

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { ReactFlow, ReactFlowProvider, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
-import { RetroHeader } from "./retro-header";
+import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
 import { layoutZones } from "./zones";
 
@@ -13,6 +13,12 @@ interface RetroBoardProps {
   /** The room shell's name; the board reads nothing else from it. */
   name: string;
   retro: Doc<"retros">;
+  /** The Team that keeps the retro (ADR-0008); undefined for a teamless one. */
+  team?: RetroTeam;
+  /** The header's menu, for attendees. */
+  menu?: ReactNode;
+  /** A line under the header: the non-attending Team reader's (ADR-0009). */
+  banner?: ReactNode;
 }
 
 // Outside the component so React Flow sees one stable object.
@@ -26,7 +32,7 @@ const nodeTypes: NodeTypes = { zone: PromptZoneNodeView };
  * drawn from the stamped format; cards, clusters and the hand arrive with
  * their tickets.
  */
-export function RetroBoard({ name, retro }: RetroBoardProps) {
+export function RetroBoard({ name, retro, team, menu, banner }: RetroBoardProps) {
   const currentStage =
     retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
 
@@ -62,7 +68,10 @@ export function RetroBoard({ name, retro }: RetroBoardProps) {
         name={name}
         stageKind={currentStage.kind}
         collectUntil={retro.collectUntil}
+        team={team}
+        menu={menu}
       />
+      {banner}
       <div className="min-h-0 flex-1">
         <ReactFlowProvider>
           <ReactFlow

--- a/src/components/retro/retro-header.test.tsx
+++ b/src/components/retro/retro-header.test.tsx
@@ -1,12 +1,18 @@
 /**
  * The board header (spec §5, §7, §19): the retro's name, the stage pill
- * showing the shared stage, and the write-time disclosure — the teamless
- * line here, the team line once #289 stamps a Team.
+ * showing the shared stage, and the write-time disclosure — the team line
+ * linking to the team page on a team retro, the teamless line otherwise.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
 import { RetroHeader } from "./retro-header";
-import { TEAMLESS_DISCLOSURE, STAGE_LABELS } from "@/convex/retroCopy";
+import { TEAMLESS_DISCLOSURE, STAGE_LABELS, keptByTeam } from "@/convex/retroCopy";
 
 afterEach(cleanup);
 
@@ -15,15 +21,35 @@ describe("RetroHeader", () => {
     render(<RetroHeader name="Sprint 12" stageKind="collect" />);
     expect(screen.getByRole("heading", { name: "Sprint 12" })).toBeTruthy();
     expect(screen.getByText(TEAMLESS_DISCLOSURE)).toBeTruthy();
+    expect(screen.getByTestId("disclosure").getAttribute("data-kept")).toBe("none");
+    expect(screen.queryByRole("link")).toBeNull();
     const pill = screen.getByTestId("stage-pill");
     expect(pill.textContent).toContain(STAGE_LABELS.collect);
     expect(pill.getAttribute("data-stage")).toBe("collect");
   });
 
-  it("shows the cards-due date only when one is set", () => {
+  it("on a team retro, the team line links to the team page", () => {
+    render(
+      <RetroHeader name="R" stageKind="group" team={{ _id: "team-1" as never, name: "Acme Squad" }} />
+    );
+    const link = screen.getByRole("link", { name: keptByTeam("Acme Squad") });
+    expect(link.getAttribute("href")).toBe("/team/team-1");
+    expect(screen.getByTestId("disclosure").getAttribute("data-kept")).toBe("team");
+    expect(screen.queryByText(TEAMLESS_DISCLOSURE)).toBeNull();
+  });
+
+  it("shows the cards-due date only when one is set, and renders the menu slot", () => {
     const { rerender } = render(<RetroHeader name="R" stageKind="collect" />);
     expect(screen.queryByTestId("collect-until")).toBeNull();
-    rerender(<RetroHeader name="R" stageKind="collect" collectUntil={Date.UTC(2026, 8, 10)} />);
+    rerender(
+      <RetroHeader
+        name="R"
+        stageKind="collect"
+        collectUntil={Date.UTC(2026, 8, 10)}
+        menu={<button>Menu</button>}
+      />
+    );
     expect(screen.getByTestId("collect-until").textContent).toMatch(/Cards due/);
+    expect(screen.getByRole("button", { name: "Menu" })).toBeTruthy();
   });
 });

--- a/src/components/retro/retro-header.tsx
+++ b/src/components/retro/retro-header.tsx
@@ -1,22 +1,35 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
 import { format } from "date-fns";
 import { StagePill } from "./stage-pill";
-import { TEAMLESS_DISCLOSURE, collectUntilLine } from "@/convex/retroCopy";
+import { TEAMLESS_DISCLOSURE, collectUntilLine, keptByTeam } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
+import type { Id } from "@/convex/_generated/dataModel";
+
+/** The owning Team as the board sees it: enough for the disclosure's link. */
+export interface RetroTeam {
+  _id: Id<"teams">;
+  name: string;
+}
 
 interface RetroHeaderProps {
   name: string;
   stageKind: StageKind;
   /** Advisory cards-due date (ADR-0020); shown, never enforced. */
   collectUntil?: number;
+  /** The Team that keeps the retro; undefined for a teamless one. */
+  team?: RetroTeam;
+  /** The header's menu (delete, claim, adopt), for attendees. */
+  menu?: ReactNode;
 }
 
 /**
  * The board header (spec §5, §19): the retro's name, the stage pill and the
- * write-time disclosure, read before the first card is typed. A teamless
- * retro carries the teamless line; the team line and its link to the team
- * page arrive with team retros (#289).
+ * write-time disclosure, read before the first card is typed. A team retro
+ * carries the team line, which doubles as the link to the team page
+ * (ADR-0008); a teamless retro carries the teamless line.
  */
-export function RetroHeader({ name, stageKind, collectUntil }: RetroHeaderProps) {
+export function RetroHeader({ name, stageKind, collectUntil, team, menu }: RetroHeaderProps) {
   return (
     <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b bg-white px-4 py-2 dark:bg-surface-1">
       <h1 className="truncate text-base font-semibold">{name}</h1>
@@ -26,9 +39,20 @@ export function RetroHeader({ name, stageKind, collectUntil }: RetroHeaderProps)
           {collectUntilLine(format(collectUntil, "d MMM"))}
         </span>
       )}
-      <p className="basis-full text-xs text-muted-foreground sm:ml-auto sm:basis-auto">
-        {TEAMLESS_DISCLOSURE}
+      <p
+        data-testid="disclosure"
+        data-kept={team ? "team" : "none"}
+        className="basis-full text-xs text-muted-foreground sm:ml-auto sm:basis-auto"
+      >
+        {team ? (
+          <Link href={`/team/${team._id}`} className="underline-offset-4 hover:underline">
+            {keptByTeam(team.name)}
+          </Link>
+        ) : (
+          TEAMLESS_DISCLOSURE
+        )}
       </p>
+      {menu}
     </header>
   );
 }

--- a/src/components/retro/retro-join-form.test.tsx
+++ b/src/components/retro/retro-join-form.test.tsx
@@ -21,7 +21,7 @@ vi.mock("next/link", () => ({
 }));
 
 import { RetroJoinForm } from "./retro-join-form";
-import { JOIN_DENIED_PERMANENT } from "@/convex/retroCopy";
+import { JOIN_DENIED_PERMANENT, joinDeniedTeam } from "@/convex/retroCopy";
 import type { Id } from "@/convex/_generated/dataModel";
 
 const roomId = "room1" as Id<"rooms">;
@@ -53,6 +53,18 @@ describe("RetroJoinForm", () => {
     expect(screen.getByText(JOIN_DENIED_PERMANENT)).toBeTruthy();
     fireEvent.change(screen.getByLabelText("Your name"), { target: { value: "Ada" } });
     expect((screen.getByRole("button", { name: "Join retro" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("is disabled with the team-members-only copy naming the Team", () => {
+    render(
+      <RetroJoinForm roomId={roomId} roomName="R" joinPolicy="teamMembers" isTeamMember={false} teamName="Acme Squad" />
+    );
+    expect(screen.getByText(joinDeniedTeam("Acme Squad"))).toBeTruthy();
+    expect(screen.getByText("This retro is for members of Acme Squad. Ask an admin for the invite link.")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Your name"), { target: { value: "Ada" } });
+    expect((screen.getByRole("button", { name: "Join retro" }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Join retro" }));
+    expect(mocks.join).not.toHaveBeenCalled();
   });
 
   it("a team member passes every policy", () => {

--- a/src/components/retro/retro-list.test.tsx
+++ b/src/components/retro/retro-list.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * The minimal listing row (spec §16.5): name, resting stage, cards-due
+ * while set, in the order given, each routing to its board.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+import { RetroRows } from "./retro-list";
+import { STAGE_LABELS } from "@/convex/retroCopy";
+
+afterEach(cleanup);
+
+describe("RetroRows", () => {
+  it("renders rows in order with name, stage and the cards-due date, linking to the board", () => {
+    render(
+      <RetroRows
+        rows={[
+          { roomId: "r1" as never, name: "Collecting", stageKind: "collect", collectUntil: Date.UTC(2026, 8, 10), createdAt: 2 },
+          { roomId: "r2" as never, name: "Closed", stageKind: "close", createdAt: 1 },
+        ]}
+      />
+    );
+    const rows = screen.getAllByTestId("retro-row");
+    expect(rows.map((row) => row.getAttribute("data-stage"))).toEqual(["collect", "close"]);
+    expect(rows[0].textContent).toContain("Collecting");
+    expect(rows[0].textContent).toContain(STAGE_LABELS.collect);
+    expect(rows[0].textContent).toMatch(/Cards due/);
+    expect(rows[1].textContent).not.toMatch(/Cards due/);
+    expect(screen.getByRole("link", { name: /Collecting/ }).getAttribute("href")).toBe("/room/r1");
+    expect(screen.getByRole("link", { name: /Closed/ }).getAttribute("href")).toBe("/room/r2");
+  });
+});

--- a/src/components/retro/retro-list.tsx
+++ b/src/components/retro/retro-list.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { format } from "date-fns";
+import { StagePill } from "./stage-pill";
+import { collectUntilLine } from "@/convex/retroCopy";
+import type { RetroListRow } from "@/convex/model/retro";
+
+interface RetroRowsProps {
+  rows: RetroListRow[];
+}
+
+/**
+ * The minimal listing row (spec §16.5): name and resting stage, with the
+ * cards-due date while one is set, routing to the board. Shared by the team
+ * page and `/dashboard/retros` until #299's history row replaces it.
+ */
+export function RetroRows({ rows }: RetroRowsProps) {
+  return (
+    <ul className="divide-y rounded-lg border" data-testid="retro-rows">
+      {rows.map((row) => (
+        <li key={row.roomId} data-testid="retro-row" data-stage={row.stageKind}>
+          <Link
+            href={`/room/${row.roomId}`}
+            className="flex items-center justify-between gap-3 px-3 py-2 transition-colors hover:bg-gray-50 dark:hover:bg-surface-3/50"
+          >
+            <span className="min-w-0 truncate text-sm font-medium">{row.name}</span>
+            <span className="flex shrink-0 items-center gap-3">
+              {row.collectUntil !== undefined && (
+                <span className="text-xs text-muted-foreground">
+                  {collectUntilLine(format(row.collectUntil, "d MMM"))}
+                </span>
+              )}
+              <StagePill kind={row.stageKind} />
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/retro/retro-menu.test.tsx
+++ b/src/components/retro/retro-menu.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * The board header's menu (spec §4.3, §5, §15.2): Delete retro is owner-only
+ * and asks with the counted confirmation; Claim ownership shows for a team
+ * admin who is not the owner; Keep with a team… shows for the owner of a
+ * teamless retro who has a Team, and adopts into the chosen one. Base UI
+ * overlays are mocked at their seams; the wiring through them is under test.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as { fn: string; args: unknown }[],
+  fail: {} as Record<string, string>,
+  counts: { cards: 47, openActions: 3 } as { cards: number; openActions: number } | undefined,
+  push: vi.fn(),
+  toasts: [] as { kind: "success" | "error"; message: string }[],
+}));
+
+vi.mock("convex/react", async () => {
+  const { getFunctionName } = await import("convex/server");
+  return {
+    useQuery: (_ref: unknown, args: unknown) => (args === "skip" ? undefined : mocks.counts),
+    useMutation: (ref: unknown) => {
+      const fn = getFunctionName(ref as never);
+      return async (args: unknown) => {
+        mocks.calls.push({ fn, args });
+        if (mocks.fail[fn]) throw new Error(mocks.fail[fn]);
+      };
+    },
+  };
+});
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (message: string) => mocks.toasts.push({ kind: "success", message }),
+    error: (message: string) => mocks.toasts.push({ kind: "error", message }),
+  },
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render: el, children }: { render: ReactElement; children?: ReactNode }) =>
+    cloneElement(el, undefined, children),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({ children, onClick, disabled, title }: { children?: ReactNode; onClick?: () => void; disabled?: boolean; title?: string }) => (
+    <button role="menuitem" onClick={onClick} disabled={disabled} title={title}>{children}</button>
+  ),
+}));
+vi.mock("@/components/ui/alert-dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    AlertDialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="alertdialog">{children}</div> : null,
+    AlertDialogContent: pass,
+    AlertDialogHeader: pass,
+    AlertDialogFooter: pass,
+    AlertDialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    AlertDialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    AlertDialogCancel: ({ children, disabled }: { children?: ReactNode; disabled?: boolean }) => (
+      <button disabled={disabled}>{children}</button>
+    ),
+    AlertDialogAction: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+      <button onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+  };
+});
+vi.mock("@/components/ui/dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Dialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="dialog">{children}</div> : null,
+    DialogContent: pass,
+    DialogHeader: pass,
+    DialogFooter: pass,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+  };
+});
+
+import { RetroMenu } from "./retro-menu";
+import { deleteRetroConfirm, keptByTeam } from "@/convex/retroCopy";
+
+const roomId = "room-1" as never;
+const acme = { _id: "team-1" as never, name: "Acme Squad" };
+const calledWith = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c) => c.args);
+
+beforeEach(() => {
+  mocks.calls = [];
+  mocks.fail = {};
+  mocks.toasts = [];
+  mocks.counts = { cards: 47, openActions: 3 };
+  mocks.push.mockReset();
+});
+afterEach(cleanup);
+
+describe("RetroMenu — delete", () => {
+  it("the owner sees the counted confirmation, deletes, and leaves for the team page", async () => {
+    render(<RetroMenu roomId={roomId} team={acme} role="owner" isOwnerAbsent={false} myTeams={[{ ...acme, role: "member" }]} />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete retro" }));
+    const dialog = within(screen.getByRole("alertdialog"));
+    expect(dialog.getByText("Delete this retro?")).toBeTruthy();
+    expect(dialog.getByText(deleteRetroConfirm(47, 3))).toBeTruthy();
+    expect(dialog.getByText(/47 cards, 3 open action items and its history are removed permanently\. This cannot be undone\./)).toBeTruthy();
+
+    fireEvent.click(dialog.getByRole("button", { name: "Delete retro" }));
+    await waitFor(() => expect(calledWith("retro:remove")).toEqual([{ roomId }]));
+    expect(mocks.push).toHaveBeenCalledWith("/team/team-1");
+  });
+
+  it("a teamless owner lands on the homepage; singular counts read as singular", async () => {
+    mocks.counts = { cards: 1, openActions: 1 };
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete retro" }));
+    expect(screen.getByText(/1 card, 1 open action item and its history/)).toBeTruthy();
+    fireEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Delete retro" }));
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/"));
+  });
+
+  it("a participant sees Delete retro disabled with the owner-only copy", () => {
+    render(<RetroMenu roomId={roomId} role="participant" isOwnerAbsent={false} myTeams={[]} />);
+    const item = screen.getByRole("menuitem", { name: "Delete retro" }) as HTMLButtonElement;
+    expect(item.disabled).toBe(true);
+    expect(item.title).toBe("Only the owner can do this.");
+  });
+
+  it("a failed delete keeps the confirmation open with the server's copy", async () => {
+    mocks.fail["retro:remove"] = "Room owner has left.";
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete retro" }));
+    fireEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Delete retro" }));
+    await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: "Room owner has left." }));
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+});
+
+describe("RetroMenu — claim", () => {
+  it("a team admin who is not the owner can claim; the server's refusal surfaces", async () => {
+    mocks.fail["retro:claim"] = "The owner is still here — ask them to transfer ownership.";
+    render(<RetroMenu roomId={roomId} team={acme} role="participant" isOwnerAbsent={false} myTeams={[{ ...acme, role: "admin" }]} />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Claim ownership" }));
+    await waitFor(() => expect(calledWith("retro:claim")).toEqual([{ roomId }]));
+    expect(mocks.toasts.at(-1)).toEqual({ kind: "error", message: "The owner is still here — ask them to transfer ownership." });
+  });
+
+  it("is absent for a team member, for the owner, and on a teamless retro", () => {
+    const { unmount } = render(<RetroMenu roomId={roomId} team={acme} role="participant" isOwnerAbsent={true} myTeams={[{ ...acme, role: "member" }]} />);
+    expect(screen.queryByRole("menuitem", { name: "Claim ownership" })).toBeNull();
+    unmount();
+    render(<RetroMenu roomId={roomId} team={acme} role="owner" isOwnerAbsent={false} myTeams={[{ ...acme, role: "admin" }]} />);
+    expect(screen.queryByRole("menuitem", { name: "Claim ownership" })).toBeNull();
+    cleanup();
+    render(<RetroMenu roomId={roomId} role="participant" isOwnerAbsent={true} myTeams={[{ ...acme, role: "admin" }]} />);
+    expect(screen.queryByRole("menuitem", { name: "Claim ownership" })).toBeNull();
+  });
+});
+
+describe("RetroMenu — keep with a team", () => {
+  it("the owner of a teamless retro picks one of their Teams and adopts into it", async () => {
+    render(
+      <RetroMenu
+        roomId={roomId}
+        role="owner"
+        isOwnerAbsent={false}
+        myTeams={[{ ...acme, role: "member" }, { _id: "team-2" as never, name: "Beta", role: "admin" }]}
+      />
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Keep with a team…" }));
+    const dialog = within(screen.getByRole("dialog"));
+    const button = dialog.getByRole("button", { name: "Keep with team" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.change(dialog.getByLabelText("Team"), { target: { value: "team-2" } });
+    fireEvent.click(dialog.getByRole("button", { name: "Keep with team" }));
+
+    await waitFor(() => expect(calledWith("retro:adoptIntoTeam")).toEqual([{ roomId, teamId: "team-2" }]));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(mocks.toasts.at(-1)).toEqual({ kind: "success", message: keptByTeam("Beta") });
+  });
+
+  it("is absent on a team retro, for a non-owner, and for someone with no Team", () => {
+    render(<RetroMenu roomId={roomId} team={acme} role="owner" isOwnerAbsent={false} myTeams={[{ ...acme, role: "admin" }]} />);
+    expect(screen.queryByRole("menuitem", { name: "Keep with a team…" })).toBeNull();
+    cleanup();
+    render(<RetroMenu roomId={roomId} role="facilitator" isOwnerAbsent={false} myTeams={[{ ...acme, role: "admin" }]} />);
+    expect(screen.queryByRole("menuitem", { name: "Keep with a team…" })).toBeNull();
+    cleanup();
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} />);
+    expect(screen.queryByRole("menuitem", { name: "Keep with a team…" })).toBeNull();
+  });
+});

--- a/src/components/retro/retro-menu.tsx
+++ b/src/components/retro/retro-menu.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery } from "convex/react";
+import { MoreHorizontal } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { resolve, type MemberRole, type TeamRole } from "@/convex/permissions";
+import {
+  ADOPT_BUTTON,
+  ADOPT_DESCRIPTION,
+  ADOPT_FAILED,
+  ADOPT_MENU_ITEM,
+  ADOPT_TITLE,
+  CLAIMED,
+  CLAIM_FAILED,
+  CLAIM_MENU_ITEM,
+  DELETE_BUTTON,
+  DELETE_FAILED,
+  DELETE_MENU_ITEM,
+  DELETE_TITLE,
+  DELETING_BUTTON,
+  RETRO_DELETED,
+  TEAM_LABEL,
+  deleteRetroConfirm,
+  keptByTeam,
+} from "@/convex/retroCopy";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/lib/toast";
+import type { RetroTeam } from "./retro-header";
+
+/** One of the viewer's Teams, as `teams.listMine` returns it. */
+export interface MyTeam {
+  _id: Id<"teams">;
+  name: string;
+  role: TeamRole;
+}
+
+interface RetroMenuProps {
+  roomId: Id<"rooms">;
+  /** The Team that keeps the retro; undefined for a teamless one. */
+  team?: RetroTeam;
+  /** The viewer's room role. */
+  role: MemberRole;
+  isOwnerAbsent: boolean;
+  /** The viewer's Teams; empty for an anonymous account. */
+  myTeams: MyTeam[];
+}
+
+/**
+ * The board header's menu (spec §4.3, §5, §15.2): the owner's *Delete
+ * retro* behind the counted confirmation; *Claim ownership* for a team
+ * admin who is not the owner (the server decides `owner-present`); *Keep
+ * with a team…* for the owner of a teamless retro who has a Team to give it
+ * to. Every item is a mutation on room-owned state, so the menu renders
+ * only for an attendee.
+ */
+export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroMenuProps) {
+  const router = useRouter();
+  const remove = useMutation(api.retro.remove);
+  const claim = useMutation(api.retro.claim);
+  const adopt = useMutation(api.retro.adoptIntoTeam);
+
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [adoptOpen, setAdoptOpen] = useState(false);
+  const [adoptTeamId, setAdoptTeamId] = useState<string>("");
+  const [isAdopting, setIsAdopting] = useState(false);
+
+  const counts = useQuery(api.retro.deleteCounts, confirmDelete ? { roomId } : "skip");
+
+  // The same decision the guard makes (ADR-0013): visible-but-disabled with
+  // the denial copy, never vanished. `permissions` are irrelevant to an
+  // owner-only verb; the poker defaults satisfy the type.
+  const deleteDecision = resolve(
+    { kind: "relationship", verb: "delete" },
+    { actorRole: role, permissions: { stageFlow: "owner", cardManagement: "owner", actionManagement: "owner", retroSettings: "owner" }, ownerAbsent: isOwnerAbsent, ownerInTeam: false }
+  );
+  const myTeamRole = team ? myTeams.find((t) => t._id === team._id)?.role : undefined;
+  const canClaim = team !== undefined && myTeamRole === "admin" && role !== "owner";
+  const canAdopt = team === undefined && role === "owner" && myTeams.length > 0;
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await remove({ roomId });
+      toast.success(RETRO_DELETED);
+      router.push(team ? `/team/${team._id}` : "/");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : DELETE_FAILED);
+      setIsDeleting(false);
+    }
+  };
+
+  const handleClaim = async () => {
+    try {
+      await claim({ roomId });
+      toast.success(CLAIMED);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : CLAIM_FAILED);
+    }
+  };
+
+  const handleAdopt = async () => {
+    const target = myTeams.find((t) => t._id === adoptTeamId);
+    if (!target) return;
+    setIsAdopting(true);
+    try {
+      await adopt({ roomId, teamId: target._id });
+      setAdoptOpen(false);
+      toast.success(keptByTeam(target.name));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : ADOPT_FAILED);
+    } finally {
+      setIsAdopting(false);
+    }
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={<Button variant="ghost" size="icon-xs" aria-label="Retro menu" />}
+        >
+          <MoreHorizontal className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {canAdopt && (
+            <DropdownMenuItem onClick={() => setAdoptOpen(true)}>{ADOPT_MENU_ITEM}</DropdownMenuItem>
+          )}
+          {canClaim && <DropdownMenuItem onClick={handleClaim}>{CLAIM_MENU_ITEM}</DropdownMenuItem>}
+          <DropdownMenuItem
+            variant="destructive"
+            disabled={!deleteDecision.allowed}
+            title={deleteDecision.allowed ? undefined : deleteDecision.message}
+            onClick={() => setConfirmDelete(true)}
+          >
+            {DELETE_MENU_ITEM}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={confirmDelete} onOpenChange={(open) => !isDeleting && setConfirmDelete(open)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{DELETE_TITLE}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {counts ? deleteRetroConfirm(counts.cards, counts.openActions) : "Counting…"}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting || counts === undefined}
+            >
+              {isDeleting ? DELETING_BUTTON : DELETE_BUTTON}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog open={adoptOpen} onOpenChange={(open) => !isAdopting && setAdoptOpen(open)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{ADOPT_TITLE}</DialogTitle>
+            <DialogDescription>{ADOPT_DESCRIPTION}</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2">
+            <Label htmlFor="adopt-team">{TEAM_LABEL}</Label>
+            <select
+              id="adopt-team"
+              value={adoptTeamId}
+              onChange={(e) => setAdoptTeamId(e.target.value)}
+              className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+            >
+              <option value="">Choose a team</option>
+              {myTeams.map((t) => (
+                <option key={t._id} value={t._id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setAdoptOpen(false)} disabled={isAdopting}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleAdopt} disabled={!adoptTeamId || isAdopting}>
+              {ADOPT_BUTTON}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/retro/retro-menu.tsx
+++ b/src/components/retro/retro-menu.tsx
@@ -6,9 +6,10 @@ import { useMutation, useQuery } from "convex/react";
 import { MoreHorizontal } from "lucide-react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { resolve, type MemberRole, type TeamRole } from "@/convex/permissions";
+import { DEFAULT_RETRO_PERMISSIONS, resolve, type MemberRole, type TeamRole } from "@/convex/permissions";
 import {
   ADOPT_BUTTON,
+  ADOPT_CHOOSE_TEAM,
   ADOPT_DESCRIPTION,
   ADOPT_FAILED,
   ADOPT_MENU_ITEM,
@@ -17,6 +18,7 @@ import {
   CLAIM_FAILED,
   CLAIM_MENU_ITEM,
   DELETE_BUTTON,
+  DELETE_COUNTING,
   DELETE_FAILED,
   DELETE_MENU_ITEM,
   DELETE_TITLE,
@@ -96,11 +98,11 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
   const counts = useQuery(api.retro.deleteCounts, confirmDelete ? { roomId } : "skip");
 
   // The same decision the guard makes (ADR-0013): visible-but-disabled with
-  // the denial copy, never vanished. `permissions` are irrelevant to an
-  // owner-only verb; the poker defaults satisfy the type.
+  // the denial copy, never vanished. An owner-only verb never reads the
+  // category levels, so the retro defaults stand in for the room's.
   const deleteDecision = resolve(
     { kind: "relationship", verb: "delete" },
-    { actorRole: role, permissions: { stageFlow: "owner", cardManagement: "owner", actionManagement: "owner", retroSettings: "owner" }, ownerAbsent: isOwnerAbsent, ownerInTeam: false }
+    { actorRole: role, permissions: DEFAULT_RETRO_PERMISSIONS, ownerAbsent: isOwnerAbsent, ownerInTeam: false }
   );
   const myTeamRole = team ? myTeams.find((t) => t._id === team._id)?.role : undefined;
   const canClaim = team !== undefined && myTeamRole === "admin" && role !== "owner";
@@ -110,6 +112,9 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
     setIsDeleting(true);
     try {
       await remove({ roomId });
+      // Drop the counts subscription before the room's absence reaches it:
+      // its guard would throw for a room that no longer exists.
+      setConfirmDelete(false);
       toast.success(RETRO_DELETED);
       router.push(team ? `/team/${team._id}` : "/");
     } catch (error) {
@@ -171,7 +176,7 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
           <AlertDialogHeader>
             <AlertDialogTitle>{DELETE_TITLE}</AlertDialogTitle>
             <AlertDialogDescription>
-              {counts ? deleteRetroConfirm(counts.cards, counts.openActions) : "Counting…"}
+              {counts ? deleteRetroConfirm(counts.cards, counts.openActions) : DELETE_COUNTING}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -201,7 +206,7 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
               onChange={(e) => setAdoptTeamId(e.target.value)}
               className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
             >
-              <option value="">Choose a team</option>
+              <option value="">{ADOPT_CHOOSE_TEAM}</option>
               {myTeams.map((t) => (
                 <option key={t._id} value={t._id}>
                   {t.name}

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -29,7 +29,7 @@ interface NewTeamDialogProps {
    * Called with the new Team instead of opening its page — the create form's
    * picker keeps the person where they were and selects the Team.
    */
-  onCreated?: (teamId: Id<"teams">) => void;
+  onCreated?: (team: { _id: Id<"teams">; name: string }) => void;
 }
 
 /**
@@ -61,7 +61,7 @@ export function NewTeamDialog({ open, onOpenChange, returnTo, onCreated }: NewTe
       const teamId = await createTeam({ name: trimmed });
       close(false);
       if (onCreated) {
-        onCreated(teamId);
+        onCreated({ _id: teamId, name: trimmed });
       } else {
         router.push(`/team/${teamId}`);
       }

--- a/src/components/team/new-team-dialog.tsx
+++ b/src/components/team/new-team-dialog.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useMutation } from "convex/react";
 import Link from "next/link";
 import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
 import { SIGN_IN_TO_CREATE } from "@/convex/teamCopy";
 import { useAuth } from "@/components/auth/auth-provider";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,11 @@ interface NewTeamDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Where the sign-in link returns to for an anonymous account. */
   returnTo: string;
+  /**
+   * Called with the new Team instead of opening its page — the create form's
+   * picker keeps the person where they were and selects the Team.
+   */
+  onCreated?: (teamId: Id<"teams">) => void;
 }
 
 /**
@@ -31,7 +37,7 @@ interface NewTeamDialogProps {
  * admin; an anonymous account is told to sign in first. The server enforces
  * the same rule, so this dialog only shapes the copy.
  */
-export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogProps) {
+export function NewTeamDialog({ open, onOpenChange, returnTo, onCreated }: NewTeamDialogProps) {
   const router = useRouter();
   const { accountType } = useAuth();
   const createTeam = useMutation(api.teams.create);
@@ -54,7 +60,11 @@ export function NewTeamDialog({ open, onOpenChange, returnTo }: NewTeamDialogPro
     try {
       const teamId = await createTeam({ name: trimmed });
       close(false);
-      router.push(`/team/${teamId}`);
+      if (onCreated) {
+        onCreated(teamId);
+      } else {
+        router.push(`/team/${teamId}`);
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to create team");
     } finally {


### PR DESCRIPTION
Closes #289

A team member creates a retro **kept by their Team**, and a Team's retros become reachable and recoverable. Spec `docs/spec/retro.md` §4.3, §4.4, §5, §6.1, §15.2, §16.5, §18.1, §19; ADR-0008, ADR-0013, ADR-0019.

## Backend

- `retro.create` takes an optional `teamId`: the Team's retro defaults (attribution, join policy, permission levels) are copied by value, `retained: true`, the stage seed keeps `review`.
- `retro.adoptIntoTeam`: the room owner who is in the Team sets the set-once `teamId` and `retained`, and stamps `teamId` onto the room's existing action items. Stages, join policy, attribution and permissions are never rewritten.
- `retro.claim`: a team admin attending a team retro whose owner is absent or out of the Team takes ownership; the previous owner's membership becomes `participant`.
- `retro.remove`: owner-level hard delete through the cascade, first step inline. `retro.deleteCounts` feeds the confirmation copy. Refuses a poker room.
- `retro.lastFormat` (pre-selection), `retro.listForTeam` (creation order), `retro.listMine` (attended, grouped by Team, `collect` first, teamless under "No team").
- `rooms.get` exposes the owning Team's name. Adopt and claim bump the activity chokepoint.

## Client

- `/retro/new`: team picker with *New team*, hidden for anonymous accounts, `?team=` pre-selection, the Team's last format first in the library, the write-time disclosure on the form.
- Board header: team disclosure linking to the team page; a menu with *Delete retro*, *Claim ownership* and *Keep with a team*.
- Room page: a Team member without attendance reads the board with a join offer and no membership row is written; the join form names the Team in its denial copy.
- Team page and `/dashboard/retros` list retros with one minimal row (name, resting stage, cards-due) until #299.

## Tests

- `convex/teamRetro.test.ts`: defaults copy and immutability, adoption invariants and the action-row stamp, claim in its four cases plus `owner-present`, delete cascade and the claim-then-delete route, join refusal for both policies, team-member read without attendance and without a membership write, pre-selection, both listings' order.
- `roomActivity.test.ts`: adopt and claim bump.
- jsdom: join form's disabled state and copy for both denial reasons, header disclosure, menu, create form picker and pre-selection, room page reader branch, both listings.

## Notes

- Spec §16.5 says the team page lists `collect` retros first; the issue says creation order. The issue is followed.
- The adoption dialog and the team-reader banner are not in the ticket but make the mutations reachable; the banner copy is new and not in the §19 register.
- "Edited or not" pre-selection falls back to the default when the last format is not a library one (#290); "You haven't added a card yet" needs cards (#291).

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd
