### PR TITLE
feat(retro): stages — advance, reveal toggle, timebox, readiness, roster, own view (#290)

### DIFF
--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -6,10 +6,13 @@ import { validateRoomName, updateRoomActivity } from "./rooms";
 import { deleteRoomAggregateChunk } from "./roomAggregate";
 import { listTeamsForUser } from "./teams";
 import {
+  currentStageOf,
   findFormat,
   seedStages,
   stampFormat,
+  type StageEntry,
   type StageKind,
+  type Visibility,
   type StampedFormat,
 } from "./retroFormats";
 import {
@@ -17,6 +20,9 @@ import {
   NO_TEAM_GROUP,
   NOT_A_RETRO,
   ONLY_OWNER_CAN_ADOPT,
+  NOT_CURRENT_STAGE,
+  STAGE_ENTRY_NOT_FOUND,
+  TIMEBOX_INVALID,
   UNKNOWN_FORMAT,
 } from "../retroCopy";
 import { refusal } from "./refusal";
@@ -121,11 +127,92 @@ export async function getBoard(
   ctx: QueryCtx,
   roomId: Id<"rooms">
 ): Promise<Doc<"retros">> {
+  return requireRetro(ctx, roomId);
+}
+
+/** The retros row of a room, or a `missing` refusal for a poker room. */
+async function requireRetro(ctx: QueryCtx, roomId: Id<"rooms">): Promise<Doc<"retros">> {
   const retro = await getRetro(ctx, roomId);
   if (!retro) {
     throw refusal("missing", NOT_A_RETRO);
   }
   return retro;
+}
+
+// --- Stages (ADR-0010, spec §7) ---
+
+/**
+ * Advance: the shared pointer moves to any entry, forward or back, and the
+ * entered-at instant is re-stamped so the advisory timebox counts from it.
+ * It destroys, finalises and hides nothing beyond the read-time projection;
+ * there is no stage guard and nothing advances itself. The walk snapshot on
+ * entering a `discuss` entry (spec §12.1) joins with the walk ticket.
+ */
+export async function advance(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; toStageId: string }
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (!retro.stages.some((stage) => stage.id === args.toStageId)) {
+    throw refusal("missing", STAGE_ENTRY_NOT_FOUND);
+  }
+  await ctx.db.patch(retro._id, {
+    currentStageId: args.toStageId,
+    currentStageEnteredAt: Date.now(),
+  });
+  await updateRoomActivity(ctx, args.roomId);
+}
+
+/**
+ * Patch one entry of the stage list in place; the act on the current entry
+ * that the two in-the-moment `stageFlow` mutations share. Refused with
+ * `stage` when the id is not the shared pointer's: an act on another entry
+ * is a structural edit and belongs to `retroSettings` (spec §23.1).
+ */
+async function patchCurrentStage(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; stageId: string },
+  patch: (entry: StageEntry) => StageEntry
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (args.stageId !== retro.currentStageId) {
+    throw refusal("stage", NOT_CURRENT_STAGE);
+  }
+  await ctx.db.patch(retro._id, {
+    stages: retro.stages.map((entry) => (entry.id === args.stageId ? patch(entry) : entry)),
+  });
+  await updateRoomActivity(ctx, args.roomId);
+}
+
+/**
+ * The in-place reveal toggle (ADR-0015): flips the current entry's reveal
+ * policy either way, covering "show the board without moving on" and "hide
+ * it again". A `stageFlow` act; the projection follows on the next read.
+ */
+export async function setCardsVisible(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; stageId: string; value: Visibility }
+): Promise<void> {
+  await patchCurrentStage(ctx, args, (entry) => ({ ...entry, cardsVisible: args.value }));
+}
+
+/**
+ * The advisory timebox on the current entry (ADR-0010): whole minutes, or
+ * none. The pill counts it down; at zero it says so and nothing else
+ * happens. A `stageFlow` act.
+ */
+export async function setTimebox(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; stageId: string; minutes?: number }
+): Promise<void> {
+  const { minutes } = args;
+  if (minutes !== undefined && (!Number.isInteger(minutes) || minutes <= 0)) {
+    throw refusal("forbidden", TIMEBOX_INVALID);
+  }
+  await patchCurrentStage(ctx, args, (entry) => {
+    const { timeboxMinutes: _dropped, ...rest } = entry;
+    return minutes === undefined ? rest : { ...rest, timeboxMinutes: minutes };
+  });
 }
 
 /**
@@ -272,13 +359,6 @@ export interface RetroListRow {
   stageKind: StageKind;
   collectUntil?: number;
   createdAt: number;
-}
-
-/** The entry the shared pointer names; the first entry if the pointer dangles. */
-export function currentStageOf(
-  retro: Pick<Doc<"retros">, "stages" | "currentStageId">
-): Doc<"retros">["stages"][number] {
-  return retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
 }
 
 function toRow(room: Doc<"rooms">, retro: Doc<"retros">): RetroListRow {

--- a/convex/model/retroFormats.ts
+++ b/convex/model/retroFormats.ts
@@ -68,6 +68,14 @@ export function newStageEntryId(): string {
 
 export const DEFAULT_VOTE_BUDGET = 5;
 
+/** The entry the shared pointer names; the first entry if the pointer dangles. */
+export function currentStageOf(retro: {
+  stages: readonly StageEntry[];
+  currentStageId: string;
+}): StageEntry {
+  return retro.stages.find((stage) => stage.id === retro.currentStageId) ?? retro.stages[0];
+}
+
 function prompts(
   entries: ReadonlyArray<readonly [id: string, label: string, hint: string, color: RetroTint]>
 ): FormatPrompt[] {

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -29,6 +29,28 @@ export const heartbeat = mutation({
   },
 });
 
+/**
+ * Readiness (ADR-0010, spec §7): a person's "I am done with this stage"
+ * signal, held in the presence payload as `{ stageId, ready }` and never in
+ * a table. One write per state change; a reader treats a payload whose
+ * `stageId` is not the current entry as absent, so an advance clears every
+ * signal with no write at all. The same guard as the heartbeat: the caller
+ * must be this room member acting as themselves.
+ */
+export const setReadiness = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    userId: v.id("users"),
+    stageId: v.string(),
+    ready: v.boolean(),
+  },
+  handler: async (ctx, { roomId, userId, stageId, ready }) => {
+    await requireActingUser(ctx, roomId, userId, "Cannot set readiness as another user");
+    await presence.updateRoomUser(ctx, roomId, userId, { stageId, ready });
+    return null;
+  },
+});
+
 export const list = query({
   args: { roomToken: v.string() },
   handler: async (ctx, { roomToken }) => {

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import * as Retro from "./model/retro";
+import { visibilityValidator } from "./schema";
 import { refusal } from "./model/refusal";
 import { ROOM_NOT_FOUND } from "./retroCopy";
 import {
@@ -41,6 +42,35 @@ export const board = query({
   handler: async (ctx, args) => {
     await requireRoomReader(ctx, args.roomId);
     return await Retro.getBoard(ctx, args.roomId);
+  },
+});
+
+// --- Stages (ADR-0010, spec §7) ---
+
+/** Move the shared pointer to any entry, forward or back (`stageFlow`). */
+export const advance = mutation({
+  args: { roomId: v.id("rooms"), toStageId: v.string() },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
+    await Retro.advance(ctx, args);
+  },
+});
+
+/** The in-place reveal toggle on the current entry (`stageFlow`, ADR-0015). */
+export const setCardsVisible = mutation({
+  args: { roomId: v.id("rooms"), stageId: v.string(), value: visibilityValidator },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
+    await Retro.setCardsVisible(ctx, args);
+  },
+});
+
+/** The current entry's advisory timebox, in whole minutes; omit to clear (`stageFlow`). */
+export const setTimebox = mutation({
+  args: { roomId: v.id("rooms"), stageId: v.string(), minutes: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
+    await Retro.setTimebox(ctx, args);
   },
 });
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -89,6 +89,50 @@ export const STAGE_LABELS: Record<
 
 export const STAGE_PILL_LABEL = "Stage";
 
+/**
+ * Each kind's empty state (ADR-0010): entering a stage with nothing in it
+ * renders an explanation, never a lock.
+ */
+export const STAGE_EMPTY: Record<
+  "collect" | "review" | "group" | "vote" | "discuss" | "close",
+  string
+> = {
+  collect: "No cards yet. Every prompt has a zone; write into any of them.",
+  review: "No open actions from earlier retros",
+  group: "Nothing to group yet. Cards written in Collect show up here.",
+  vote: "Nothing to vote on yet. Cards and groups show up here once written.",
+  discuss: "Nothing to discuss yet. Topics show up here once cards are written.",
+  close: "No action items yet.",
+};
+export const TIMEBOX_OVER = "Timebox over";
+
+// --- Stage navigation (spec §7) ---
+
+export const BACK_TO_TEAM = "Back to the team";
+export const NEXT_STAGE = "Next stage";
+export const PREVIOUS_STAGE = "Previous stage";
+export const BRING_EVERYONE_HERE = "Bring everyone here";
+export const SHOW_CARDS = "Show cards";
+export const HIDE_CARDS = "Hide cards";
+export const TIMEBOX_LABEL = "Timebox (minutes)";
+export const STAGES_NAV_LABEL = "Stages";
+export const STAGE_ACT_FAILED = "That did not go through. Try again.";
+
+// --- Roster and readiness (spec §7) ---
+
+export const ROSTER_TITLE = "People";
+export const READY_LABEL = "Ready";
+export const READY_TOGGLE_LABEL = "I'm ready";
+
+/** An in-the-moment act (`setCardsVisible`, the timebox) naming an entry that is not the shared pointer's. */
+export const NOT_CURRENT_STAGE = "Only the current stage can be changed here";
+
+/** `setTimebox` with anything but a positive whole number of minutes. */
+export const TIMEBOX_INVALID = "Timebox must be a whole number of minutes";
+
+/** A stage act naming an entry the list does not carry. */
+export const STAGE_ENTRY_NOT_FOUND = "That stage is no longer in this retro";
+
 // --- Board (spec §16.5, §19) ---
 
 export const collectUntilLine = (date: string) => `Cards due ${date}`;

--- a/convex/retroStages.test.ts
+++ b/convex/retroStages.test.ts
@@ -1,0 +1,154 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+
+// Stages (ADR-0010, spec §7): advance moves the shared pointer to any entry,
+// forward or back, re-stamps `currentStageEnteredAt`, and is `stageFlow`.
+// The in-place reveal toggle and the timebox act on the current entry only.
+// Nothing here forbids by stage; every act is a person's.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string) => seedNamedUser(t, authUserId, authUserId);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+/** An owner and a participant in a fresh teamless retro. */
+async function seedRetro(t: T) {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, {
+    name: "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+  });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  const retro = await retroRow(t, roomId);
+  return { roomId, stages: retro.stages };
+}
+
+describe("retro.advance", () => {
+  it("is refused for a participant at defaults, and for an entry the list does not carry", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+
+    await expect(
+      as(t, "guest").mutation(api.retro.advance, { roomId, toStageId: stages[1].id })
+    ).rejects.toThrow("Only facilitators and the owner");
+    await expect(
+      as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: "nope" })
+    ).rejects.toThrow("That stage is no longer in this retro");
+    expect((await retroRow(t, roomId)).currentStageId).toBe(stages[0].id);
+  });
+
+  it("moves the shared pointer forward and back and re-stamps the entered-at instant", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+    const before = (await retroRow(t, roomId)).currentStageEnteredAt;
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[3].id });
+    let retro = await retroRow(t, roomId);
+    expect(retro.currentStageId).toBe(stages[3].id);
+    expect(retro.currentStageEnteredAt).toBeGreaterThanOrEqual(before);
+    const enteredThird = retro.currentStageEnteredAt;
+
+    // Back the stamp up so the re-stamp is observable within one tick.
+    await t.run((ctx) => ctx.db.patch(retro._id, { currentStageEnteredAt: enteredThird - 5_000 }));
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[0].id });
+    retro = await retroRow(t, roomId);
+    expect(retro.currentStageId).toBe(stages[0].id);
+    expect(retro.currentStageEnteredAt).toBeGreaterThan(enteredThird - 5_000);
+  });
+});
+
+describe("retro.setCardsVisible", () => {
+  it("flips the current entry's reveal policy in place, both ways", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+    expect(stages[0]).toMatchObject({ kind: "collect", cardsVisible: "hidden" });
+
+    await as(t, "owner").mutation(api.retro.setCardsVisible, {
+      roomId,
+      stageId: stages[0].id,
+      value: "visible",
+    });
+    expect((await retroRow(t, roomId)).stages[0].cardsVisible).toBe("visible");
+
+    await as(t, "owner").mutation(api.retro.setCardsVisible, {
+      roomId,
+      stageId: stages[0].id,
+      value: "hidden",
+    });
+    const retro = await retroRow(t, roomId);
+    expect(retro.stages[0].cardsVisible).toBe("hidden");
+    // Nothing else on the list moved.
+    expect(retro.stages.slice(1)).toEqual(stages.slice(1));
+  });
+
+  it("refuses any stage id other than the current entry, and a participant at defaults", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+
+    await expect(
+      as(t, "owner").mutation(api.retro.setCardsVisible, {
+        roomId,
+        stageId: stages[2].id,
+        value: "hidden",
+      })
+    ).rejects.toThrow("Only the current stage can be changed here");
+    await expect(
+      as(t, "guest").mutation(api.retro.setCardsVisible, {
+        roomId,
+        stageId: stages[0].id,
+        value: "visible",
+      })
+    ).rejects.toThrow("Only facilitators and the owner");
+    expect((await retroRow(t, roomId)).stages).toEqual(stages);
+  });
+});
+
+describe("retro.setTimebox", () => {
+  it("sets and clears the current entry's advisory timebox", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+
+    await as(t, "owner").mutation(api.retro.setTimebox, {
+      roomId,
+      stageId: stages[0].id,
+      minutes: 10,
+    });
+    expect((await retroRow(t, roomId)).stages[0].timeboxMinutes).toBe(10);
+
+    await as(t, "owner").mutation(api.retro.setTimebox, { roomId, stageId: stages[0].id });
+    const retro = await retroRow(t, roomId);
+    expect(retro.stages[0].timeboxMinutes).toBeUndefined();
+    // The stage did not move: a timebox never fires an advance (ADR-0010).
+    expect(retro.currentStageId).toBe(stages[0].id);
+  });
+
+  it("refuses another entry, a non-positive value and a participant at defaults", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+
+    await expect(
+      as(t, "owner").mutation(api.retro.setTimebox, { roomId, stageId: stages[1].id, minutes: 5 })
+    ).rejects.toThrow("Only the current stage can be changed here");
+    await expect(
+      as(t, "owner").mutation(api.retro.setTimebox, { roomId, stageId: stages[0].id, minutes: 0 })
+    ).rejects.toThrow("Timebox must be a whole number of minutes");
+    await expect(
+      as(t, "guest").mutation(api.retro.setTimebox, { roomId, stageId: stages[0].id, minutes: 5 })
+    ).rejects.toThrow("Only facilitators and the owner");
+  });
+});

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -541,6 +541,25 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     await expectBumped(t, roomId, stale);
   });
 
+  it("advance, setCardsVisible and setTimebox bump (spec §7)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t, false);
+    const retro = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const acts = [
+      () => as(t, "auth-member").mutation(api.retro.advance, { roomId, toStageId: retro.stages[1].id }),
+      () => as(t, "auth-member").mutation(api.retro.setCardsVisible, { roomId, stageId: retro.stages[1].id, value: "hidden" }),
+      () => as(t, "auth-member").mutation(api.retro.setTimebox, { roomId, stageId: retro.stages[1].id, minutes: 5 }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+  });
+
   it("claim bumps", async () => {
     const t = convexTest(schema, modules);
     const { roomId, memberId, stale } = await seedTeamRetro(t, true);

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -11,16 +11,31 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 const mocks = vi.hoisted(() => ({
   queries: {} as Record<string, unknown>,
   join: vi.fn(),
+  mutations: [] as { fn: string; args: unknown }[],
+  presenceCalls: [] as unknown[][],
   auth: { authUserId: "auth-1", isLoading: false, isAuthenticated: true, accountType: "anonymous" as string },
 }));
 
 vi.mock("@/convex/_generated/api", () => ({
-  api: { retro: { board: "retro.board" }, teams: { listMine: "teams.listMine" } },
+  api: {
+    retro: { board: "retro.board", advance: "retro.advance", setCardsVisible: "retro.setCardsVisible", setTimebox: "retro.setTimebox" },
+    teams: { listMine: "teams.listMine" },
+    presence: { setReadiness: "presence.setReadiness" },
+  },
 }));
 vi.mock("convex/react", () => ({
   useQuery: (ref: string, args: unknown) => (args === "skip" ? undefined : mocks.queries[ref]),
-  useMutation: () => mocks.join,
+  useMutation: (ref: string) => async (args: unknown) => {
+    mocks.mutations.push({ fn: ref, args });
+  },
 }));
+vi.mock("@convex-dev/presence/react", () => ({
+  default: (...args: unknown[]) => {
+    mocks.presenceCalls.push(args);
+    return [{ userId: "user1", online: true, lastDisconnected: 0 }];
+  },
+}));
+vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => mocks.auth }));
 vi.mock("@/components/retro/retro-join-form", () => ({
   RetroJoinForm: ({ roomName, teamName, isTeamMember }: { roomName: string; teamName?: string; isTeamMember: boolean }) => (
@@ -30,11 +45,13 @@ vi.mock("@/components/retro/retro-join-form", () => ({
   ),
 }));
 vi.mock("@/components/retro/retro-board", () => ({
-  RetroBoard: ({ retro, team, menu, banner }: { retro: { currentStageId: string }; team?: { name: string }; menu?: React.ReactNode; banner?: React.ReactNode }) => (
-    <div data-testid="board" data-team={team?.name}>
+  RetroBoard: ({ retro, team, menu, banner, viewer }: { retro: { currentStageId: string }; team?: { name: string }; menu?: React.ReactNode; banner?: React.ReactNode; viewer?: { userId: string; onSetReady: (ready: boolean) => void; controls: { onAdvance: (id: string) => void; stageFlow: { allowed: boolean } } } }) => (
+    <div data-testid="board" data-team={team?.name} data-viewer={viewer?.userId} data-stage-flow={String(viewer?.controls.stageFlow.allowed)}>
       {retro.currentStageId}
       {menu}
       {banner}
+      {viewer && <button onClick={() => viewer.onSetReady(true)}>ready</button>}
+      {viewer && <button onClick={() => viewer.controls.onAdvance("s2")}>advance</button>}
     </div>
   ),
 }));
@@ -62,8 +79,13 @@ const teamed = {
 
 beforeEach(() => {
   mocks.join.mockReset();
+  mocks.mutations = [];
+  mocks.presenceCalls = [];
   mocks.auth.accountType = "anonymous";
-  mocks.queries = { "retro.board": { currentStageId: "collect" }, "teams.listMine": [] };
+  mocks.queries = {
+    "retro.board": { currentStageId: "s1", stages: [{ id: "s1", kind: "collect" }, { id: "s2", kind: "group" }] },
+    "teams.listMine": [],
+  };
 });
 afterEach(cleanup);
 
@@ -86,10 +108,26 @@ describe("RetroRoomContent", () => {
 
   it("mounts the board with the menu and the viewer's role once a membership exists", () => {
     render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
-    expect(screen.getByTestId("board").textContent).toContain("collect");
+    expect(screen.getByTestId("board").textContent).toContain("s1");
     expect(screen.getByTestId("menu").textContent).toBe("owner");
     expect(screen.queryByTestId("join-form")).toBeNull();
     expect(screen.queryByTestId("team-reader-banner")).toBeNull();
+  });
+
+  it("an attendee heartbeats as themselves, writes readiness keyed to the shared entry, and holds the stageFlow decision", async () => {
+    render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
+    expect(mocks.presenceCalls[0]?.slice(1)).toEqual([roomId, "user1"]);
+    const board = screen.getByTestId("board");
+    expect(board.getAttribute("data-viewer")).toBe("user1");
+    expect(board.getAttribute("data-stage-flow")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "ready" }));
+    fireEvent.click(screen.getByRole("button", { name: "advance" }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.mutations).toEqual([
+      { fn: "presence.setReadiness", args: { roomId, userId: "user1", stageId: "s1", ready: true } },
+      { fn: "retro.advance", args: { roomId, toStageId: "s2" } },
+    ]);
   });
 
   it("a Team member who never joined reads the board with no menu, and joins only on their own click", async () => {
@@ -101,6 +139,9 @@ describe("RetroRoomContent", () => {
     expect(screen.queryByTestId("menu")).toBeNull();
     expect(screen.queryByTestId("join-form")).toBeNull();
     expect(screen.getByTestId("team-reader-banner").textContent).toContain("member of Acme Squad");
+    // No attendance, no heartbeat: the presence hook never mounts.
+    expect(mocks.presenceCalls).toEqual([]);
+    expect(board.getAttribute("data-viewer")).toBeNull();
     await new Promise((r) => setTimeout(r, 0));
     expect(mocks.join).not.toHaveBeenCalled();
 

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -1,24 +1,33 @@
 "use client";
 
-import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useCallback, useMemo, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import usePresence from "@convex-dev/presence/react";
 import { api } from "@/convex/_generated/api";
-import { Id } from "@/convex/_generated/dataModel";
+import { Doc, Id } from "@/convex/_generated/dataModel";
 import { useAuth } from "@/components/auth/auth-provider";
 import { CenteredMessage } from "@/components/centered-message";
 import { Button } from "@/components/ui/button";
 import { RetroJoinForm } from "@/components/retro/retro-join-form";
-import { RetroBoard } from "@/components/retro/retro-board";
+import { RetroBoard, type BoardViewer } from "@/components/retro/retro-board";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
 import type { RetroTeam } from "@/components/retro/retro-header";
+import type { StageControls } from "@/components/retro/stage-nav";
+import { currentStageOf } from "@/convex/model/retroFormats";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import { usePermissions } from "@/hooks/usePermissions";
+import { toast } from "@/lib/toast";
 import {
   CHECKING_SESSION,
   JOIN_RETRO_BUTTON,
   LOADING_BOARD,
   LOADING_TITLE,
+  NOT_A_RETRO,
+  STAGE_ACT_FAILED,
   readingAsTeamMember,
 } from "@/convex/retroCopy";
+
+const NOT_A_RETRO_DECISION = { allowed: false, message: NOT_A_RETRO } as const;
 
 /** What `api.users.getMyMembership` returns for a member. */
 export type MyMembership = { _id: Id<"users"> };
@@ -84,6 +93,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
       <RetroBoard
         name={room.name}
         retro={retro}
+        users={roomData.users}
         team={team}
         banner={
           <div
@@ -102,19 +112,90 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     );
   }
 
-  const role = roomData.users.find((u) => u._id === membership?._id)?.role ?? "participant";
   return (
-    <RetroBoard
-      name={room.name}
+    <AttendeeBoard
+      roomId={roomId}
+      roomData={roomData}
       retro={retro}
       team={team}
+      userId={membership!._id}
+      myTeams={(myTeams ?? []) as MyTeam[]}
+    />
+  );
+}
+
+interface AttendeeBoardProps {
+  roomId: Id<"rooms">;
+  roomData: RoomWithRelatedData;
+  retro: Doc<"retros">;
+  team?: RetroTeam;
+  userId: Id<"users">;
+  myTeams: MyTeam[];
+}
+
+/**
+ * The attendee's board: one presence subscription (heartbeat as this
+ * member), the readiness write, and the stageFlow wiring. Its own component
+ * so the presence hook — which has no skip — mounts only once a membership
+ * exists; a Team reader never heartbeats.
+ */
+function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: AttendeeBoardProps) {
+  const presence = usePresence(api.presence, roomId, userId);
+  const setReadiness = useMutation(api.presence.setReadiness);
+  const advance = useMutation(api.retro.advance);
+  const setCardsVisible = useMutation(api.retro.setCardsVisible);
+  const setTimebox = useMutation(api.retro.setTimebox);
+  const permissions = usePermissions(roomData, userId);
+  // The room is a retro here (this branch mounts under the retro type), so
+  // the poker arm is a routing bug rather than a state; deny rather than throw.
+  const stageFlow = permissions.ceremony === "retro" ? permissions.stageFlow : NOT_A_RETRO_DECISION;
+  const currentStageId = currentStageOf(retro).id;
+
+  const run = useCallback(async (act: Promise<unknown>) => {
+    try {
+      await act;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : STAGE_ACT_FAILED);
+    }
+  }, []);
+
+  const controls = useMemo<StageControls>(
+    () => ({
+      stageFlow,
+      onAdvance: (toStageId) => void run(advance({ roomId, toStageId })),
+      onSetCardsVisible: (value) =>
+        void run(setCardsVisible({ roomId, stageId: currentStageId, value })),
+      onSetTimebox: (minutes) =>
+        void run(setTimebox({ roomId, stageId: currentStageId, ...(minutes !== undefined ? { minutes } : {}) })),
+    }),
+    [stageFlow, run, advance, setCardsVisible, setTimebox, roomId, currentStageId]
+  );
+
+  const viewer = useMemo<BoardViewer>(
+    () => ({
+      userId,
+      presence,
+      onSetReady: (ready) => void run(setReadiness({ roomId, userId, stageId: currentStageId, ready })),
+      controls,
+    }),
+    [userId, presence, run, setReadiness, roomId, currentStageId, controls]
+  );
+
+  const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
+  return (
+    <RetroBoard
+      name={roomData.room.name}
+      retro={retro}
+      users={roomData.users}
+      team={team}
+      viewer={viewer}
       menu={
         <RetroMenu
           roomId={roomId}
           team={team}
           role={role}
           isOwnerAbsent={roomData.isOwnerAbsent}
-          myTeams={(myTeams ?? []) as MyTeam[]}
+          myTeams={myTeams}
         />
       }
     />

--- a/src/components/retro/readiness.ts
+++ b/src/components/retro/readiness.ts
@@ -1,0 +1,65 @@
+import type { RoomUserData } from "@/convex/model/users";
+import { orderUsersByPresence, type UserWithPresence } from "@/hooks/useRoomPresence";
+
+/**
+ * Readiness (ADR-0010, spec §7): a person's "I am done with this stage"
+ * signal, held in the presence payload as `{ stageId, ready }` and shown
+ * named per person, never summed. The projection is the whole clearing
+ * mechanism: a payload keyed to any entry but the current one is absent, so
+ * an advance clears every signal without a write. Pure, so a jsdom test
+ * proves it without the presence component.
+ */
+export interface ReadinessPayload {
+  stageId: string;
+  ready: boolean;
+}
+
+/** What `presence.list` returns per person; `data` is the readiness payload when set. */
+export interface PresenceEntry {
+  userId: string;
+  online: boolean;
+  lastDisconnected: number;
+  data?: unknown;
+}
+
+function isReadinessPayload(data: unknown): data is ReadinessPayload {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as ReadinessPayload).stageId === "string" &&
+    typeof (data as ReadinessPayload).ready === "boolean"
+  );
+}
+
+/** Ready iff the payload is keyed to the current entry and says so. */
+export function readinessOf(data: unknown, currentStageId: string): boolean {
+  return isReadinessPayload(data) && data.stageId === currentStageId && data.ready;
+}
+
+/** One roster row: the member, their presence and their readiness for the current entry. */
+export interface RosterRow extends UserWithPresence {
+  ready: boolean;
+}
+
+/**
+ * The roster: every member with presence and readiness merged on, in the
+ * one ordering rule (online first, then by join time).
+ */
+export function projectRoster(
+  users: readonly RoomUserData[],
+  presence: readonly PresenceEntry[] | undefined,
+  currentStageId: string
+): RosterRow[] {
+  const byUserId = new Map((presence ?? []).map((entry) => [entry.userId, entry]));
+  const rows: RosterRow[] = users.map((user) => {
+    const entry = byUserId.get(user._id);
+    const online = entry?.online ?? false;
+    return {
+      ...user,
+      isOnline: online,
+      lastSeen: online ? null : (entry?.lastDisconnected ?? null),
+      ready: readinessOf(entry?.data, currentStageId),
+    };
+  });
+  return orderUsersByPresence(rows) as RosterRow[];
+}

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -1,21 +1,42 @@
 "use client";
 
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { ReactFlow, ReactFlowProvider, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { Users } from "lucide-react";
 import type { Doc } from "@/convex/_generated/dataModel";
+import type { RoomUserData } from "@/convex/model/users";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
-import { currentStageOf } from "@/convex/model/retro";
+import { Button } from "@/components/ui/button";
+import { ROSTER_TITLE } from "@/convex/retroCopy";
+import { currentStageOf } from "@/convex/model/retroFormats";
 import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
 import { layoutZones } from "./zones";
+import { StageNav, type StageControls } from "./stage-nav";
+import { StageEmptyState } from "./stage-empty-state";
+import { RetroRoster } from "./retro-roster";
+import type { PresenceEntry } from "./readiness";
+
+/** What an attendee brings to the board that a Team reader does not. */
+export interface BoardViewer {
+  userId: string;
+  /** The room's presence list; undefined while loading. */
+  presence: readonly PresenceEntry[] | undefined;
+  onSetReady: (ready: boolean) => void;
+  controls: StageControls;
+}
 
 interface RetroBoardProps {
   /** The room shell's name; the board reads nothing else from it. */
   name: string;
   retro: Doc<"retros">;
+  /** The roster's members, from the room shell. */
+  users: readonly RoomUserData[];
   /** The Team that keeps the retro (ADR-0008); undefined for a teamless one. */
   team?: RetroTeam;
+  /** The attendee's presence and stageFlow wiring; absent for a Team reader. */
+  viewer?: BoardViewer;
   /** The header's menu, for attendees. */
   menu?: ReactNode;
   /** A line under the header: the non-attending Team reader's (ADR-0009). */
@@ -32,9 +53,16 @@ const nodeTypes: NodeTypes = { zone: PromptZoneNodeView };
  * and trackpad, only visible elements rendered. The prompt soft zones are
  * drawn from the stamped format; cards, clusters and the hand arrive with
  * their tickets.
+ *
+ * The root shows the shared stage (`data-stage`); the viewer's own view may
+ * sit on another entry (`data-view-stage`) without moving anyone (ADR-0010).
  */
-export function RetroBoard({ name, retro, team, menu, banner }: RetroBoardProps) {
+export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: RetroBoardProps) {
   const currentStage = currentStageOf(retro);
+  /** The viewer's own view; null follows the shared pointer. */
+  const [viewStageId, setViewStageId] = useState<string | null>(null);
+  const [rosterOpen, setRosterOpen] = useState(false);
+  const viewStage = retro.stages.find((stage) => stage.id === viewStageId) ?? currentStage;
 
   // The page is titled by the retro's name (spec §18.1). Set here rather than
   // in the route's metadata, which would have to fetch the room server-side
@@ -58,40 +86,81 @@ export function RetroBoard({ name, retro, team, menu, banner }: RetroBoardProps)
     [retro.format.prompts]
   );
 
+  const onlineCount = viewer?.presence?.filter((entry) => entry.online).length;
+
   return (
     <div
       className="flex h-screen w-screen flex-col bg-white dark:bg-surface-1"
       data-testid="retro-board"
       data-stage={currentStage.kind}
+      data-view-stage={viewStage.kind}
     >
       <RetroHeader
         name={name}
         stageKind={currentStage.kind}
+        timeboxMinutes={currentStage.timeboxMinutes}
+        enteredAt={retro.currentStageEnteredAt}
         collectUntil={retro.collectUntil}
         team={team}
-        menu={menu}
+        menu={
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-label={ROSTER_TITLE}
+              aria-pressed={rosterOpen}
+              onClick={() => setRosterOpen((open) => !open)}
+            >
+              <Users className="size-4" />
+              {onlineCount !== undefined ? `${onlineCount}/${users.length}` : users.length}
+            </Button>
+            {menu}
+          </>
+        }
       />
       {banner}
-      <div className="min-h-0 flex-1">
-        <ReactFlowProvider>
-          <ReactFlow
-            nodes={nodes}
-            nodeTypes={nodeTypes}
-            fitView
-            fitViewOptions={{ padding: 0.1, maxZoom: 1 }}
-            proOptions={{ hideAttribution: true }}
-            minZoom={0.1}
-            maxZoom={4}
-            nodesConnectable={false}
-            onlyRenderVisibleElements
-            panOnScroll
-            panOnDrag={[1, 2]}
-            selectionOnDrag
-            preventScrolling={false}
-          >
-            <CanvasDotsBackground />
-          </ReactFlow>
-        </ReactFlowProvider>
+      <StageNav
+        stages={retro.stages}
+        currentStageId={currentStage.id}
+        viewStageId={viewStageId}
+        onView={setViewStageId}
+        controls={viewer?.controls}
+      />
+      <div className="relative flex min-h-0 flex-1">
+        <div className="relative min-w-0 flex-1">
+          <StageEmptyState kind={viewStage.kind} />
+          <ReactFlowProvider>
+            <ReactFlow
+              nodes={nodes}
+              nodeTypes={nodeTypes}
+              fitView
+              fitViewOptions={{ padding: 0.1, maxZoom: 1 }}
+              proOptions={{ hideAttribution: true }}
+              minZoom={0.1}
+              maxZoom={4}
+              nodesConnectable={false}
+              onlyRenderVisibleElements
+              panOnScroll
+              panOnDrag={[1, 2]}
+              selectionOnDrag
+              preventScrolling={false}
+            >
+              <CanvasDotsBackground />
+            </ReactFlow>
+          </ReactFlowProvider>
+        </div>
+        {rosterOpen && (
+          <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">
+            <RetroRoster
+              users={users}
+              presence={viewer?.presence}
+              currentStage={currentStage}
+              myUserId={viewer?.userId}
+              onSetReady={viewer?.onSetReady}
+            />
+          </aside>
+        )}
       </div>
     </div>
   );

--- a/src/components/retro/retro-header.tsx
+++ b/src/components/retro/retro-header.tsx
@@ -15,6 +15,9 @@ export interface RetroTeam {
 interface RetroHeaderProps {
   name: string;
   stageKind: StageKind;
+  /** The current entry's advisory timebox and when it was entered (spec §7). */
+  timeboxMinutes?: number;
+  enteredAt?: number;
   /** Advisory cards-due date (ADR-0020); shown, never enforced. */
   collectUntil?: number;
   /** The Team that keeps the retro; undefined for a teamless one. */
@@ -29,11 +32,19 @@ interface RetroHeaderProps {
  * carries the team line, which doubles as the link to the team page
  * (ADR-0008); a teamless retro carries the teamless line.
  */
-export function RetroHeader({ name, stageKind, collectUntil, team, menu }: RetroHeaderProps) {
+export function RetroHeader({
+  name,
+  stageKind,
+  timeboxMinutes,
+  enteredAt,
+  collectUntil,
+  team,
+  menu,
+}: RetroHeaderProps) {
   return (
     <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b bg-white px-4 py-2 dark:bg-surface-1">
       <h1 className="truncate text-base font-semibold">{name}</h1>
-      <StagePill kind={stageKind} />
+      <StagePill kind={stageKind} timeboxMinutes={timeboxMinutes} enteredAt={enteredAt} />
       {collectUntil !== undefined && (
         <span data-testid="collect-until" className="text-sm text-muted-foreground">
           {collectUntilLine(format(collectUntil, "d MMM"))}

--- a/src/components/retro/retro-roster.test.tsx
+++ b/src/components/retro/retro-roster.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Readiness and the roster (ADR-0010, spec §7): readiness lives in the
+ * presence payload as `{ stageId, ready }`; the projection treats a payload
+ * whose stageId is not the current entry as absent, so an advance clears it
+ * with no write. The roster shows presence and readiness named per person,
+ * offers the viewer's own toggle at one write per change, and offers none
+ * in `collect`.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
+import { readinessOf, projectRoster } from "./readiness";
+import { RetroRoster } from "./retro-roster";
+import type { StageEntry } from "@/convex/model/retroFormats";
+
+afterEach(cleanup);
+
+const users = [
+  { _id: "u1", name: "Ada", isSpectator: false, role: "owner", joinedAt: 1, membershipId: "m1" },
+  { _id: "u2", name: "Ben", isSpectator: false, role: "participant", joinedAt: 2, membershipId: "m2" },
+  { _id: "u3", name: "Cy", isSpectator: false, role: "participant", joinedAt: 3, membershipId: "m3" },
+] as never[];
+
+const group: StageEntry = { id: "s-group", kind: "group", cardsVisible: "visible", tallyVisible: "visible" };
+const collect: StageEntry = { id: "s-collect", kind: "collect", cardsVisible: "hidden", tallyVisible: "visible" };
+
+describe("readinessOf", () => {
+  it("reads ready only from a payload keyed to the current entry", () => {
+    expect(readinessOf({ stageId: "s-group", ready: true }, "s-group")).toBe(true);
+    expect(readinessOf({ stageId: "s-group", ready: false }, "s-group")).toBe(false);
+    // Advancing clears it: the old entry's payload is absent for the new one.
+    expect(readinessOf({ stageId: "s-collect", ready: true }, "s-group")).toBe(false);
+    expect(readinessOf(undefined, "s-group")).toBe(false);
+    expect(readinessOf("garbage", "s-group")).toBe(false);
+    expect(readinessOf({ ready: true }, "s-group")).toBe(false);
+  });
+});
+
+describe("projectRoster", () => {
+  it("merges presence and readiness onto every member, online first", () => {
+    const presence = [
+      { userId: "u2", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: true } },
+      { userId: "u1", online: false, lastDisconnected: 500, data: { stageId: "s-group", ready: true } },
+    ];
+    const rows = projectRoster(users, presence, "s-group");
+    expect(rows.map((r) => [r.name, r.isOnline, r.ready])).toEqual([
+      ["Ben", true, true],
+      ["Ada", false, true],
+      ["Cy", false, false],
+    ]);
+  });
+
+  it("reads everyone as not ready after the pointer moves", () => {
+    const presence = [
+      { userId: "u1", online: true, lastDisconnected: 0, data: { stageId: "s-collect", ready: true } },
+    ];
+    expect(projectRoster(users, presence, "s-group").every((r) => !r.ready)).toBe(true);
+    expect(projectRoster(users, undefined, "s-group").every((r) => !r.isOnline && !r.ready)).toBe(true);
+  });
+});
+
+describe("RetroRoster", () => {
+  it("shows each person with readiness, and the viewer's toggle writes once per change", () => {
+    const onSetReady = vi.fn();
+    const presence = [
+      { userId: "u1", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: false } },
+      { userId: "u2", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: true } },
+    ];
+    render(
+      <RetroRoster users={users} presence={presence} currentStage={group} myUserId="u1" onSetReady={onSetReady} />
+    );
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(3);
+    const ben = rows.find((r) => r.textContent?.includes("Ben"))!;
+    expect(ben.getAttribute("data-ready")).toBe("true");
+    expect(within(ben).getByText("Ready")).toBeTruthy();
+    const cy = rows.find((r) => r.textContent?.includes("Cy"))!;
+    expect(cy.getAttribute("data-ready")).toBe("false");
+    expect(cy.getAttribute("data-online")).toBe("false");
+
+    const toggle = screen.getByRole("switch", { name: "I'm ready" });
+    fireEvent.click(toggle);
+    expect(onSetReady).toHaveBeenCalledTimes(1);
+    expect(onSetReady).toHaveBeenCalledWith(true);
+  });
+
+  it("offers no readiness in collect", () => {
+    render(
+      <RetroRoster users={users} presence={undefined} currentStage={collect} myUserId="u1" onSetReady={vi.fn()} />
+    );
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText("Ready")).toBeNull();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getAllByRole("listitem")[0].hasAttribute("data-ready")).toBe(false);
+  });
+});

--- a/src/components/retro/retro-roster.tsx
+++ b/src/components/retro/retro-roster.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo } from "react";
+import type { RoomUserData } from "@/convex/model/users";
+import type { StageEntry } from "@/convex/model/retroFormats";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { getColorFromName, getInitial } from "@/lib/avatar-utils";
+import { READY_LABEL, READY_TOGGLE_LABEL, ROSTER_TITLE } from "@/convex/retroCopy";
+import { projectRoster, type PresenceEntry } from "./readiness";
+
+interface RetroRosterProps {
+  users: readonly RoomUserData[];
+  /** The room's presence list; undefined while loading. */
+  presence: readonly PresenceEntry[] | undefined;
+  currentStage: Pick<StageEntry, "id" | "kind">;
+  /** The viewer, when attending; a Team reader has no row and no toggle. */
+  myUserId?: string;
+  /** The viewer's readiness write: one call per state change. */
+  onSetReady?: (ready: boolean) => void;
+}
+
+/**
+ * The roster panel (spec §7): presence and names for every member, with
+ * readiness named per person and the viewer's own toggle. `collect` offers
+ * none — there the only signal is whether a person has written, which the
+ * cards ticket adds — so nothing durable ever records who declared
+ * themselves finished.
+ */
+export function RetroRoster({ users, presence, currentStage, myUserId, onSetReady }: RetroRosterProps) {
+  const rows = useMemo(
+    () => projectRoster(users, presence, currentStage.id),
+    [users, presence, currentStage.id]
+  );
+  const offersReadiness = currentStage.kind !== "collect";
+  const me = rows.find((row) => row._id === myUserId);
+
+  return (
+    <section data-testid="retro-roster" aria-label={ROSTER_TITLE} className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold">{ROSTER_TITLE}</h2>
+      {offersReadiness && me && onSetReady && (
+        <div className="flex items-center gap-2">
+          <Switch
+            id="my-readiness"
+            checked={me.ready}
+            onCheckedChange={(checked) => onSetReady(checked)}
+            aria-label={READY_TOGGLE_LABEL}
+          />
+          <Label htmlFor="my-readiness">{READY_TOGGLE_LABEL}</Label>
+        </div>
+      )}
+      <ul className="flex flex-col gap-1.5">
+        {rows.map((row) => (
+          <li
+            key={row._id}
+            data-online={String(row.isOnline)}
+            {...(offersReadiness ? { "data-ready": String(row.ready) } : {})}
+            className="flex items-center gap-2 text-sm"
+          >
+            <Avatar size="sm" className={cn("ring-2", row.isOnline ? "ring-green-500" : "ring-gray-400 grayscale")}>
+              {row.avatarUrl && <AvatarImage src={row.avatarUrl} alt={row.name} />}
+              <AvatarFallback className={getColorFromName(row.name)}>
+                <span className="text-xs font-medium text-white">{getInitial(row.name)}</span>
+              </AvatarFallback>
+            </Avatar>
+            <span className={cn("min-w-0 flex-1 truncate", !row.isOnline && "text-muted-foreground")}>
+              {row.name}
+            </span>
+            {offersReadiness && row.ready && (
+              <span className="rounded-full bg-green-50 px-2 py-0.5 text-xs text-green-700 dark:bg-status-success-bg dark:text-status-success-fg">
+                {READY_LABEL}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/retro/stage-empty-state.tsx
+++ b/src/components/retro/stage-empty-state.tsx
@@ -1,0 +1,21 @@
+import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
+import type { StageKind } from "@/convex/model/retroFormats";
+
+/**
+ * A stage with nothing in it (ADR-0010): an explanation over the canvas,
+ * never a lock. The cards ticket conditions it on the board being empty
+ * for the viewed entry; until then every entry reads its line.
+ */
+export function StageEmptyState({ kind }: { kind: StageKind }) {
+  return (
+    <div
+      data-testid="stage-empty-state"
+      data-kind={kind}
+      className="pointer-events-none absolute inset-x-0 top-4 z-10 flex justify-center px-4"
+    >
+      <p className="rounded-lg border bg-white/90 px-4 py-2 text-sm text-muted-foreground shadow-sm backdrop-blur dark:bg-surface-2/90">
+        <span className="font-medium text-foreground">{STAGE_LABELS[kind]}.</span> {STAGE_EMPTY[kind]}
+      </p>
+    </div>
+  );
+}

--- a/src/components/retro/stage-nav.test.tsx
+++ b/src/components/retro/stage-nav.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Stage navigation (ADR-0010, spec §7): the list of entries; any member
+ * navigates their own view to another entry and "Back to the team" returns
+ * it; a stageFlow holder advances forward or back and brings everyone to
+ * the entry they are viewing; the reveal toggle and the timebox act on the
+ * current entry; a participant sees the controls disabled with the denial
+ * copy, never vanished.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { StageNav } from "./stage-nav";
+import type { StageEntry } from "@/convex/model/retroFormats";
+import { RESOLVED_ALLOWED } from "@/convex/permissions";
+
+afterEach(cleanup);
+
+const stages: StageEntry[] = [
+  { id: "s1", kind: "collect", cardsVisible: "hidden", tallyVisible: "visible" },
+  { id: "s2", kind: "group", cardsVisible: "visible", tallyVisible: "visible" },
+  { id: "s3", kind: "vote", cardsVisible: "visible", tallyVisible: "hidden", voteBudget: 5 },
+  { id: "s4", kind: "discuss", cardsVisible: "visible", tallyVisible: "visible" },
+];
+
+const denied = { allowed: false as const, message: "Only facilitators and the owner can do this" };
+
+type Props = Parameters<typeof StageNav>[0];
+type Controls = NonNullable<Props["controls"]>;
+
+function renderNav(over: Partial<Omit<Props, "controls">> & Partial<Controls> & { controls?: null } = {}) {
+  const { stages: s, currentStageId, viewStageId, onView, controls, ...rest } = over;
+  const ctl: Controls = {
+    stageFlow: RESOLVED_ALLOWED,
+    onAdvance: vi.fn(),
+    onSetCardsVisible: vi.fn(),
+    onSetTimebox: vi.fn(),
+    ...rest,
+  };
+  const props = {
+    stages: s ?? stages,
+    currentStageId: currentStageId ?? "s2",
+    viewStageId: viewStageId ?? null,
+    onView: onView ?? vi.fn(),
+    ...(controls === null ? {} : { controls: ctl }),
+  };
+  render(<StageNav {...props} />);
+  return { ...props, ...ctl };
+}
+
+describe("StageNav — own view", () => {
+  it("lists every entry, marks the shared one, and navigates the view on click", () => {
+    const props = renderNav();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent)).toEqual(["Collect", "Group", "Vote", "Discuss"]);
+    expect(tabs[1].getAttribute("data-shared")).toBe("true");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByRole("button", { name: "Back to the team" })).toBeNull();
+
+    fireEvent.click(tabs[3]);
+    expect(props.onView).toHaveBeenCalledWith("s4");
+  });
+
+  it("when the view is elsewhere, Back to the team returns it", () => {
+    const props = renderNav({ viewStageId: "s4" });
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[3].getAttribute("aria-selected")).toBe("true");
+    expect(tabs[1].getAttribute("data-shared")).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "Back to the team" }));
+    expect(props.onView).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("StageNav — advance", () => {
+  it("a stageFlow holder advances forward and back from the shared entry", () => {
+    const props = renderNav();
+    fireEvent.click(screen.getByRole("button", { name: "Next stage" }));
+    expect(props.onAdvance).toHaveBeenCalledWith("s3");
+    fireEvent.click(screen.getByRole("button", { name: "Previous stage" }));
+    expect(props.onAdvance).toHaveBeenCalledWith("s1");
+  });
+
+  it("at the ends, the edge button is disabled; nothing advances by itself", () => {
+    renderNav({ currentStageId: "s4" });
+    expect((screen.getByRole("button", { name: "Next stage" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Previous stage" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("viewing another entry offers to bring everyone there", () => {
+    const props = renderNav({ viewStageId: "s4" });
+    fireEvent.click(screen.getByRole("button", { name: "Bring everyone here" }));
+    expect(props.onAdvance).toHaveBeenCalledWith("s4");
+  });
+
+  it("a participant sees the controls disabled with the denial copy", () => {
+    renderNav({ stageFlow: denied, viewStageId: "s4" });
+    // The denial overlay renames each control with the copy and disables it.
+    const controls = screen.getAllByRole("button", { name: denied.message });
+    expect(controls).toHaveLength(3);
+    expect(controls.every((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+    // The own-view tabs stay open to everyone.
+    expect(screen.getAllByRole("tab").every((t) => !(t as HTMLButtonElement).disabled)).toBe(true);
+  });
+});
+
+describe("StageNav — a Team reader", () => {
+  it("gets the tabs and Back to the team, and no stageFlow control at all", () => {
+    renderNav({ controls: null, viewStageId: "s4" });
+    expect(screen.getAllByRole("tab")).toHaveLength(4);
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Back to the team" })).toBeTruthy();
+  });
+});
+
+describe("StageNav — the current entry's controls", () => {
+  it("flips the reveal policy of the current entry", () => {
+    const props = renderNav({ currentStageId: "s1" });
+    fireEvent.click(screen.getByRole("button", { name: "Show cards" }));
+    expect(props.onSetCardsVisible).toHaveBeenCalledWith("visible");
+    cleanup();
+    const again = renderNav({ currentStageId: "s2" });
+    fireEvent.click(screen.getByRole("button", { name: "Hide cards" }));
+    expect(again.onSetCardsVisible).toHaveBeenCalledWith("hidden");
+  });
+
+  it("sets and clears the current entry's timebox", () => {
+    const props = renderNav({
+      stages: stages.map((s) => (s.id === "s2" ? { ...s, timeboxMinutes: 10 } : s)),
+    });
+    const input = screen.getByLabelText("Timebox (minutes)") as HTMLInputElement;
+    expect(input.value).toBe("10");
+    fireEvent.change(input, { target: { value: "15" } });
+    fireEvent.blur(input);
+    expect(props.onSetTimebox).toHaveBeenCalledWith(15);
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+    expect(props.onSetTimebox).toHaveBeenCalledWith(undefined);
+  });
+
+  it("hides the current entry's controls while the view is elsewhere", () => {
+    renderNav({ viewStageId: "s4" });
+    expect(screen.queryByRole("button", { name: /cards$/ })).toBeNull();
+    expect(screen.queryByLabelText("Timebox (minutes)")).toBeNull();
+  });
+});

--- a/src/components/retro/stage-nav.tsx
+++ b/src/components/retro/stage-nav.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { ResolvedDecision } from "@/convex/permissions";
+import { permissionProps } from "@/hooks/usePermissions";
+import type { StageEntry, Visibility } from "@/convex/model/retroFormats";
+import {
+  BACK_TO_TEAM,
+  BRING_EVERYONE_HERE,
+  HIDE_CARDS,
+  NEXT_STAGE,
+  PREVIOUS_STAGE,
+  SHOW_CARDS,
+  STAGES_NAV_LABEL,
+  STAGE_LABELS,
+  TIMEBOX_LABEL,
+} from "@/convex/retroCopy";
+
+interface StageNavProps {
+  stages: readonly StageEntry[];
+  /** The shared pointer. */
+  currentStageId: string;
+  /** The viewer's own view; null follows the shared pointer. */
+  viewStageId: string | null;
+  onView: (stageId: string | null) => void;
+  /** The stageFlow controls, for an attendee; a Team reader gets the tabs alone. */
+  controls?: StageControls;
+}
+
+export interface StageControls {
+  /** The `stageFlow` decision: denied renders the controls disabled with the copy. */
+  stageFlow: ResolvedDecision;
+  onAdvance: (toStageId: string) => void;
+  onSetCardsVisible: (value: Visibility) => void;
+  onSetTimebox: (minutes: number | undefined) => void;
+}
+
+/**
+ * The stage strip (ADR-0010, spec §7): every entry as a tab. Clicking one
+ * moves the viewer's own view, never the shared pointer; "Back to the team"
+ * returns it. The stageFlow controls move the shared pointer forward or
+ * back, or bring everyone to the viewed entry, and flip the current entry's
+ * reveal policy and timebox in place. Nothing here is a lock: a stage
+ * projects and defaults, a person moves it.
+ */
+export function StageNav({
+  stages,
+  currentStageId,
+  viewStageId,
+  onView,
+  controls,
+}: StageNavProps) {
+  const sharedIndex = stages.findIndex((stage) => stage.id === currentStageId);
+  const current = stages[sharedIndex] ?? stages[0];
+  const viewing = viewStageId ?? current.id;
+  const viewingShared = viewing === current.id;
+  const previous = stages[sharedIndex - 1];
+  const next = stages[sharedIndex + 1];
+  const deny = controls ? permissionProps(controls.stageFlow) : {};
+
+  return (
+    <div
+      data-testid="stage-nav"
+      className="flex flex-wrap items-center gap-2 border-b bg-white px-4 py-1.5 dark:bg-surface-1"
+    >
+      <div role="tablist" aria-label={STAGES_NAV_LABEL} className="flex flex-wrap items-center gap-1">
+        {stages.map((stage) => {
+          const selected = stage.id === viewing;
+          const shared = stage.id === current.id;
+          return (
+            <button
+              key={stage.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              data-shared={String(shared)}
+              onClick={() => onView(shared ? null : stage.id)}
+              className={cn(
+                "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                selected
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-gray-100 dark:hover:bg-surface-3",
+                shared && !selected && "underline underline-offset-4"
+              )}
+            >
+              {STAGE_LABELS[stage.kind]}
+            </button>
+          );
+        })}
+      </div>
+
+      {!viewingShared && (
+        <Button type="button" variant="outline" size="sm" onClick={() => onView(null)}>
+          {BACK_TO_TEAM}
+        </Button>
+      )}
+
+      {controls && (
+      <div className="ml-auto flex flex-wrap items-center gap-2">
+        {viewingShared && (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-label={current.cardsVisible === "hidden" ? SHOW_CARDS : HIDE_CARDS}
+              onClick={() => controls.onSetCardsVisible(current.cardsVisible === "hidden" ? "visible" : "hidden")}
+              {...deny}
+            >
+              {current.cardsVisible === "hidden" ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+              {current.cardsVisible === "hidden" ? SHOW_CARDS : HIDE_CARDS}
+            </Button>
+            <TimeboxField
+              // Remount on a server change so the draft never fights the stored value.
+              key={`${current.id}:${current.timeboxMinutes ?? ""}`}
+              minutes={current.timeboxMinutes}
+              onCommit={controls.onSetTimebox}
+              denial={controls.stageFlow.allowed ? undefined : controls.stageFlow.message}
+            />
+          </>
+        )}
+        {!viewingShared && (
+          <Button type="button" size="sm" aria-label={BRING_EVERYONE_HERE} onClick={() => controls.onAdvance(viewing)} {...deny}>
+            {BRING_EVERYONE_HERE}
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label={PREVIOUS_STAGE}
+          disabled={!previous}
+          onClick={() => previous && controls.onAdvance(previous.id)}
+          {...deny}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label={NEXT_STAGE}
+          disabled={!next}
+          onClick={() => next && controls.onAdvance(next.id)}
+          {...deny}
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+      )}
+    </div>
+  );
+}
+
+/** The timebox input: commits whole minutes on blur, or clears when emptied. */
+function TimeboxField({
+  minutes,
+  onCommit,
+  denial,
+}: {
+  minutes: number | undefined;
+  onCommit: (minutes: number | undefined) => void;
+  denial?: string;
+}) {
+  const [draft, setDraft] = useState(minutes === undefined ? "" : String(minutes));
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      if (minutes !== undefined) onCommit(undefined);
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setDraft(minutes === undefined ? "" : String(minutes));
+      return;
+    }
+    if (parsed !== minutes) onCommit(parsed);
+  };
+  return (
+    <div className="flex items-center gap-1.5">
+      <Label htmlFor="stage-timebox" className="text-xs text-muted-foreground">
+        {TIMEBOX_LABEL}
+      </Label>
+      <Input
+        id="stage-timebox"
+        type="number"
+        min={1}
+        step={1}
+        inputMode="numeric"
+        className="h-8 w-16"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        {...(denial ? { readOnly: true, title: denial } : {})}
+      />
+    </div>
+  );
+}

--- a/src/components/retro/stage-pill.test.tsx
+++ b/src/components/retro/stage-pill.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * The stage pill (spec §7): the shared stage's label, and the advisory
+ * timebox counting down from the entry's minutes and the entered-at
+ * instant, reading "Timebox over" at zero and nothing else.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import { StagePill } from "./stage-pill";
+import { STAGE_LABELS, TIMEBOX_OVER } from "@/convex/retroCopy";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("StagePill", () => {
+  it("shows the label and no countdown when the entry has no timebox", () => {
+    render(<StagePill kind="group" />);
+    expect(screen.getByTestId("stage-pill").textContent).toBe(STAGE_LABELS.group);
+    expect(screen.queryByTestId("timebox")).toBeNull();
+  });
+
+  it("counts down from the entry's minutes since the entered-at instant, then reads Timebox over", () => {
+    vi.useFakeTimers();
+    const enteredAt = Date.UTC(2026, 8, 5, 10, 0, 0);
+    vi.setSystemTime(enteredAt + 30_000);
+    render(<StagePill kind="vote" timeboxMinutes={5} enteredAt={enteredAt} />);
+    const timebox = screen.getByTestId("timebox");
+    expect(timebox.textContent).toBe("4:30");
+    expect(timebox.getAttribute("data-over")).toBe("false");
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(screen.getByTestId("timebox").textContent).toBe("3:30");
+
+    act(() => {
+      vi.advanceTimersByTime(4 * 60_000);
+    });
+    expect(screen.getByTestId("timebox").textContent).toBe(TIMEBOX_OVER);
+    expect(screen.getByTestId("timebox").getAttribute("data-over")).toBe("true");
+    // The pill still names the stage: nothing advanced.
+    expect(screen.getByTestId("stage-pill").getAttribute("data-stage")).toBe("vote");
+  });
+});

--- a/src/components/retro/stage-pill.tsx
+++ b/src/components/retro/stage-pill.tsx
@@ -1,22 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import { STAGE_LABELS, STAGE_PILL_LABEL } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
+import { timeboxReading } from "./timebox";
+
+interface StagePillProps {
+  kind: StageKind;
+  /** The entry's advisory timebox; the countdown shows only when set. */
+  timeboxMinutes?: number;
+  /** The instant the shared pointer entered the entry. */
+  enteredAt?: number;
+}
+
+/** A once-a-second clock, running only while a countdown is shown. */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return now;
+}
 
 /**
  * The stage pill (spec §7): the one place the board says which stage is
- * shared. Shows the shared pointer's kind; the advisory timebox countdown
- * joins it with the stages ticket.
+ * shared, with the advisory timebox counting down beside the label. At zero
+ * it reads "Timebox over" and nothing else happens.
  */
-export function StagePill({ kind }: { kind: StageKind }) {
+export function StagePill({ kind, timeboxMinutes, enteredAt }: StagePillProps) {
+  const hasTimebox = timeboxMinutes !== undefined && enteredAt !== undefined;
+  const now = useNow(hasTimebox);
+  const reading = hasTimebox ? timeboxReading(timeboxMinutes, enteredAt, now) : undefined;
   return (
     <Badge
       variant="secondary"
       data-testid="stage-pill"
       data-stage={kind}
       aria-label={`${STAGE_PILL_LABEL}: ${STAGE_LABELS[kind]}`}
-      className="h-7 px-3 text-sm"
+      className="h-7 gap-2 px-3 text-sm"
     >
       {STAGE_LABELS[kind]}
+      {reading && (
+        <span
+          data-testid="timebox"
+          data-over={String(reading.over)}
+          className={cn(
+            "tabular-nums",
+            reading.over ? "text-red-700 dark:text-status-error-fg" : "text-muted-foreground"
+          )}
+        >
+          {reading.label}
+        </span>
+      )}
     </Badge>
   );
 }

--- a/src/components/retro/timebox.ts
+++ b/src/components/retro/timebox.ts
@@ -1,0 +1,41 @@
+import { calculateCurrentTime, formatTimerTime } from "@/convex/timerState";
+import { TIMEBOX_OVER } from "@/convex/retroCopy";
+
+/**
+ * The advisory timebox reading (ADR-0010, spec §7): `timeboxMinutes * 60`
+ * minus the seconds since the shared pointer entered the entry, computed
+ * with the timer's own calculator so the board and the poker timer agree on
+ * a second. At or below zero it reads "Timebox over" and nothing else
+ * happens: the count never fires an advance.
+ */
+export interface TimeboxReading {
+  remainingSeconds: number;
+  over: boolean;
+  /** MM:SS, or the "Timebox over" line. */
+  label: string;
+}
+
+export function timeboxReading(
+  timeboxMinutes: number,
+  enteredAt: number,
+  now: number = Date.now()
+): TimeboxReading {
+  const elapsed = calculateCurrentTime(
+    {
+      startedAt: enteredAt,
+      pausedAt: null,
+      elapsedSeconds: 0,
+      isRunning: true,
+      lastUpdatedBy: null,
+      lastAction: null,
+    },
+    now
+  ).currentSeconds;
+  const remainingSeconds = timeboxMinutes * 60 - elapsed;
+  const over = remainingSeconds <= 0;
+  return {
+    remainingSeconds,
+    over,
+    label: over ? TIMEBOX_OVER : formatTimerTime(remainingSeconds),
+  };
+}


### PR DESCRIPTION
Part (a) of #290. Part (b), settings and the pre-stamp editor, is stacked on this branch.

- `retro.advance({ toStageId })` under `stageFlow`, forward or back, re-stamping `currentStageEnteredAt`. No finished state.
- `retro.setCardsVisible` flips the reveal policy on the current entry only; another entry refuses `stage`.
- `retro.setTimebox` keeps an advisory timebox on the current entry; the pill counts down through `calculateCurrentTime` and reads "over" past the limit, nothing moves.
- Readiness is a presence payload `{ stageId, ready }` written through `presence.setReadiness`, guarded by `requireActingUser`. A payload for a stage that is not the current one reads as absent, so advancing clears it with no extra write. Not offered in collect.
- Roster panel with online state and readiness per person.
- Own view: every attendee can look at any stage, "Back to the team" returns to the shared one, "Bring everyone here" advances to the viewed one.
- Every stage kind renders its pill and an empty state, never a lock.
- All three mutations bump room activity (proved in `roomActivity.test.ts`).

Tests: convex-test for advance/toggle/timebox and the chokepoint; node for the timebox reading and the readiness projection; jsdom for the pill, roster, stage nav and the attendee wiring.

Not done here: the collect-stage "has written" signal on the roster belongs to #291. No live browser run yet, the presence mutation needs a dev push first.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd