### PR TITLE
feat(retro): settings dialog and the pre-stamp format editor (#290)

### DIFF
--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -238,19 +238,12 @@ async function getRetro(
 }
 
 /**
- * The board's structure read (spec §9): the `retros` row. Identity-free, so
- * every viewer shares one cached result. Cards and clusters join it with
- * the cards ticket.
+ * The retros row of a room, or a `missing` refusal for a poker room. Also
+ * the board's structure read (spec §9): identity-free, so every viewer
+ * shares one cached result; cards and clusters join it with the cards
+ * ticket.
  */
-export async function getBoard(
-  ctx: QueryCtx,
-  roomId: Id<"rooms">
-): Promise<Doc<"retros">> {
-  return requireRetro(ctx, roomId);
-}
-
-/** The retros row of a room, or a `missing` refusal for a poker room. */
-async function requireRetro(ctx: QueryCtx, roomId: Id<"rooms">): Promise<Doc<"retros">> {
+export async function requireRetro(ctx: QueryCtx, roomId: Id<"rooms">): Promise<Doc<"retros">> {
   const retro = await getRetro(ctx, roomId);
   if (!retro) {
     throw refusal("missing", NOT_A_RETRO);
@@ -269,9 +262,9 @@ async function requireRetro(ctx: QueryCtx, roomId: Id<"rooms">): Promise<Doc<"re
  */
 export async function advance(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; toStageId: string }
+  args: { room: Doc<"rooms">; toStageId: string }
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (!retro.stages.some((stage) => stage.id === args.toStageId)) {
     throw refusal("missing", STAGE_ENTRY_NOT_FOUND);
   }
@@ -279,7 +272,7 @@ export async function advance(
     currentStageId: args.toStageId,
     currentStageEnteredAt: Date.now(),
   });
-  await updateRoomActivity(ctx, args.roomId);
+  await updateRoomActivity(ctx, args.room);
 }
 
 /**
@@ -290,17 +283,17 @@ export async function advance(
  */
 async function patchCurrentStage(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; stageId: string },
+  args: { room: Doc<"rooms">; stageId: string },
   patch: (entry: StageEntry) => StageEntry
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (args.stageId !== retro.currentStageId) {
     throw refusal("stage", NOT_CURRENT_STAGE);
   }
   await ctx.db.patch(retro._id, {
     stages: retro.stages.map((entry) => (entry.id === args.stageId ? patch(entry) : entry)),
   });
-  await updateRoomActivity(ctx, args.roomId);
+  await updateRoomActivity(ctx, args.room);
 }
 
 /**
@@ -310,7 +303,7 @@ async function patchCurrentStage(
  */
 export async function setCardsVisible(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; stageId: string; value: Visibility }
+  args: { room: Doc<"rooms">; stageId: string; value: Visibility }
 ): Promise<void> {
   await patchCurrentStage(ctx, args, (entry) => ({ ...entry, cardsVisible: args.value }));
 }
@@ -322,7 +315,7 @@ export async function setCardsVisible(
  */
 export async function setTimebox(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; stageId: string; minutes?: number }
+  args: { room: Doc<"rooms">; stageId: string; minutes?: number }
 ): Promise<void> {
   const { minutes } = args;
   if (minutes !== undefined && (!Number.isInteger(minutes) || minutes <= 0)) {
@@ -343,7 +336,7 @@ export async function setTimebox(
  */
 export async function renameRetro(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; name: string }
+  args: { room: Doc<"rooms">; name: string }
 ): Promise<void> {
   let name: string;
   try {
@@ -351,8 +344,8 @@ export async function renameRetro(
   } catch (error) {
     throw refusal("forbidden", error instanceof Error ? error.message : NAME_INVALID);
   }
-  await ctx.db.patch(args.roomId, { name });
-  await updateRoomActivity(ctx, args.roomId);
+  await ctx.db.patch(args.room._id, { name });
+  await updateRoomActivity(ctx, args.room);
 }
 
 /**
@@ -367,17 +360,17 @@ export async function setJoinPolicy(
     throw refusal("forbidden", TEAM_MEMBERS_NEEDS_TEAM);
   }
   await ctx.db.patch(args.room._id, { joinPolicy: args.joinPolicy });
-  await updateRoomActivity(ctx, args.room._id);
+  await updateRoomActivity(ctx, args.room);
 }
 
 /** The advisory cards-due date (ADR-0020); undefined clears it. It closes nothing. */
 export async function setCollectUntil(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; collectUntil?: number }
+  args: { room: Doc<"rooms">; collectUntil?: number }
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   await ctx.db.patch(retro._id, { collectUntil: args.collectUntil });
-  await updateRoomActivity(ctx, args.roomId);
+  await updateRoomActivity(ctx, args.room);
 }
 
 /** The label, trimmed, or a refusal when blank. */
@@ -399,13 +392,14 @@ function validateTint(color: string): string {
 /** Write the retro's prompts back, renumbered; the name is kept. */
 async function writePrompts(
   ctx: MutationCtx,
+  room: Doc<"rooms">,
   retro: Doc<"retros">,
   prompts: readonly FormatPrompt[]
 ): Promise<void> {
   await ctx.db.patch(retro._id, {
     format: { ...retro.format, prompts: renumberPrompts(prompts) },
   });
-  await updateRoomActivity(ctx, retro.roomId);
+  await updateRoomActivity(ctx, room);
 }
 
 export interface PromptEdit {
@@ -421,9 +415,9 @@ export interface PromptEdit {
  */
 export async function updatePrompt(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; promptId: string } & PromptEdit
+  args: { room: Doc<"rooms">; promptId: string } & PromptEdit
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   const prompt = retro.format.prompts.find((p) => p.id === args.promptId);
   if (!prompt) {
     throw refusal("missing", PROMPT_NOT_FOUND);
@@ -437,6 +431,7 @@ export async function updatePrompt(
   }
   await writePrompts(
     ctx,
+    args.room,
     retro,
     retro.format.prompts.map((p) => (p.id === prompt.id ? edited : p))
   );
@@ -445,9 +440,9 @@ export async function updatePrompt(
 /** Add a prompt at any stage, last in order, up to the cap. */
 export async function addPrompt(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; label: string; hint?: string; color: string }
+  args: { room: Doc<"rooms">; label: string; hint?: string; color: string }
 ): Promise<string> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (retro.format.prompts.length >= MAX_PROMPTS) {
     throw refusal("forbidden", TOO_MANY_PROMPTS);
   }
@@ -459,7 +454,7 @@ export async function addPrompt(
   };
   const hint = args.hint?.trim();
   if (hint) prompt.hint = hint;
-  await writePrompts(ctx, retro, [...retro.format.prompts, prompt]);
+  await writePrompts(ctx, args.room, retro, [...retro.format.prompts, prompt]);
   return prompt.id;
 }
 
@@ -471,9 +466,9 @@ export async function addPrompt(
  */
 export async function removePrompt(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; promptId: string }
+  args: { room: Doc<"rooms">; promptId: string }
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (!retro.format.prompts.some((p) => p.id === args.promptId)) {
     throw refusal("missing", PROMPT_NOT_FOUND);
   }
@@ -482,13 +477,14 @@ export async function removePrompt(
   }
   const answered = await ctx.db
     .query("retroCards")
-    .withIndex("by_room_prompt", (q) => q.eq("roomId", args.roomId).eq("promptId", args.promptId))
+    .withIndex("by_room_prompt", (q) => q.eq("roomId", args.room._id).eq("promptId", args.promptId))
     .first();
   if (answered) {
     throw refusal("forbidden", CARDS_STILL_ANSWER);
   }
   await writePrompts(
     ctx,
+    args.room,
     retro,
     retro.format.prompts.filter((p) => p.id !== args.promptId)
   );
@@ -497,11 +493,12 @@ export async function removePrompt(
 /** Write the stage list back; the pointer is untouched. */
 async function writeStages(
   ctx: MutationCtx,
+  room: Doc<"rooms">,
   retro: Doc<"retros">,
   stages: readonly StageEntry[]
 ): Promise<void> {
   await ctx.db.patch(retro._id, { stages: [...stages] });
-  await updateRoomActivity(ctx, retro.roomId);
+  await updateRoomActivity(ctx, room);
 }
 
 /**
@@ -511,14 +508,14 @@ async function writeStages(
  */
 export async function addStage(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; kind: StageKind; index?: number }
+  args: { room: Doc<"rooms">; kind: StageKind; index?: number }
 ): Promise<string> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (retro.stages.length >= MAX_STAGES) {
     throw refusal("forbidden", TOO_MANY_STAGES);
   }
   const entry = newStageEntry(args.kind);
-  await writeStages(ctx, retro, insertStage(retro.stages, entry, args.index));
+  await writeStages(ctx, args.room, retro, insertStage(retro.stages, entry, args.index));
   return entry.id;
 }
 
@@ -530,9 +527,9 @@ export async function addStage(
  */
 export async function removeStage(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; stageId: string }
+  args: { room: Doc<"rooms">; stageId: string }
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   if (!retro.stages.some((stage) => stage.id === args.stageId)) {
     throw refusal("missing", STAGE_ENTRY_NOT_FOUND);
   }
@@ -544,6 +541,7 @@ export async function removeStage(
   }
   await writeStages(
     ctx,
+    args.room,
     retro,
     retro.stages.filter((stage) => stage.id !== args.stageId)
   );
@@ -556,9 +554,9 @@ export async function removeStage(
  */
 export async function reorderStages(
   ctx: MutationCtx,
-  args: { roomId: Id<"rooms">; stageIds: string[] }
+  args: { room: Doc<"rooms">; stageIds: string[] }
 ): Promise<void> {
-  const retro = await requireRetro(ctx, args.roomId);
+  const retro = await requireRetro(ctx, args.room._id);
   const check = reorderKeepsLocks(retro.stages, args.stageIds, retro.currentStageId);
   if (!check.ok) {
     throw refusal(
@@ -566,7 +564,7 @@ export async function reorderStages(
       check.reason === "not-a-permutation" ? STAGE_ORDER_INVALID : STAGE_ORDER_LOCKED
     );
   }
-  await writeStages(ctx, retro, orderStagesBy(retro.stages, args.stageIds));
+  await writeStages(ctx, args.room, retro, orderStagesBy(retro.stages, args.stageIds));
 }
 
 /**

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -8,6 +8,7 @@ import { listTeamsForUser } from "./teams";
 import {
   currentStageOf,
   findFormat,
+  insertStage,
   isLockedKindEntry,
   isRetroTint,
   LOCKED_STAGE_KINDS,
@@ -15,6 +16,7 @@ import {
   MAX_STAGES,
   newPromptId,
   newStageEntry,
+  orderStagesBy,
   reorderKeepsLocks,
   renumberPrompts,
   seedStages,
@@ -30,6 +32,7 @@ import {
   CARDS_STILL_ANSWER,
   FORMAT_NAME_REQUIRED,
   LAST_PROMPT,
+  NAME_INVALID,
   NO_TEAM_GROUP,
   NOT_A_RETRO,
   NOT_CURRENT_STAGE,
@@ -148,11 +151,14 @@ function resolveCreateShape(
 ): { format: StampedFormat; stages: StageEntry[] } {
   const hasTeam = args.team !== undefined;
   if (args.format) {
+    // An edited copy without a stage list seeds as its base library entry
+    // does (a Lean Coffee copy keeps its visible collect), else the standard.
+    const base = findFormat(args.format.name);
     return {
       format: validateStampedFormat(args.format),
       stages: args.stages
         ? validateStageList(args.stages)
-        : seedStages({ collectVisible: false }, { hasTeam }),
+        : seedStages({ collectVisible: base?.collectVisible }, { hasTeam }),
     };
   }
   const library = args.formatName === undefined ? undefined : findFormat(args.formatName);
@@ -331,6 +337,25 @@ export async function setTimebox(
 // --- Settings (ADR-0021, spec §6.4) ---
 
 /**
+ * Rename the retro. The room's name rule is shared with poker; its plain
+ * error becomes a `forbidden` refusal here so the retro client can tell a
+ * rule from a transient failure (spec §4.5).
+ */
+export async function renameRetro(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; name: string }
+): Promise<void> {
+  let name: string;
+  try {
+    name = validateRoomName(args.name);
+  } catch (error) {
+    throw refusal("forbidden", error instanceof Error ? error.message : NAME_INVALID);
+  }
+  await ctx.db.patch(args.roomId, { name });
+  await updateRoomActivity(ctx, args.roomId);
+}
+
+/**
  * The join policy (ADR-0013): `teamMembers` is offered only when a Team
  * keeps the retro, since nobody could satisfy it otherwise.
  */
@@ -387,12 +412,12 @@ export interface PromptEdit {
   label?: string;
   /** An empty string clears the hint. */
   hint?: string;
-  color?: string;
 }
 
 /**
- * Edit a prompt's label, hint or tint at any stage. Renaming changes no
- * card: a card stores the prompt's id, never its label (ADR-0016).
+ * Edit a prompt's label or hint at any stage (spec §6.4; the tint is a
+ * create-form choice, §6.1). Renaming changes no card: a card stores the
+ * prompt's id, never its label (ADR-0016).
  */
 export async function updatePrompt(
   ctx: MutationCtx,
@@ -405,7 +430,6 @@ export async function updatePrompt(
   }
   const edited: FormatPrompt = { ...prompt };
   if (args.label !== undefined) edited.label = validatePromptLabel(args.label);
-  if (args.color !== undefined) edited.color = validateTint(args.color);
   if (args.hint !== undefined) {
     const hint = args.hint.trim();
     if (hint) edited.hint = hint;
@@ -494,11 +518,7 @@ export async function addStage(
     throw refusal("forbidden", TOO_MANY_STAGES);
   }
   const entry = newStageEntry(args.kind);
-  const at =
-    args.index === undefined ? retro.stages.length : Math.max(0, Math.min(args.index, retro.stages.length));
-  const stages = [...retro.stages];
-  stages.splice(at, 0, entry);
-  await writeStages(ctx, retro, stages);
+  await writeStages(ctx, retro, insertStage(retro.stages, entry, args.index));
   return entry.id;
 }
 
@@ -530,9 +550,9 @@ export async function removeStage(
 }
 
 /**
- * Reorder the list: a permutation of the existing ids in which `collect`,
- * `discuss` and the current entry hold their index. Entries are re-listed,
- * never rewritten.
+ * Reorder the list (spec §6.4): a permutation in which the current entry
+ * keeps its index and collect stays ahead of discuss; see
+ * `reorderKeepsLocks`. Entries are re-listed, never rewritten.
  */
 export async function reorderStages(
   ctx: MutationCtx,
@@ -546,12 +566,7 @@ export async function reorderStages(
       check.reason === "not-a-permutation" ? STAGE_ORDER_INVALID : STAGE_ORDER_LOCKED
     );
   }
-  const byId = new Map(retro.stages.map((stage) => [stage.id, stage]));
-  await writeStages(
-    ctx,
-    retro,
-    args.stageIds.map((id) => byId.get(id)!)
-  );
+  await writeStages(ctx, retro, orderStagesBy(retro.stages, args.stageIds));
 }
 
 /**

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -1,15 +1,25 @@
 import { MutationCtx, QueryCtx } from "../_generated/server";
 import { Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
-import { DEFAULT_RETRO_PERMISSIONS } from "../permissions";
+import { DEFAULT_RETRO_PERMISSIONS, type JoinPolicy } from "../permissions";
 import { validateRoomName, updateRoomActivity } from "./rooms";
 import { deleteRoomAggregateChunk } from "./roomAggregate";
 import { listTeamsForUser } from "./teams";
 import {
   currentStageOf,
   findFormat,
+  isLockedKindEntry,
+  isRetroTint,
+  LOCKED_STAGE_KINDS,
+  MAX_PROMPTS,
+  MAX_STAGES,
+  newPromptId,
+  newStageEntry,
+  reorderKeepsLocks,
+  renumberPrompts,
   seedStages,
   stampFormat,
+  type FormatPrompt,
   type StageEntry,
   type StageKind,
   type Visibility,
@@ -17,13 +27,29 @@ import {
 } from "./retroFormats";
 import {
   ALREADY_KEPT_BY_TEAM,
+  CARDS_STILL_ANSWER,
+  FORMAT_NAME_REQUIRED,
+  LAST_PROMPT,
   NO_TEAM_GROUP,
   NOT_A_RETRO,
-  ONLY_OWNER_CAN_ADOPT,
   NOT_CURRENT_STAGE,
+  ONLY_OWNER_CAN_ADOPT,
+  PROMPT_IDS_UNIQUE,
+  PROMPT_LABEL_REQUIRED,
+  PROMPT_NOT_FOUND,
+  STAGE_CURRENT_LOCKED,
   STAGE_ENTRY_NOT_FOUND,
+  STAGE_IDS_UNIQUE,
+  STAGE_KIND_LOCKED,
+  STAGE_ORDER_INVALID,
+  STAGE_ORDER_LOCKED,
+  TEAM_MEMBERS_NEEDS_TEAM,
   TIMEBOX_INVALID,
+  TINT_OUTSIDE_PALETTE,
+  TOO_MANY_PROMPTS,
+  TOO_MANY_STAGES,
   UNKNOWN_FORMAT,
+  VOTE_BUDGET_INVALID,
 } from "../retroCopy";
 import { refusal } from "./refusal";
 
@@ -37,8 +63,16 @@ import { refusal } from "./refusal";
 export interface CreateRetroArgs {
   name: string;
   ownerId: Id<"users">;
-  /** A library format's name; the edited-copy seam is #290's. */
-  formatName: string;
+  /** A library format's name, stamped as shipped; `format` takes precedence. */
+  formatName?: string;
+  /**
+   * The edited copy from the create form (ADR-0021): stamped as given,
+   * under whatever name the creator left on it. The shipped constant is
+   * never read for it.
+   */
+  format?: StampedFormat;
+  /** The edited stage list; the standard seed when absent. */
+  stages?: StageEntry[];
   /** Advisory cards-due date (ADR-0020). */
   collectUntil?: number;
   /**
@@ -61,10 +95,7 @@ export async function createRetro(
   ctx: MutationCtx,
   args: CreateRetroArgs
 ): Promise<Id<"rooms">> {
-  const format = findFormat(args.formatName);
-  if (!format) {
-    throw refusal("missing", UNKNOWN_FORMAT);
-  }
+  const { format, stages } = resolveCreateShape(args);
   const name = validateRoomName(args.name);
   const now = Date.now();
   // Copied by value, whole (ADR-0008): the room's stored values are
@@ -85,11 +116,10 @@ export async function createRetro(
     permissions: { ...(defaults?.permissions ?? DEFAULT_RETRO_PERMISSIONS) },
   });
 
-  const stages = seedStages(format, { hasTeam: args.team !== undefined });
   await ctx.db.insert("retros", {
     roomId,
     attribution: defaults?.attribution ?? "named",
-    format: stampFormat(format),
+    format,
     stages,
     currentStageId: stages[0].id,
     currentStageEnteredAt: now,
@@ -105,6 +135,89 @@ export async function createRetro(
   });
 
   return roomId;
+}
+
+/**
+ * What creation stamps: the edited copy when the form sent one, else the
+ * library entry by name; the edited stage list when sent, else the seed.
+ * Both are validated as data — the shipped constant is never consulted for
+ * an edited copy, so an edit there can never leak back into it.
+ */
+function resolveCreateShape(
+  args: Pick<CreateRetroArgs, "formatName" | "format" | "stages" | "team">
+): { format: StampedFormat; stages: StageEntry[] } {
+  const hasTeam = args.team !== undefined;
+  if (args.format) {
+    return {
+      format: validateStampedFormat(args.format),
+      stages: args.stages
+        ? validateStageList(args.stages)
+        : seedStages({ collectVisible: false }, { hasTeam }),
+    };
+  }
+  const library = args.formatName === undefined ? undefined : findFormat(args.formatName);
+  if (!library) {
+    throw refusal("missing", UNKNOWN_FORMAT);
+  }
+  return {
+    format: stampFormat(library),
+    stages: args.stages ? validateStageList(args.stages) : seedStages(library, { hasTeam }),
+  };
+}
+
+/** A stamped format as data: a name, one to ten prompts with unique ids, labels and palette tints. */
+export function validateStampedFormat(format: StampedFormat): StampedFormat {
+  const name = format.name.trim();
+  if (!name) {
+    throw refusal("forbidden", FORMAT_NAME_REQUIRED);
+  }
+  if (format.prompts.length === 0) {
+    throw refusal("forbidden", LAST_PROMPT);
+  }
+  if (format.prompts.length > MAX_PROMPTS) {
+    throw refusal("forbidden", TOO_MANY_PROMPTS);
+  }
+  if (new Set(format.prompts.map((p) => p.id)).size !== format.prompts.length) {
+    throw refusal("forbidden", PROMPT_IDS_UNIQUE);
+  }
+  const prompts = renumberPrompts(
+    format.prompts.map((p) => {
+      const prompt: FormatPrompt = {
+        id: p.id,
+        label: validatePromptLabel(p.label),
+        color: validateTint(p.color),
+        order: p.order,
+      };
+      const hint = p.hint?.trim();
+      if (hint) prompt.hint = hint;
+      return prompt;
+    })
+  );
+  return { name, prompts };
+}
+
+/** A stage list as data: one to ten entries, unique ids, at least one collect and one discuss. */
+export function validateStageList(stages: readonly StageEntry[]): StageEntry[] {
+  if (stages.length > MAX_STAGES) {
+    throw refusal("forbidden", TOO_MANY_STAGES);
+  }
+  if (new Set(stages.map((s) => s.id)).size !== stages.length) {
+    throw refusal("forbidden", STAGE_IDS_UNIQUE);
+  }
+  for (const kind of LOCKED_STAGE_KINDS) {
+    if (!stages.some((s) => s.kind === kind)) {
+      throw refusal("forbidden", STAGE_KIND_LOCKED);
+    }
+  }
+  for (const stage of stages) {
+    if (stage.voteBudget !== undefined && (!Number.isInteger(stage.voteBudget) || stage.voteBudget <= 0)) {
+      throw refusal("forbidden", VOTE_BUDGET_INVALID);
+    }
+    if (stage.timeboxMinutes !== undefined && (!Number.isInteger(stage.timeboxMinutes) || stage.timeboxMinutes <= 0)) {
+      throw refusal("forbidden", TIMEBOX_INVALID);
+    }
+  }
+  return stages.map((stage) => ({ ...stage }));
 }
 
 /** The retros row of a room, or null for a poker room. */
@@ -213,6 +326,232 @@ export async function setTimebox(
     const { timeboxMinutes: _dropped, ...rest } = entry;
     return minutes === undefined ? rest : { ...rest, timeboxMinutes: minutes };
   });
+}
+
+// --- Settings (ADR-0021, spec §6.4) ---
+
+/**
+ * The join policy (ADR-0013): `teamMembers` is offered only when a Team
+ * keeps the retro, since nobody could satisfy it otherwise.
+ */
+export async function setJoinPolicy(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; joinPolicy: JoinPolicy }
+): Promise<void> {
+  if (args.joinPolicy === "teamMembers" && args.room.teamId === undefined) {
+    throw refusal("forbidden", TEAM_MEMBERS_NEEDS_TEAM);
+  }
+  await ctx.db.patch(args.room._id, { joinPolicy: args.joinPolicy });
+  await updateRoomActivity(ctx, args.room._id);
+}
+
+/** The advisory cards-due date (ADR-0020); undefined clears it. It closes nothing. */
+export async function setCollectUntil(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; collectUntil?: number }
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  await ctx.db.patch(retro._id, { collectUntil: args.collectUntil });
+  await updateRoomActivity(ctx, args.roomId);
+}
+
+/** The label, trimmed, or a refusal when blank. */
+function validatePromptLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) {
+    throw refusal("forbidden", PROMPT_LABEL_REQUIRED);
+  }
+  return trimmed;
+}
+
+function validateTint(color: string): string {
+  if (!isRetroTint(color)) {
+    throw refusal("forbidden", TINT_OUTSIDE_PALETTE);
+  }
+  return color;
+}
+
+/** Write the retro's prompts back, renumbered; the name is kept. */
+async function writePrompts(
+  ctx: MutationCtx,
+  retro: Doc<"retros">,
+  prompts: readonly FormatPrompt[]
+): Promise<void> {
+  await ctx.db.patch(retro._id, {
+    format: { ...retro.format, prompts: renumberPrompts(prompts) },
+  });
+  await updateRoomActivity(ctx, retro.roomId);
+}
+
+export interface PromptEdit {
+  label?: string;
+  /** An empty string clears the hint. */
+  hint?: string;
+  color?: string;
+}
+
+/**
+ * Edit a prompt's label, hint or tint at any stage. Renaming changes no
+ * card: a card stores the prompt's id, never its label (ADR-0016).
+ */
+export async function updatePrompt(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; promptId: string } & PromptEdit
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  const prompt = retro.format.prompts.find((p) => p.id === args.promptId);
+  if (!prompt) {
+    throw refusal("missing", PROMPT_NOT_FOUND);
+  }
+  const edited: FormatPrompt = { ...prompt };
+  if (args.label !== undefined) edited.label = validatePromptLabel(args.label);
+  if (args.color !== undefined) edited.color = validateTint(args.color);
+  if (args.hint !== undefined) {
+    const hint = args.hint.trim();
+    if (hint) edited.hint = hint;
+    else delete edited.hint;
+  }
+  await writePrompts(
+    ctx,
+    retro,
+    retro.format.prompts.map((p) => (p.id === prompt.id ? edited : p))
+  );
+}
+
+/** Add a prompt at any stage, last in order, up to the cap. */
+export async function addPrompt(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; label: string; hint?: string; color: string }
+): Promise<string> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (retro.format.prompts.length >= MAX_PROMPTS) {
+    throw refusal("forbidden", TOO_MANY_PROMPTS);
+  }
+  const prompt: FormatPrompt = {
+    id: newPromptId(),
+    label: validatePromptLabel(args.label),
+    color: validateTint(args.color),
+    order: retro.format.prompts.length,
+  };
+  const hint = args.hint?.trim();
+  if (hint) prompt.hint = hint;
+  await writePrompts(ctx, retro, [...retro.format.prompts, prompt]);
+  return prompt.id;
+}
+
+/**
+ * Remove a prompt only while no card answers it (spec §6.4): a card keeps
+ * its prompt id for life, so removing an answered prompt would orphan it.
+ * The check reads the card table through `by_room_prompt`. `forbidden`,
+ * never `stage`: the rule is about cards, not the pointer.
+ */
+export async function removePrompt(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; promptId: string }
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (!retro.format.prompts.some((p) => p.id === args.promptId)) {
+    throw refusal("missing", PROMPT_NOT_FOUND);
+  }
+  if (retro.format.prompts.length <= 1) {
+    throw refusal("forbidden", LAST_PROMPT);
+  }
+  const answered = await ctx.db
+    .query("retroCards")
+    .withIndex("by_room_prompt", (q) => q.eq("roomId", args.roomId).eq("promptId", args.promptId))
+    .first();
+  if (answered) {
+    throw refusal("forbidden", CARDS_STILL_ANSWER);
+  }
+  await writePrompts(
+    ctx,
+    retro,
+    retro.format.prompts.filter((p) => p.id !== args.promptId)
+  );
+}
+
+/** Write the stage list back; the pointer is untouched. */
+async function writeStages(
+  ctx: MutationCtx,
+  retro: Doc<"retros">,
+  stages: readonly StageEntry[]
+): Promise<void> {
+  await ctx.db.patch(retro._id, { stages: [...stages] });
+  await updateRoomActivity(ctx, retro.roomId);
+}
+
+/**
+ * Add an entry of a kind with the seed's defaults, at `index` or at the
+ * end, up to the cap. Any kind may repeat (a second vote is a second round
+ * of dots); the existing entries are the same rows afterwards.
+ */
+export async function addStage(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; kind: StageKind; index?: number }
+): Promise<string> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (retro.stages.length >= MAX_STAGES) {
+    throw refusal("forbidden", TOO_MANY_STAGES);
+  }
+  const entry = newStageEntry(args.kind);
+  const at =
+    args.index === undefined ? retro.stages.length : Math.max(0, Math.min(args.index, retro.stages.length));
+  const stages = [...retro.stages];
+  stages.splice(at, 0, entry);
+  await writeStages(ctx, retro, stages);
+  return entry.id;
+}
+
+/**
+ * Remove an entry except `collect`, `discuss` and the current one (spec
+ * §6.4): the two kinds because the write stage and the walk stay in every
+ * retro (a second entry of either is free to go), the current one because
+ * the ground under the shared pointer never moves.
+ */
+export async function removeStage(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; stageId: string }
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  if (!retro.stages.some((stage) => stage.id === args.stageId)) {
+    throw refusal("missing", STAGE_ENTRY_NOT_FOUND);
+  }
+  if (isLockedKindEntry(retro.stages, args.stageId)) {
+    throw refusal("forbidden", STAGE_KIND_LOCKED);
+  }
+  if (args.stageId === retro.currentStageId) {
+    throw refusal("forbidden", STAGE_CURRENT_LOCKED);
+  }
+  await writeStages(
+    ctx,
+    retro,
+    retro.stages.filter((stage) => stage.id !== args.stageId)
+  );
+}
+
+/**
+ * Reorder the list: a permutation of the existing ids in which `collect`,
+ * `discuss` and the current entry hold their index. Entries are re-listed,
+ * never rewritten.
+ */
+export async function reorderStages(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; stageIds: string[] }
+): Promise<void> {
+  const retro = await requireRetro(ctx, args.roomId);
+  const check = reorderKeepsLocks(retro.stages, args.stageIds, retro.currentStageId);
+  if (!check.ok) {
+    throw refusal(
+      "forbidden",
+      check.reason === "not-a-permutation" ? STAGE_ORDER_INVALID : STAGE_ORDER_LOCKED
+    );
+  }
+  const byId = new Map(retro.stages.map((stage) => [stage.id, stage]));
+  await writeStages(
+    ctx,
+    retro,
+    args.stageIds.map((id) => byId.get(id)!)
+  );
 }
 
 /**

--- a/convex/model/retroFormats.ts
+++ b/convex/model/retroFormats.ts
@@ -66,16 +66,17 @@ export function newStageEntryId(): string {
   return crypto.randomUUID();
 }
 
+/** Every stage kind, in the seed's order. */
+export const STAGE_KINDS: readonly StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
+
 export const DEFAULT_VOTE_BUDGET = 5;
 
 /** A retro carries at most ten prompts and ten stage entries (spec §2). */
 export const MAX_PROMPTS = 10;
 export const MAX_STAGES = 10;
 
-/** A fresh prompt id for a prompt added after the library's. */
-export function newPromptId(): string {
-  return crypto.randomUUID();
-}
+/** A fresh prompt id for a prompt added after the library's; the same minting as a stage's. */
+export const newPromptId = newStageEntryId;
 
 export function isRetroTint(color: string): color is RetroTint {
   return (RETRO_TINTS as readonly string[]).includes(color);
@@ -202,8 +203,7 @@ export function seedStages(
   format: Pick<RetroFormat, "collectVisible">,
   options: { hasTeam: boolean }
 ): StageEntry[] {
-  const kinds: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
-  return kinds
+  return STAGE_KINDS
     .filter((kind) => options.hasTeam || kind !== "review")
     .map((kind) => newStageEntry(kind, { collectVisible: format.collectVisible }));
 }

--- a/convex/model/retroFormats.ts
+++ b/convex/model/retroFormats.ts
@@ -243,10 +243,12 @@ export function isLockedKindEntry(stages: readonly StageEntry[], stageId: string
 }
 
 /**
- * Whether `next` is a permutation of `stages` in which every locked entry —
- * the last of a locked kind, and the current entry when there is one —
- * keeps its index. The reorder rule for the create form and the running
- * retro alike.
+ * Whether `nextIds` is a legal reorder of `stages` (spec §6.4): a
+ * permutation in which the current entry keeps its index (the ground under
+ * the shared pointer never moves) and the locked kinds keep their order
+ * among themselves (collect stays ahead of discuss); every other entry may
+ * be placed anywhere, before or after them. The rule for the create form
+ * (no current entry) and the running retro alike.
  */
 export function reorderKeepsLocks(
   stages: readonly StageEntry[],
@@ -260,9 +262,29 @@ export function reorderKeepsLocks(
   if (!ids.every((id) => nextIds.includes(id))) {
     return { ok: false, reason: "not-a-permutation" };
   }
-  const held = ids.every(
-    (id, index) =>
-      (!isLockedKindEntry(stages, id) && id !== currentStageId) || nextIds[index] === id
-  );
+  if (currentStageId !== undefined && ids.indexOf(currentStageId) !== nextIds.indexOf(currentStageId)) {
+    return { ok: false, reason: "locked-moved" };
+  }
+  const lockedBefore = ids.filter((id) => isLockedKindEntry(stages, id));
+  const lockedAfter = nextIds.filter((id) => isLockedKindEntry(stages, id));
+  const held = lockedBefore.every((id, i) => lockedAfter[i] === id);
   return held ? { ok: true } : { ok: false, reason: "locked-moved" };
+}
+
+/** The list with `entry` inserted at `index` (clamped), or at the end. */
+export function insertStage(
+  stages: readonly StageEntry[],
+  entry: StageEntry,
+  index?: number
+): StageEntry[] {
+  const next = [...stages];
+  const at = index === undefined ? next.length : Math.max(0, Math.min(index, next.length));
+  next.splice(at, 0, entry);
+  return next;
+}
+
+/** The same entries re-listed in the order of `ids`; the caller has checked `ids` is a permutation. */
+export function orderStagesBy(stages: readonly StageEntry[], ids: readonly string[]): StageEntry[] {
+  const byId = new Map(stages.map((stage) => [stage.id, stage]));
+  return ids.map((id) => byId.get(id)!);
 }

--- a/convex/model/retroFormats.ts
+++ b/convex/model/retroFormats.ts
@@ -68,6 +68,24 @@ export function newStageEntryId(): string {
 
 export const DEFAULT_VOTE_BUDGET = 5;
 
+/** A retro carries at most ten prompts and ten stage entries (spec §2). */
+export const MAX_PROMPTS = 10;
+export const MAX_STAGES = 10;
+
+/** A fresh prompt id for a prompt added after the library's. */
+export function newPromptId(): string {
+  return crypto.randomUUID();
+}
+
+export function isRetroTint(color: string): color is RetroTint {
+  return (RETRO_TINTS as readonly string[]).includes(color);
+}
+
+/** Prompts renumbered 0..n-1 in list order. */
+export function renumberPrompts(prompts: readonly FormatPrompt[]): FormatPrompt[] {
+  return prompts.map((prompt, order) => ({ ...prompt, order }));
+}
+
 /** The entry the shared pointer names; the first entry if the pointer dangles. */
 export function currentStageOf(retro: {
   stages: readonly StageEntry[];
@@ -187,16 +205,64 @@ export function seedStages(
   const kinds: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
   return kinds
     .filter((kind) => options.hasTeam || kind !== "review")
-    .map((kind) => {
-      const entry: StageEntry = {
-        // An entry's identity is its own, never its kind: a kind may repeat
-        // (a second vote entry is a second round of dots, ADR-0010, spec §2).
-        id: newStageEntryId(),
-        kind,
-        cardsVisible: kind === "collect" && !format.collectVisible ? "hidden" : "visible",
-        tallyVisible: kind === "vote" ? "hidden" : "visible",
-      };
-      if (kind === "vote") entry.voteBudget = DEFAULT_VOTE_BUDGET;
-      return entry;
-    });
+    .map((kind) => newStageEntry(kind, { collectVisible: format.collectVisible }));
+}
+
+/**
+ * A fresh entry of a kind with the seed's defaults: `collect` hides cards
+ * unless the format says otherwise, `vote` hides the tally and carries the
+ * default budget, everything else is visible with no budget.
+ */
+export function newStageEntry(
+  kind: StageKind,
+  options: { collectVisible?: boolean } = {}
+): StageEntry {
+  const entry: StageEntry = {
+    // An entry's identity is its own, never its kind: a kind may repeat
+    // (a second vote entry is a second round of dots, ADR-0010, spec §2).
+    id: newStageEntryId(),
+    kind,
+    cardsVisible: kind === "collect" && !options.collectVisible ? "hidden" : "visible",
+    tallyVisible: kind === "vote" ? "hidden" : "visible",
+  };
+  if (kind === "vote") entry.voteBudget = DEFAULT_VOTE_BUDGET;
+  return entry;
+}
+
+/** The kinds every retro keeps at least one of (ADR-0021): the write stage and the walk. */
+export const LOCKED_STAGE_KINDS: readonly StageKind[] = ["collect", "discuss"];
+
+/**
+ * Whether the entry is the last of a locked kind, so it can neither be
+ * removed nor moved. A second entry of the same kind is free.
+ */
+export function isLockedKindEntry(stages: readonly StageEntry[], stageId: string): boolean {
+  const entry = stages.find((stage) => stage.id === stageId);
+  if (!entry || !LOCKED_STAGE_KINDS.includes(entry.kind)) return false;
+  return stages.filter((stage) => stage.kind === entry.kind).length === 1;
+}
+
+/**
+ * Whether `next` is a permutation of `stages` in which every locked entry —
+ * the last of a locked kind, and the current entry when there is one —
+ * keeps its index. The reorder rule for the create form and the running
+ * retro alike.
+ */
+export function reorderKeepsLocks(
+  stages: readonly StageEntry[],
+  nextIds: readonly string[],
+  currentStageId?: string
+): { ok: true } | { ok: false; reason: "not-a-permutation" | "locked-moved" } {
+  const ids = stages.map((stage) => stage.id);
+  if (nextIds.length !== ids.length || new Set(nextIds).size !== ids.length) {
+    return { ok: false, reason: "not-a-permutation" };
+  }
+  if (!ids.every((id) => nextIds.includes(id))) {
+    return { ok: false, reason: "not-a-permutation" };
+  }
+  const held = ids.every(
+    (id, index) =>
+      (!isLockedKindEntry(stages, id) && id !== currentStageId) || nextIds[index] === id
+  );
+  return held ? { ok: true } : { ok: false, reason: "locked-moved" };
 }

--- a/convex/model/rooms.ts
+++ b/convex/model/rooms.ts
@@ -192,9 +192,11 @@ export const RETRO_ACTIVITY_GRANULARITY_MS = 60 * 60 * 1000;
  */
 export async function updateRoomActivity(
   ctx: MutationCtx,
-  roomId: Id<"rooms">
+  roomOrId: Doc<"rooms"> | Id<"rooms">
 ): Promise<void> {
-  const room = await ctx.db.get(roomId);
+  // A caller whose guard already loaded the room passes the row; the id
+  // form re-reads it.
+  const room = typeof roomOrId === "string" ? await ctx.db.get(roomOrId) : roomOrId;
   if (!room) return;
   const now = Date.now();
   if (
@@ -203,7 +205,7 @@ export async function updateRoomActivity(
   ) {
     return;
   }
-  await ctx.db.patch(roomId, { lastActivityAt: now });
+  await ctx.db.patch(room._id, { lastActivityAt: now });
 }
 
 /**

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -1,7 +1,14 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import * as Retro from "./model/retro";
-import { visibilityValidator } from "./schema";
+import {
+  joinPolicyValidator,
+  retroFormatValidator,
+  retroStageValidator,
+  stageKindValidator,
+  visibilityValidator,
+} from "./schema";
+import * as Rooms from "./model/rooms";
 import { refusal } from "./model/refusal";
 import { ROOM_NOT_FOUND } from "./retroCopy";
 import {
@@ -21,7 +28,12 @@ import {
 export const create = mutation({
   args: {
     name: v.string(),
-    formatName: v.string(),
+    /** A library format by name, stamped as shipped. */
+    formatName: v.optional(v.string()),
+    /** The create form's edited copy (spec §6.1); wins over `formatName`. */
+    format: v.optional(retroFormatValidator),
+    /** The create form's edited stage list; the standard seed when absent. */
+    stages: v.optional(v.array(retroStageValidator)),
     collectUntil: v.optional(v.number()),
     teamId: v.optional(v.id("teams")),
   },
@@ -71,6 +83,103 @@ export const setTimebox = mutation({
   handler: async (ctx, args) => {
     await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
     await Retro.setTimebox(ctx, args);
+  },
+});
+
+// --- Settings (ADR-0021, spec §6.4) ---
+
+/** Rename the retro (`retroSettings`). */
+export const rename = mutation({
+  args: { roomId: v.id("rooms"), name: v.string() },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Rooms.renameRoom(ctx, args);
+  },
+});
+
+/** Edit who may join (`retroSettings`); `teamMembers` only on a team retro. */
+export const setJoinPolicy = mutation({
+  args: { roomId: v.id("rooms"), joinPolicy: joinPolicyValidator },
+  handler: async (ctx, args) => {
+    const { room } = await requireCan(ctx, args.roomId, {
+      kind: "category",
+      category: "retroSettings",
+    });
+    await Retro.setJoinPolicy(ctx, { room, joinPolicy: args.joinPolicy });
+  },
+});
+
+/** The advisory cards-due date; omit to clear (`retroSettings`). */
+export const setCollectUntil = mutation({
+  args: { roomId: v.id("rooms"), collectUntil: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Retro.setCollectUntil(ctx, args);
+  },
+});
+
+/** Edit a prompt's label, hint or tint at any stage (`retroSettings`). */
+export const updatePrompt = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    promptId: v.string(),
+    label: v.optional(v.string()),
+    hint: v.optional(v.string()),
+    color: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Retro.updatePrompt(ctx, args);
+  },
+});
+
+/** Add a prompt at any stage, up to ten (`retroSettings`). Returns its id. */
+export const addPrompt = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    label: v.string(),
+    hint: v.optional(v.string()),
+    color: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    return await Retro.addPrompt(ctx, args);
+  },
+});
+
+/** Remove a prompt no card answers (`retroSettings`). */
+export const removePrompt = mutation({
+  args: { roomId: v.id("rooms"), promptId: v.string() },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Retro.removePrompt(ctx, args);
+  },
+});
+
+/** Add a stage entry of a kind, at an index or at the end (`retroSettings`). Returns its id. */
+export const addStage = mutation({
+  args: { roomId: v.id("rooms"), kind: stageKindValidator, index: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    return await Retro.addStage(ctx, args);
+  },
+});
+
+/** Remove a stage entry except collect, discuss and the current one (`retroSettings`). */
+export const removeStage = mutation({
+  args: { roomId: v.id("rooms"), stageId: v.string() },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Retro.removeStage(ctx, args);
+  },
+});
+
+/** Reorder the stage list; collect, discuss and the current entry hold their place (`retroSettings`). */
+export const reorderStages = mutation({
+  args: { roomId: v.id("rooms"), stageIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
+    await Retro.reorderStages(ctx, args);
   },
 });
 

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -52,7 +52,7 @@ export const board = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
     await requireRoomReader(ctx, args.roomId);
-    return await Retro.getBoard(ctx, args.roomId);
+    return await Retro.requireRetro(ctx, args.roomId);
   },
 });
 
@@ -62,8 +62,9 @@ export const board = query({
 export const advance = mutation({
   args: { roomId: v.id("rooms"), toStageId: v.string() },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
-    await Retro.advance(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "stageFlow" });
+    await Retro.advance(ctx, { room, ...rest });
   },
 });
 
@@ -71,8 +72,9 @@ export const advance = mutation({
 export const setCardsVisible = mutation({
   args: { roomId: v.id("rooms"), stageId: v.string(), value: visibilityValidator },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
-    await Retro.setCardsVisible(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "stageFlow" });
+    await Retro.setCardsVisible(ctx, { room, ...rest });
   },
 });
 
@@ -80,8 +82,9 @@ export const setCardsVisible = mutation({
 export const setTimebox = mutation({
   args: { roomId: v.id("rooms"), stageId: v.string(), minutes: v.optional(v.number()) },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "stageFlow" });
-    await Retro.setTimebox(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "stageFlow" });
+    await Retro.setTimebox(ctx, { room, ...rest });
   },
 });
 
@@ -91,8 +94,9 @@ export const setTimebox = mutation({
 export const rename = mutation({
   args: { roomId: v.id("rooms"), name: v.string() },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.renameRetro(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.renameRetro(ctx, { room, ...rest });
   },
 });
 
@@ -112,8 +116,9 @@ export const setJoinPolicy = mutation({
 export const setCollectUntil = mutation({
   args: { roomId: v.id("rooms"), collectUntil: v.optional(v.number()) },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.setCollectUntil(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.setCollectUntil(ctx, { room, ...rest });
   },
 });
 
@@ -126,8 +131,9 @@ export const updatePrompt = mutation({
     hint: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.updatePrompt(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.updatePrompt(ctx, { room, ...rest });
   },
 });
 
@@ -140,8 +146,9 @@ export const addPrompt = mutation({
     color: v.string(),
   },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    return await Retro.addPrompt(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    return await Retro.addPrompt(ctx, { room, ...rest });
   },
 });
 
@@ -149,8 +156,9 @@ export const addPrompt = mutation({
 export const removePrompt = mutation({
   args: { roomId: v.id("rooms"), promptId: v.string() },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.removePrompt(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.removePrompt(ctx, { room, ...rest });
   },
 });
 
@@ -158,8 +166,9 @@ export const removePrompt = mutation({
 export const addStage = mutation({
   args: { roomId: v.id("rooms"), kind: stageKindValidator, index: v.optional(v.number()) },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    return await Retro.addStage(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    return await Retro.addStage(ctx, { room, ...rest });
   },
 });
 
@@ -167,8 +176,9 @@ export const addStage = mutation({
 export const removeStage = mutation({
   args: { roomId: v.id("rooms"), stageId: v.string() },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.removeStage(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.removeStage(ctx, { room, ...rest });
   },
 });
 
@@ -176,8 +186,9 @@ export const removeStage = mutation({
 export const reorderStages = mutation({
   args: { roomId: v.id("rooms"), stageIds: v.array(v.string()) },
   handler: async (ctx, args) => {
-    await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Retro.reorderStages(ctx, args);
+    const { roomId, ...rest } = args;
+    const { room } = await requireCan(ctx, roomId, { kind: "category", category: "retroSettings" });
+    await Retro.reorderStages(ctx, { room, ...rest });
   },
 });
 

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -8,7 +8,6 @@ import {
   stageKindValidator,
   visibilityValidator,
 } from "./schema";
-import * as Rooms from "./model/rooms";
 import { refusal } from "./model/refusal";
 import { ROOM_NOT_FOUND } from "./retroCopy";
 import {
@@ -93,7 +92,7 @@ export const rename = mutation({
   args: { roomId: v.id("rooms"), name: v.string() },
   handler: async (ctx, args) => {
     await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });
-    await Rooms.renameRoom(ctx, args);
+    await Retro.renameRetro(ctx, args);
   },
 });
 
@@ -118,14 +117,13 @@ export const setCollectUntil = mutation({
   },
 });
 
-/** Edit a prompt's label, hint or tint at any stage (`retroSettings`). */
+/** Edit a prompt's label or hint at any stage (`retroSettings`). */
 export const updatePrompt = mutation({
   args: {
     roomId: v.id("rooms"),
     promptId: v.string(),
     label: v.optional(v.string()),
     hint: v.optional(v.string()),
-    color: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await requireCan(ctx, args.roomId, { kind: "category", category: "retroSettings" });

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -147,6 +147,29 @@ export const NO_TEAM_OPTION = NO_TEAM_GROUP;
 export const NEW_TEAM_OPTION = "New team…";
 export const TEAM_DESCRIPTION = "A team keeps the retro and decides who can read it later.";
 
+// --- Prompt and stage-list edits (spec §6.4) ---
+
+export const PROMPT_LABEL_REQUIRED = "A prompt needs a label";
+export const TINT_OUTSIDE_PALETTE = "Pick a tint from the palette";
+export const PROMPT_NOT_FOUND = "That prompt is no longer in this retro";
+export const TOO_MANY_PROMPTS = "A retro has at most 10 prompts";
+export const LAST_PROMPT = "A retro needs at least one prompt";
+/** `removePrompt` while a card answers it: a `forbidden` refusal, not `stage`. */
+export const CARDS_STILL_ANSWER = "Cards still answer this prompt";
+
+export const TOO_MANY_STAGES = "A retro has at most 10 stages";
+export const FORMAT_NAME_REQUIRED = "A format needs a name";
+export const PROMPT_IDS_UNIQUE = "Every prompt needs its own id";
+export const STAGE_IDS_UNIQUE = "Every stage needs its own id";
+export const VOTE_BUDGET_INVALID = "Vote budget must be a whole number of dots";
+export const STAGE_KIND_LOCKED = "Collect and Discuss stay in every retro";
+export const STAGE_CURRENT_LOCKED = "The current stage keeps its place";
+export const STAGE_ORDER_LOCKED = "Collect, Discuss and the current stage keep their place";
+export const STAGE_ORDER_INVALID = "The new order must list every stage once";
+
+/** `setJoinPolicy` to `teamMembers` on a retro no Team keeps. */
+export const TEAM_MEMBERS_NEEDS_TEAM = "Only a team retro can be limited to team members";
+
 /** `adoptIntoTeam` by an attendee who does not own the room. */
 export const ONLY_OWNER_CAN_ADOPT = "Only the room owner can give this retro to a team.";
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -53,6 +53,8 @@ export const RETRO_NAME_DESCRIPTION = "Leave empty for a dated name";
 export const FORMAT_LABEL = "Format";
 export const FORMAT_CHANGE = "Change";
 export const FORMAT_COLLAPSE = "Done";
+/** The picker line under a Team's own edited format (ADR-0021). */
+export const LAST_USED_DESCRIPTION = "What this team used last.";
 export const COLLECT_UNTIL_LABEL = "Cards due";
 export const COLLECT_UNTIL_DESCRIPTION =
   "Optional. Shown on the board as a reminder; it closes nothing by itself.";
@@ -146,6 +148,40 @@ export const TEAM_LABEL = "Team";
 export const NO_TEAM_OPTION = NO_TEAM_GROUP;
 export const NEW_TEAM_OPTION = "New team…";
 export const TEAM_DESCRIPTION = "A team keeps the retro and decides who can read it later.";
+
+// --- Retro settings (spec §6.4) ---
+
+export const SETTINGS_MENU_ITEM = "Retro settings…";
+export const SETTINGS_TITLE = "Retro settings";
+export const SETTINGS_DESCRIPTION =
+  "Prompts and stages can change at any stage. Collect, Discuss and the current stage keep their place.";
+export const JOIN_POLICY_LABEL = "Who can join";
+export const JOIN_POLICY_OPTIONS: { value: "anyone" | "permanentAccounts" | "teamMembers"; label: string }[] = [
+  { value: "anyone", label: "Anyone with the link" },
+  { value: "permanentAccounts", label: "Signed-in accounts" },
+  { value: "teamMembers", label: "Team members" },
+];
+export const SETTINGS_FAILED = "That change did not go through. Try again.";
+
+// --- The format editor (spec §6.1, §6.4) ---
+
+export const FORMAT_NAME_LABEL = "Format name";
+export const PROMPTS_TITLE = "Prompts";
+export const PROMPT_LABEL_FIELD = "Prompt label";
+export const PROMPT_HINT_FIELD = "Hint";
+export const PROMPT_HINT_PLACEHOLDER = "Shown while writing, never on the board";
+export const TINT_FIELD = "Tint";
+export const ADD_PROMPT = "Add prompt";
+export const NEW_PROMPT_LABEL = "New prompt";
+export const removePromptLabel = (label: string) => `Remove ${label}`;
+export const STAGES_TITLE = "Stages";
+export const ADD_STAGE = "Add stage";
+export const removeStageLabel = (label: string) => `Remove ${label}`;
+export const moveStageUpLabel = (label: string) => `Move ${label} up`;
+export const moveStageDownLabel = (label: string) => `Move ${label} down`;
+export const cardsHiddenIn = (label: string) => `Cards hidden in ${label}`;
+export const cardsVisibleIn = (label: string) => `Cards visible in ${label}`;
+export const CURRENT_STAGE_TAG = "current";
 
 // --- Prompt and stage-list edits (spec §6.4) ---
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -195,6 +195,7 @@ export const CARDS_STILL_ANSWER = "Cards still answer this prompt";
 
 export const TOO_MANY_STAGES = "A retro has at most 10 stages";
 export const FORMAT_NAME_REQUIRED = "A format needs a name";
+export const NAME_INVALID = "That name will not do";
 export const PROMPT_IDS_UNIQUE = "Every prompt needs its own id";
 export const STAGE_IDS_UNIQUE = "Every stage needs its own id";
 export const VOTE_BUDGET_INVALID = "Vote budget must be a whole number of dots";

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -5,6 +5,7 @@
  * imports here. Later retro tickets extend it; #300 tests the register
  * against it.
  */
+import type { JoinPolicy } from "./permissions";
 
 // --- Board header disclosures (ADR-0008, ADR-0019) ---
 
@@ -156,7 +157,7 @@ export const SETTINGS_TITLE = "Retro settings";
 export const SETTINGS_DESCRIPTION =
   "Prompts and stages can change at any stage. Collect, Discuss and the current stage keep their place.";
 export const JOIN_POLICY_LABEL = "Who can join";
-export const JOIN_POLICY_OPTIONS: { value: "anyone" | "permanentAccounts" | "teamMembers"; label: string }[] = [
+export const JOIN_POLICY_OPTIONS: { value: JoinPolicy; label: string }[] = [
   { value: "anyone", label: "Anyone with the link" },
   { value: "permanentAccounts", label: "Signed-in accounts" },
   { value: "teamMembers", label: "Team members" },

--- a/convex/retroSettings.test.ts
+++ b/convex/retroSettings.test.ts
@@ -55,7 +55,7 @@ async function seedCard(t: T, roomId: Id<"rooms">, promptId: string) {
 }
 
 describe("retro.rename, setJoinPolicy, setCollectUntil", () => {
-  it("a retroSettings holder renames the retro; a participant at defaults is refused", async () => {
+  it("a retroSettings holder renames the retro; a participant at defaults and a blank name are refused", async () => {
     const t = convexTest(schema, modules);
     const { roomId } = await seedRetro(t);
 
@@ -65,9 +65,9 @@ describe("retro.rename, setJoinPolicy, setCollectUntil", () => {
     await expect(
       as(t, "guest").mutation(api.retro.rename, { roomId, name: "Mine" })
     ).rejects.toThrow("Only facilitators and the owner");
-    await expect(
-      as(t, "owner").mutation(api.retro.rename, { roomId, name: "  " })
-    ).rejects.toThrow("Room name is required");
+    // A refusal, not a plain error (spec §4.5).
+    const blank = await as(t, "owner").mutation(api.retro.rename, { roomId, name: "  " }).catch((e) => e);
+    expect(blank.data).toEqual({ code: "forbidden", message: "Room name is required" });
   });
 
   it("edits the join policy, refusing teamMembers on a teamless retro", async () => {
@@ -102,7 +102,7 @@ describe("retro.rename, setJoinPolicy, setCollectUntil", () => {
 });
 
 describe("retro prompts", () => {
-  it("edits a prompt's label, hint and tint at any stage, changing no card", async () => {
+  it("edits a prompt's label and hint at any stage, changing no card", async () => {
     const t = convexTest(schema, modules);
     const { roomId, retro } = await seedRetro(t);
     const prompt = retro.format.prompts[0];
@@ -115,7 +115,6 @@ describe("retro prompts", () => {
       promptId: prompt.id,
       label: "What worked?",
       hint: "Keep it.",
-      color: "teal",
     });
 
     const after = await retroRow(t, roomId);
@@ -123,7 +122,6 @@ describe("retro prompts", () => {
       ...prompt,
       label: "What worked?",
       hint: "Keep it.",
-      color: "teal",
     });
     expect(after.format.prompts.slice(1)).toEqual(retro.format.prompts.slice(1));
     expect((await t.run((ctx) => ctx.db.get(cardId)))?.promptId).toBe(prompt.id);
@@ -140,7 +138,7 @@ describe("retro prompts", () => {
       as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId, label: "  " })
     ).rejects.toThrow("A prompt needs a label");
     await expect(
-      as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId, color: "chartreuse" })
+      as(t, "owner").mutation(api.retro.addPrompt, { roomId, label: "P", color: "chartreuse" })
     ).rejects.toThrow("Pick a tint from the palette");
     await expect(
       as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId: "nope", label: "x" })
@@ -272,31 +270,35 @@ describe("retro stage list", () => {
     expect((await retroRow(t, roomId)).stages).toEqual(retro.stages);
   });
 
-  it("reorders the list as a permutation, with collect, discuss and the current entry holding their place", async () => {
+  it("reorders the list as a permutation: the current entry keeps its index, collect stays ahead of discuss, the rest move freely", async () => {
     const t = convexTest(schema, modules);
     const { roomId, retro } = await seedRetro(t);
     const [collect, group, vote, discuss, close] = retro.stages;
 
-    // Swap group and vote: collect (current) and discuss keep their index.
+    // Close moves ahead of discuss; vote after it. Collect (current) keeps index 0.
     await as(t, "owner").mutation(api.retro.reorderStages, {
       roomId,
-      stageIds: [collect.id, vote.id, group.id, discuss.id, close.id],
+      stageIds: [collect.id, group.id, close.id, discuss.id, vote.id],
     });
     const after = await retroRow(t, roomId);
-    expect(after.stages).toEqual([collect, vote, group, discuss, close]);
+    expect(after.stages).toEqual([collect, group, close, discuss, vote]);
 
+    // The current entry shifted.
     await expect(
       as(t, "owner").mutation(api.retro.reorderStages, {
         roomId,
-        stageIds: [vote.id, collect.id, group.id, discuss.id, close.id],
+        stageIds: [group.id, collect.id, close.id, discuss.id, vote.id],
       })
     ).rejects.toThrow("Collect, Discuss and the current stage keep their place");
+    // Discuss ahead of collect.
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: vote.id });
     await expect(
       as(t, "owner").mutation(api.retro.reorderStages, {
         roomId,
-        stageIds: [collect.id, vote.id, group.id, close.id, discuss.id],
+        stageIds: [discuss.id, group.id, close.id, collect.id, vote.id],
       })
     ).rejects.toThrow("Collect, Discuss and the current stage keep their place");
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: collect.id });
     await expect(
       as(t, "owner").mutation(api.retro.reorderStages, {
         roomId,
@@ -315,7 +317,7 @@ describe("retro stage list", () => {
         stageIds: [collect.id, group.id, vote.id, discuss.id, close.id],
       })
     ).rejects.toThrow("Only facilitators and the owner");
-    expect((await retroRow(t, roomId)).stages).toEqual([collect, vote, group, discuss, close]);
+    expect((await retroRow(t, roomId)).stages).toEqual([collect, group, close, discuss, vote]);
   });
 });
 

--- a/convex/retroSettings.test.ts
+++ b/convex/retroSettings.test.ts
@@ -1,0 +1,394 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT, RETRO_FORMATS, findFormat } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+
+// Retro settings (ADR-0021, spec §6.4, §23.1): under `retroSettings` a
+// holder renames the retro, edits the join policy and the cards-due date,
+// edits prompts at any stage, and edits the stage list except `collect`,
+// `discuss` and the current entry. Past entries are never rewritten; a
+// prompt with cards is never removed; the shipped constant is never touched.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string, accountType?: "anonymous" | "permanent") =>
+  seedNamedUser(t, authUserId, authUserId, accountType);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+/** An owner and a participant in a fresh teamless retro. */
+async function seedRetro(t: T, formatName = DEFAULT_RETRO_FORMAT.name) {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, { name: "R", formatName });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  const retro = await retroRow(t, roomId);
+  return { roomId, retro };
+}
+
+/** A card answering `promptId`, seeded directly (the cards ticket owns the write). */
+async function seedCard(t: T, roomId: Id<"rooms">, promptId: string) {
+  return t.run((ctx) =>
+    ctx.db.insert("retroCards", {
+      roomId,
+      clientId: crypto.randomUUID(),
+      text: "a card",
+      promptId,
+      position: { x: 0, y: 0 },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      committedAt: Date.now(),
+    })
+  );
+}
+
+describe("retro.rename, setJoinPolicy, setCollectUntil", () => {
+  it("a retroSettings holder renames the retro; a participant at defaults is refused", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+
+    await as(t, "owner").mutation(api.retro.rename, { roomId, name: "Sprint 43" });
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.name).toBe("Sprint 43");
+
+    await expect(
+      as(t, "guest").mutation(api.retro.rename, { roomId, name: "Mine" })
+    ).rejects.toThrow("Only facilitators and the owner");
+    await expect(
+      as(t, "owner").mutation(api.retro.rename, { roomId, name: "  " })
+    ).rejects.toThrow("Room name is required");
+  });
+
+  it("edits the join policy, refusing teamMembers on a teamless retro", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+
+    await as(t, "owner").mutation(api.retro.setJoinPolicy, { roomId, joinPolicy: "permanentAccounts" });
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.joinPolicy).toBe("permanentAccounts");
+
+    await expect(
+      as(t, "owner").mutation(api.retro.setJoinPolicy, { roomId, joinPolicy: "teamMembers" })
+    ).rejects.toThrow("Only a team retro can be limited to team members");
+    await expect(
+      as(t, "guest").mutation(api.retro.setJoinPolicy, { roomId, joinPolicy: "anyone" })
+    ).rejects.toThrow("Only facilitators and the owner");
+    expect((await t.run((ctx) => ctx.db.get(roomId)))?.joinPolicy).toBe("permanentAccounts");
+  });
+
+  it("sets and clears the cards-due date", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const due = Date.now() + 86_400_000;
+
+    await as(t, "owner").mutation(api.retro.setCollectUntil, { roomId, collectUntil: due });
+    expect((await retroRow(t, roomId)).collectUntil).toBe(due);
+    await as(t, "owner").mutation(api.retro.setCollectUntil, { roomId });
+    expect((await retroRow(t, roomId)).collectUntil).toBeUndefined();
+    await expect(
+      as(t, "guest").mutation(api.retro.setCollectUntil, { roomId, collectUntil: due })
+    ).rejects.toThrow("Only facilitators and the owner");
+  });
+});
+
+describe("retro prompts", () => {
+  it("edits a prompt's label, hint and tint at any stage, changing no card", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const prompt = retro.format.prompts[0];
+    const cardId = await seedCard(t, roomId, prompt.id);
+    // Not in collect: prompt edits are not a stage act.
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: retro.stages[2].id });
+
+    await as(t, "owner").mutation(api.retro.updatePrompt, {
+      roomId,
+      promptId: prompt.id,
+      label: "What worked?",
+      hint: "Keep it.",
+      color: "teal",
+    });
+
+    const after = await retroRow(t, roomId);
+    expect(after.format.prompts[0]).toEqual({
+      ...prompt,
+      label: "What worked?",
+      hint: "Keep it.",
+      color: "teal",
+    });
+    expect(after.format.prompts.slice(1)).toEqual(retro.format.prompts.slice(1));
+    expect((await t.run((ctx) => ctx.db.get(cardId)))?.promptId).toBe(prompt.id);
+    // The shipped constant is untouched.
+    expect(DEFAULT_RETRO_FORMAT.prompts[0].label).toBe("What went well?");
+  });
+
+  it("refuses a blank label, a tint outside the palette, an unknown prompt and a participant", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const promptId = retro.format.prompts[0].id;
+
+    await expect(
+      as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId, label: "  " })
+    ).rejects.toThrow("A prompt needs a label");
+    await expect(
+      as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId, color: "chartreuse" })
+    ).rejects.toThrow("Pick a tint from the palette");
+    await expect(
+      as(t, "owner").mutation(api.retro.updatePrompt, { roomId, promptId: "nope", label: "x" })
+    ).rejects.toThrow("That prompt is no longer in this retro");
+    await expect(
+      as(t, "guest").mutation(api.retro.updatePrompt, { roomId, promptId, label: "x" })
+    ).rejects.toThrow("Only facilitators and the owner");
+    expect((await retroRow(t, roomId)).format).toEqual(retro.format);
+  });
+
+  it("adds prompts up to ten, each with a fresh id and the next order", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const start = retro.format.prompts.length;
+
+    for (let i = start; i < 10; i++) {
+      await as(t, "owner").mutation(api.retro.addPrompt, {
+        roomId,
+        label: `Prompt ${i}`,
+        color: "pink",
+      });
+    }
+    const after = await retroRow(t, roomId);
+    expect(after.format.prompts).toHaveLength(10);
+    expect(after.format.prompts.map((p) => p.order)).toEqual([...Array(10).keys()]);
+    expect(new Set(after.format.prompts.map((p) => p.id)).size).toBe(10);
+    expect(after.format.prompts[start]).toMatchObject({ label: `Prompt ${start}`, color: "pink" });
+
+    await expect(
+      as(t, "owner").mutation(api.retro.addPrompt, { roomId, label: "Eleven", color: "pink" })
+    ).rejects.toThrow("A retro has at most 10 prompts");
+    expect((await retroRow(t, roomId)).format.prompts).toHaveLength(10);
+  });
+
+  it("removes a prompt only while no card answers it, and never the last one", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const [answered, free] = retro.format.prompts;
+    await seedCard(t, roomId, answered.id);
+
+    await expect(
+      as(t, "owner").mutation(api.retro.removePrompt, { roomId, promptId: answered.id })
+    ).rejects.toThrow("Cards still answer this prompt");
+
+    await as(t, "owner").mutation(api.retro.removePrompt, { roomId, promptId: free.id });
+    const after = await retroRow(t, roomId);
+    expect(after.format.prompts.map((p) => p.id)).toEqual(
+      retro.format.prompts.filter((p) => p.id !== free.id).map((p) => p.id)
+    );
+    expect(after.format.prompts.map((p) => p.order)).toEqual([0, 1]);
+
+    await expect(
+      as(t, "owner").mutation(api.retro.removePrompt, { roomId, promptId: answered.id })
+    ).rejects.toThrow("Cards still answer this prompt");
+
+    // With its cards gone the prompt may go, but never the last one.
+    await t.run(async (ctx) => {
+      for await (const card of ctx.db.query("retroCards").withIndex("by_room", (q) => q.eq("roomId", roomId))) {
+        await ctx.db.delete(card._id);
+      }
+    });
+    await as(t, "owner").mutation(api.retro.removePrompt, { roomId, promptId: answered.id });
+    const only = (await retroRow(t, roomId)).format.prompts;
+    expect(only).toHaveLength(1);
+    await expect(
+      as(t, "owner").mutation(api.retro.removePrompt, { roomId, promptId: only[0].id })
+    ).rejects.toThrow("A retro needs at least one prompt");
+  });
+});
+
+describe("retro stage list", () => {
+  it("adds an entry with its kind's defaults, at an index or at the end, up to ten", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    expect(retro.stages.map((s) => s.kind)).toEqual(["collect", "group", "vote", "discuss", "close"]);
+
+    const reviewId = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "review", index: 1 });
+    const voteId = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "vote" });
+    const after = await retroRow(t, roomId);
+    expect(after.stages.map((s) => s.kind)).toEqual(["collect", "review", "group", "vote", "discuss", "close", "vote"]);
+    expect(after.stages[1]).toEqual({ id: reviewId, kind: "review", cardsVisible: "visible", tallyVisible: "visible" });
+    expect(after.stages[6]).toEqual({ id: voteId, kind: "vote", cardsVisible: "visible", tallyVisible: "hidden", voteBudget: 5 });
+    // The earlier entries are the same rows: past entries are never rewritten.
+    expect(after.stages.filter((s) => s.id !== reviewId && s.id !== voteId)).toEqual(retro.stages);
+    expect(after.currentStageId).toBe(retro.currentStageId);
+
+    for (let i = after.stages.length; i < 10; i++) {
+      await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "group" });
+    }
+    await expect(
+      as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "close" })
+    ).rejects.toThrow("A retro has at most 10 stages");
+    expect((await retroRow(t, roomId)).stages).toHaveLength(10);
+  });
+
+  it("removes any entry except collect, discuss and the current one", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const byKind = Object.fromEntries(retro.stages.map((s) => [s.kind, s]));
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: byKind.group.id });
+
+    await expect(
+      as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: byKind.collect.id })
+    ).rejects.toThrow("Collect and Discuss stay in every retro");
+    await expect(
+      as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: byKind.discuss.id })
+    ).rejects.toThrow("Collect and Discuss stay in every retro");
+    await expect(
+      as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: byKind.group.id })
+    ).rejects.toThrow("The current stage keeps its place");
+    await expect(
+      as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: "nope" })
+    ).rejects.toThrow("That stage is no longer in this retro");
+    await expect(
+      as(t, "guest").mutation(api.retro.removeStage, { roomId, stageId: byKind.vote.id })
+    ).rejects.toThrow("Only facilitators and the owner");
+
+    await as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: byKind.vote.id });
+    const after = await retroRow(t, roomId);
+    expect(after.stages.map((s) => s.kind)).toEqual(["collect", "group", "discuss", "close"]);
+    expect(after.currentStageId).toBe(byKind.group.id);
+  });
+
+  it("a second entry of a locked kind may go; the last of its kind may not", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const second = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "discuss" });
+    await as(t, "owner").mutation(api.retro.removeStage, { roomId, stageId: second });
+    expect((await retroRow(t, roomId)).stages).toEqual(retro.stages);
+  });
+
+  it("reorders the list as a permutation, with collect, discuss and the current entry holding their place", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro } = await seedRetro(t);
+    const [collect, group, vote, discuss, close] = retro.stages;
+
+    // Swap group and vote: collect (current) and discuss keep their index.
+    await as(t, "owner").mutation(api.retro.reorderStages, {
+      roomId,
+      stageIds: [collect.id, vote.id, group.id, discuss.id, close.id],
+    });
+    const after = await retroRow(t, roomId);
+    expect(after.stages).toEqual([collect, vote, group, discuss, close]);
+
+    await expect(
+      as(t, "owner").mutation(api.retro.reorderStages, {
+        roomId,
+        stageIds: [vote.id, collect.id, group.id, discuss.id, close.id],
+      })
+    ).rejects.toThrow("Collect, Discuss and the current stage keep their place");
+    await expect(
+      as(t, "owner").mutation(api.retro.reorderStages, {
+        roomId,
+        stageIds: [collect.id, vote.id, group.id, close.id, discuss.id],
+      })
+    ).rejects.toThrow("Collect, Discuss and the current stage keep their place");
+    await expect(
+      as(t, "owner").mutation(api.retro.reorderStages, {
+        roomId,
+        stageIds: [collect.id, vote.id, group.id, discuss.id],
+      })
+    ).rejects.toThrow("The new order must list every stage once");
+    await expect(
+      as(t, "owner").mutation(api.retro.reorderStages, {
+        roomId,
+        stageIds: [collect.id, vote.id, vote.id, discuss.id, close.id],
+      })
+    ).rejects.toThrow("The new order must list every stage once");
+    await expect(
+      as(t, "guest").mutation(api.retro.reorderStages, {
+        roomId,
+        stageIds: [collect.id, group.id, vote.id, discuss.id, close.id],
+      })
+    ).rejects.toThrow("Only facilitators and the owner");
+    expect((await retroRow(t, roomId)).stages).toEqual([collect, vote, group, discuss, close]);
+  });
+});
+
+describe("retro.create — the edited copy (spec §6.1)", () => {
+  const shippedSnapshot = JSON.stringify(RETRO_FORMATS);
+
+  it("stamps the edited prompts and stage list under the creator's name, leaving the shipped constant untouched", async () => {
+    const t = convexTest(schema, modules);
+    await seedUser(t, "owner");
+    const base = findFormat("Sailboat")!;
+    const format = {
+      name: "Our sailboat",
+      prompts: [
+        ...base.prompts.map((p, i) => (i === 0 ? { ...p, label: "Tailwind", color: "pink" } : { ...p })),
+        { id: "storm", label: "Storm", hint: "A risk we saw coming.", color: "violet", order: 4 },
+      ],
+    };
+    const stages = [
+      { id: "c", kind: "collect" as const, cardsVisible: "visible" as const, tallyVisible: "visible" as const },
+      { id: "v", kind: "vote" as const, cardsVisible: "visible" as const, tallyVisible: "hidden" as const, voteBudget: 3 },
+      { id: "d", kind: "discuss" as const, cardsVisible: "visible" as const, tallyVisible: "visible" as const },
+    ];
+
+    const roomId = await as(t, "owner").mutation(api.retro.create, { name: "R", format, stages });
+
+    const retro = await retroRow(t, roomId);
+    expect(retro.format).toEqual(format);
+    expect(retro.stages).toEqual(stages);
+    expect(retro.currentStageId).toBe("c");
+    expect(JSON.stringify(RETRO_FORMATS)).toBe(shippedSnapshot);
+    expect(findFormat("Sailboat")!.prompts[0].label).toBe("Wind");
+  });
+
+  it("an edited copy keeps its base name when the creator did not rename it", async () => {
+    const t = convexTest(schema, modules);
+    await seedUser(t, "owner");
+    const roomId = await as(t, "owner").mutation(api.retro.create, {
+      name: "R",
+      format: { name: DEFAULT_RETRO_FORMAT.name, prompts: [{ id: "one", label: "One", color: "blue", order: 0 }] },
+    });
+    const retro = await retroRow(t, roomId);
+    expect(retro.format.name).toBe(DEFAULT_RETRO_FORMAT.name);
+    expect(retro.format.prompts).toHaveLength(1);
+    // No stages given: the standard seed for a teamless retro.
+    expect(retro.stages.map((s) => s.kind)).toEqual(["collect", "group", "vote", "discuss", "close"]);
+  });
+
+  it("refuses an eleventh prompt, a list without collect or discuss, and a tint outside the palette", async () => {
+    const t = convexTest(schema, modules);
+    await seedUser(t, "owner");
+    const prompts = Array.from({ length: 11 }, (_, i) => ({ id: `p${i}`, label: `P${i}`, color: "blue", order: i }));
+    await expect(
+      as(t, "owner").mutation(api.retro.create, { name: "R", format: { name: "X", prompts } })
+    ).rejects.toThrow("A retro has at most 10 prompts");
+    await expect(
+      as(t, "owner").mutation(api.retro.create, {
+        name: "R",
+        format: { name: "X", prompts: prompts.slice(0, 1) },
+        stages: [{ id: "g", kind: "group", cardsVisible: "visible", tallyVisible: "visible" }],
+      })
+    ).rejects.toThrow("Collect and Discuss stay in every retro");
+    await expect(
+      as(t, "owner").mutation(api.retro.create, {
+        name: "R",
+        format: { name: "X", prompts: [{ id: "p", label: "P", color: "mauve", order: 0 }] },
+      })
+    ).rejects.toThrow("Pick a tint from the palette");
+    await expect(
+      as(t, "owner").mutation(api.retro.create, {
+        name: "R",
+        format: { name: "X", prompts: [{ id: "p", label: " ", color: "blue", order: 0 }] },
+      })
+    ).rejects.toThrow("A prompt needs a label");
+    expect(await t.run((ctx) => ctx.db.query("rooms").collect())).toEqual([]);
+  });
+});

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -560,6 +560,44 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     }
   });
 
+  it("every retroSettings mutation bumps (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t, false);
+    const retro = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const me = as(t, "auth-member");
+    const promptId = retro.format.prompts[0].id;
+    const close = retro.stages[retro.stages.length - 1];
+    const acts: (() => Promise<unknown>)[] = [
+      () => me.mutation(api.retro.rename, { roomId, name: "Renamed" }),
+      () => me.mutation(api.retro.setJoinPolicy, { roomId, joinPolicy: "permanentAccounts" }),
+      () => me.mutation(api.retro.setCollectUntil, { roomId, collectUntil: Date.now() + 1000 }),
+      () => me.mutation(api.retro.updatePrompt, { roomId, promptId, label: "Edited" }),
+      () => me.mutation(api.retro.addPrompt, { roomId, label: "New", color: "pink" }),
+      () => me.mutation(api.retro.removePrompt, { roomId, promptId: retro.format.prompts[1].id }),
+      () => me.mutation(api.retro.addStage, { roomId, kind: "review", index: 1 }),
+      () => me.mutation(api.retro.removeStage, { roomId, stageId: close.id }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+    // Reorder over whatever the list now holds: the review entry was added at 1, close removed.
+    const now = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const ids = now.stages.map((s) => s.id);
+    // Swap the two free entries after review (group, vote), keeping collect (current) and discuss.
+    const swapped = [ids[0], ids[1], ids[3], ids[2], ids[4]];
+    const stale = Date.now() - HOUR - 60_000;
+    await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+    await me.mutation(api.retro.reorderStages, { roomId, stageIds: swapped });
+    await expectBumped(t, roomId, stale);
+  });
+
   it("claim bumps", async () => {
     const t = convexTest(schema, modules);
     const { roomId, memberId, stale } = await seedTeamRetro(t, true);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -271,6 +271,7 @@ export default defineSchema({
   })
     .index("by_room", ["roomId"])
     .index("by_room_author", ["roomId", "authorId"])
+    .index("by_room_prompt", ["roomId", "promptId"]) // the prompt-removal check (spec §6.4)
     .index("by_room_client", ["roomId", "clientId"])
     .index("by_cluster", ["clusterId"]),
 

--- a/src/app/retro/new/create-content.test.tsx
+++ b/src/app/retro/new/create-content.test.tsx
@@ -265,12 +265,16 @@ describe("CreateRetroContent — editing the format before stamping (spec §6.1)
     expect(kinds()).toEqual(["collect", "group", "vote", "discuss", "close"]);
     fireEvent.click(editor.getByRole("button", { name: "Move Vote up" }));
     expect(kinds()).toEqual(["collect", "vote", "group", "discuss", "close"]);
-    // Group cannot move down past discuss; collect cannot move at all.
-    expect((editor.getByRole("button", { name: "Move Group down" }) as HTMLButtonElement).disabled).toBe(true);
-    expect((editor.getByRole("button", { name: "Move Collect down" }) as HTMLButtonElement).disabled).toBe(true);
+    // A free entry passes discuss; discuss never passes collect.
+    fireEvent.click(editor.getByRole("button", { name: "Move Close up" }));
+    expect(kinds()).toEqual(["collect", "vote", "group", "close", "discuss"]);
+    expect((editor.getByRole("button", { name: "Move Discuss up" }) as HTMLButtonElement).disabled).toBe(false);
+    expect((editor.getByRole("button", { name: "Move Collect up" }) as HTMLButtonElement).disabled).toBe(true);
     fireEvent.change(editor.getByLabelText("Add stage"), { target: { value: "review" } });
     fireEvent.click(editor.getByRole("button", { name: "Add stage" }));
-    expect(kinds()).toEqual(["collect", "vote", "group", "discuss", "close", "review"]);
+    expect(kinds()).toEqual(["collect", "vote", "group", "close", "discuss", "review"]);
+    fireEvent.click(editor.getByRole("button", { name: "Move Review up" }));
+    expect(kinds()).toEqual(["collect", "vote", "group", "close", "review", "discuss"]);
   });
 
   it("the creator may rename an edited format; a fresh library pick starts over from its stamp", async () => {

--- a/src/app/retro/new/create-content.test.tsx
+++ b/src/app/retro/new/create-content.test.tsx
@@ -180,14 +180,6 @@ describe("CreateRetroContent — team", () => {
     expect(screen.getByTestId("format-selected").textContent).toContain("4Ls");
   });
 
-  it("falls back to the default when the last format's name is not in the library", () => {
-    mocks.auth.accountType = "permanent";
-    mocks.searchParams = new URLSearchParams("team=team-1");
-    mocks.queries["retro.lastFormat"] = { name: "Our own", prompts: [] };
-    render(<CreateRetroContent />);
-    expect(screen.getByTestId("format-selected").textContent).toContain(DEFAULT_RETRO_FORMAT.name);
-  });
-
   it("New team opens the dialog and selects the Team it creates before the Teams read catches up", async () => {
     mocks.auth.accountType = "permanent";
     render(<CreateRetroContent />);
@@ -209,5 +201,110 @@ describe("CreateRetroContent — team", () => {
     mocks.queries["retro.lastFormat"] = undefined;
     render(<CreateRetroContent />);
     expect((screen.getByRole("button", { name: "Start retro" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("CreateRetroContent — editing the format before stamping (spec §6.1)", () => {
+  const shipped = JSON.stringify(RETRO_FORMATS);
+
+  function expandEditor() {
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    return screen.getByTestId("format-editor");
+  }
+
+  it("stamps the edited copy: a renamed prompt, an added prompt, a removed stage, a visible collect; the shipped constant is untouched", async () => {
+    render(<CreateRetroContent />);
+    const editor = within(expandEditor());
+
+    const first = editor.getAllByLabelText("Prompt label")[0] as HTMLInputElement;
+    expect(first.value).toBe("What went well?");
+    fireEvent.change(first, { target: { value: "What worked?" } });
+    fireEvent.blur(first);
+    fireEvent.change(editor.getAllByLabelText("Tint")[0], { target: { value: "teal" } });
+
+    fireEvent.click(editor.getByRole("button", { name: "Add prompt" }));
+    expect(editor.getAllByLabelText("Prompt label")).toHaveLength(4);
+
+    // Remove the vote stage; flip collect to visible.
+    fireEvent.click(editor.getByRole("button", { name: "Remove Vote" }));
+    fireEvent.click(editor.getByRole("button", { name: "Cards hidden in Collect" }));
+    expect(editor.getByRole("button", { name: "Cards visible in Collect" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start retro" }));
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1));
+    const args = mocks.create.mock.calls[0][0];
+    expect("formatName" in args).toBe(false);
+    expect(args.format.name).toBe(DEFAULT_RETRO_FORMAT.name);
+    expect(args.format.prompts.map((p: { label: string; color: string }) => [p.label, p.color])).toEqual([
+      ["What worked?", "teal"],
+      ["What should we do differently?", "amber"],
+      ["Ideas", "blue"],
+      ["New prompt", expect.any(String)],
+    ]);
+    expect(args.format.prompts.map((p: { order: number }) => p.order)).toEqual([0, 1, 2, 3]);
+    expect(args.stages.map((s: { kind: string }) => s.kind)).toEqual(["collect", "group", "discuss", "close"]);
+    expect(args.stages[0].cardsVisible).toBe("visible");
+    expect(JSON.stringify(RETRO_FORMATS)).toBe(shipped);
+  });
+
+  it("caps prompts at ten and never removes collect or discuss", () => {
+    render(<CreateRetroContent />);
+    const editor = within(expandEditor());
+    for (let i = 3; i < 10; i++) fireEvent.click(editor.getByRole("button", { name: "Add prompt" }));
+    expect(editor.getAllByLabelText("Prompt label")).toHaveLength(10);
+    expect((editor.getByRole("button", { name: "Add prompt" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((editor.getByRole("button", { name: "Remove Collect" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((editor.getByRole("button", { name: "Remove Discuss" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((editor.getByRole("button", { name: "Remove Group" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("reorders the free entries around collect and discuss, and adds an entry", () => {
+    render(<CreateRetroContent />);
+    const editor = within(expandEditor());
+    const kinds = () => editor.getAllByTestId("stage-row").map((r) => r.getAttribute("data-kind"));
+    expect(kinds()).toEqual(["collect", "group", "vote", "discuss", "close"]);
+    fireEvent.click(editor.getByRole("button", { name: "Move Vote up" }));
+    expect(kinds()).toEqual(["collect", "vote", "group", "discuss", "close"]);
+    // Group cannot move down past discuss; collect cannot move at all.
+    expect((editor.getByRole("button", { name: "Move Group down" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((editor.getByRole("button", { name: "Move Collect down" }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(editor.getByLabelText("Add stage"), { target: { value: "review" } });
+    fireEvent.click(editor.getByRole("button", { name: "Add stage" }));
+    expect(kinds()).toEqual(["collect", "vote", "group", "discuss", "close", "review"]);
+  });
+
+  it("the creator may rename an edited format; a fresh library pick starts over from its stamp", async () => {
+    render(<CreateRetroContent />);
+    const editor = within(expandEditor());
+    fireEvent.change(editor.getByLabelText("Format name"), { target: { value: "Our three" } });
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByTestId("format-selected").textContent).toContain("Our three");
+
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    fireEvent.click(screen.getByLabelText("Lean Coffee"));
+    expect((within(screen.getByTestId("format-editor")).getByLabelText("Format name") as HTMLInputElement).value).toBe("Lean Coffee");
+    expect(within(screen.getByTestId("format-editor")).getByRole("button", { name: "Cards visible in Collect" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start retro" }));
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledTimes(1));
+    const args = mocks.create.mock.calls[0][0];
+    expect(args.format.name).toBe("Lean Coffee");
+    expect(args.stages[0].cardsVisible).toBe("visible");
+  });
+
+  it("pre-selects a Team's edited last format under its own name, with its prompts", () => {
+    mocks.auth.accountType = "permanent";
+    mocks.searchParams = new URLSearchParams("team=team-1");
+    mocks.queries["retro.lastFormat"] = {
+      name: "Our own",
+      prompts: [{ id: "x", label: "Keep", color: "green", order: 0 }],
+    };
+    render(<CreateRetroContent />);
+    expect(screen.getByTestId("format-selected").textContent).toContain("Our own");
+    expect(screen.getByTestId("format-selected").textContent).toContain("Keep");
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    const radios = within(screen.getByTestId("format-library")).getAllByRole("radio");
+    expect(radios[0].getAttribute("aria-label")).toBe("Our own");
+    expect(radios).toHaveLength(RETRO_FORMATS.length + 1);
   });
 });

--- a/src/app/retro/new/create-content.tsx
+++ b/src/app/retro/new/create-content.tsx
@@ -26,11 +26,25 @@ import { NewTeamDialog } from "@/components/team/new-team-dialog";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { tintClasses } from "@/components/retro/tints";
+import { FormatEditor } from "@/components/retro/format-editor";
+import {
+  addPrompt,
+  addStage,
+  draftFromLibrary,
+  removePrompt,
+  removeStage,
+  renameFormat,
+  reorderStages,
+  setCardsVisible,
+  updatePrompt,
+  type FormatDraft,
+} from "@/components/retro/format-draft";
 import {
   DEFAULT_RETRO_FORMAT,
   RETRO_FORMATS,
   findFormat,
   type RetroFormat,
+  type StampedFormat,
 } from "@/convex/model/retroFormats";
 import {
   COLLECT_UNTIL_DESCRIPTION,
@@ -41,6 +55,7 @@ import {
   FORMAT_CHANGE,
   FORMAT_COLLAPSE,
   FORMAT_LABEL,
+  LAST_USED_DESCRIPTION,
   NEW_RETRO_DESCRIPTION,
   NEW_RETRO_TITLE,
   NEW_TEAM_OPTION,
@@ -66,7 +81,7 @@ function parseCollectUntil(value: string): number | undefined {
 /** The picker's "New team" option value; never a Team id. */
 const NEW_TEAM_VALUE = "__new";
 
-function PromptList({ format }: { format: RetroFormat }) {
+function PromptList({ format }: { format: StampedFormat }) {
   return (
     <ul className="flex flex-wrap gap-1.5">
       {format.prompts.map((prompt) => {
@@ -91,8 +106,10 @@ function PromptList({ format }: { format: RetroFormat }) {
  * retro; `?team=` pre-selects one. The format opens pre-selected — the
  * chosen Team's newest retro's format, else the default — and collapsed to
  * one line; expanding shows the six-format library with the pre-selected
- * format first. The write-time disclosure shows before the retro exists.
- * Editing a format before stamping is #290.
+ * format first, and the chosen format's prompts and stage list, editable
+ * before stamping (ADR-0021): the edited copy is what is stamped, the
+ * shipped constant is never touched. The write-time disclosure shows before
+ * the retro exists.
  */
 export function CreateRetroContent() {
   const router = useRouter();
@@ -108,8 +125,8 @@ export function CreateRetroContent() {
    * reflects it, so a quick Start never creates a teamless retro.
    */
   const [createdTeam, setCreatedTeam] = useState<{ _id: Id<"teams">; name: string } | null>(null);
-  /** The person's explicit pick; null means "the pre-selection". */
-  const [chosenFormat, setChosenFormat] = useState<RetroFormat | null>(null);
+  /** The edited copy; null means "the pre-selection, unedited". */
+  const [draft, setDraft] = useState<FormatDraft | null>(null);
   const [libraryOpen, setLibraryOpen] = useState(false);
   const [collectUntil, setCollectUntil] = useState("");
   const [isCreating, setIsCreating] = useState(false);
@@ -125,18 +142,32 @@ export function CreateRetroContent() {
     selectedTeam ? { teamId: selectedTeam._id } : "skip"
   );
 
-  // Pre-selection (spec §6.1): the Team's newest retro's format when it is
-  // one the library carries, else the default. The edited-copy case (#290)
-  // widens this to the stamped format itself.
-  const preselected = useMemo(
-    () => (lastFormat ? findFormat(lastFormat.name) : undefined) ?? DEFAULT_RETRO_FORMAT,
-    [lastFormat]
-  );
-  const format = chosenFormat ?? preselected;
+  // Pre-selection (spec §6.1): the Team's newest retro's format, edited or
+  // not — a library entry when the name is one the library carries, else
+  // the stamped copy itself as a library entry of its own — else the default.
+  const preselected = useMemo<RetroFormat>(() => {
+    if (!lastFormat) return DEFAULT_RETRO_FORMAT;
+    return (
+      findFormat(lastFormat.name) ?? {
+        name: lastFormat.name,
+        description: LAST_USED_DESCRIPTION,
+        prompts: lastFormat.prompts,
+      }
+    );
+  }, [lastFormat]);
+  const hasTeam = selectedTeam !== undefined;
+  // The unedited draft of the pre-selection, minted once per pre-selection so
+  // its stage ids stay put across renders.
+  const baseDraft = useMemo(() => draftFromLibrary(preselected, { hasTeam }), [preselected, hasTeam]);
+  const current = draft ?? baseDraft;
   const library = useMemo(
     () => [preselected, ...RETRO_FORMATS.filter((entry) => entry.name !== preselected.name)],
     [preselected]
   );
+  /** The library entry the draft started from, by name; an edited name matches none. */
+  const [pickedName, setPickedName] = useState<string | null>(null);
+  const selectedName = pickedName ?? preselected.name;
+  const edit = (reduce: (d: FormatDraft) => FormatDraft) => setDraft(reduce(current));
 
   const handleTeamChange = (value: string) => {
     if (value === NEW_TEAM_VALUE) {
@@ -144,9 +175,10 @@ export function CreateRetroContent() {
       return;
     }
     setTeamId(value);
-    // A new Team brings its own pre-selection; a pick made for the old one
-    // does not carry over.
-    setChosenFormat(null);
+    // A new Team brings its own pre-selection and seed; a pick or an edit
+    // made for the old one does not carry over.
+    setDraft(null);
+    setPickedName(null);
   };
 
   const handleCreate = useCallback(async () => {
@@ -164,9 +196,15 @@ export function CreateRetroContent() {
 
     try {
       const due = parseCollectUntil(collectUntil);
+      // Unedited and shipped: by name, so the server stamps the constant.
+      // Edited, or a Team's own format: the copy itself, prompts and stages.
+      const shape =
+        draft === null && findFormat(preselected.name)
+          ? { formatName: preselected.name }
+          : { format: current.format, stages: current.stages };
       const roomId = await createRetro({
         name: name.trim() || defaultRetroName(new Date()),
-        formatName: format.name,
+        ...shape,
         ...(due !== undefined ? { collectUntil: due } : {}),
         ...(selectedTeam ? { teamId: selectedTeam._id } : {}),
       });
@@ -176,7 +214,7 @@ export function CreateRetroContent() {
       toast.error(CREATE_RETRO_FAILED);
       setIsCreating(false);
     }
-  }, [ensureSession, collectUntil, createRetro, name, format, selectedTeam, router]);
+  }, [ensureSession, collectUntil, createRetro, name, draft, preselected, current, selectedTeam, router]);
 
   // A Team named in the URL that the reads have not confirmed yet would be
   // silently dropped, and a Team whose last format is still loading would
@@ -240,7 +278,7 @@ export function CreateRetroContent() {
                       <div data-testid="format-library" className="space-y-2">
                         {library.map((entry) => {
                           const id = `format-${entry.name.replace(/\W+/g, "-").toLowerCase()}`;
-                          const selected = entry.name === format.name;
+                          const selected = entry.name === selectedName;
                           return (
                             <label
                               key={entry.name}
@@ -259,7 +297,10 @@ export function CreateRetroContent() {
                                   name="format"
                                   value={entry.name}
                                   checked={selected}
-                                  onChange={() => setChosenFormat(entry)}
+                                  onChange={() => {
+                                    setPickedName(entry.name);
+                                    setDraft(draftFromLibrary(entry, { hasTeam }));
+                                  }}
                                   aria-label={entry.name}
                                   className="mt-0.5 accent-primary"
                                 />
@@ -276,6 +317,17 @@ export function CreateRetroContent() {
                             </label>
                           );
                         })}
+                        <FormatEditor
+                          draft={current}
+                          onRenameFormat={(value) => edit((d) => renameFormat(d, value))}
+                          onUpdatePrompt={(promptId, change) => edit((d) => updatePrompt(d, promptId, change))}
+                          onAddPrompt={() => edit(addPrompt)}
+                          onRemovePrompt={(promptId) => edit((d) => removePrompt(d, promptId))}
+                          onAddStage={(kind) => edit((d) => addStage(d, kind))}
+                          onRemoveStage={(stageId) => edit((d) => removeStage(d, stageId))}
+                          onReorderStages={(ids) => edit((d) => reorderStages(d, ids))}
+                          onSetCardsVisible={(stageId, value) => edit((d) => setCardsVisible(d, stageId, value))}
+                        />
                         <Button
                           type="button"
                           variant="outline"
@@ -291,8 +343,8 @@ export function CreateRetroContent() {
                         className="flex items-center justify-between gap-3 rounded-lg border p-3"
                       >
                         <div className="min-w-0 space-y-1.5">
-                          <div className="truncate text-sm font-medium">{format.name}</div>
-                          <PromptList format={format} />
+                          <div className="truncate text-sm font-medium">{current.format.name}</div>
+                          <PromptList format={current.format} />
                         </div>
                         <Button
                           type="button"

--- a/src/app/retro/new/create-content.tsx
+++ b/src/app/retro/new/create-content.tsx
@@ -27,6 +27,7 @@ import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { tintClasses } from "@/components/retro/tints";
 import { FormatEditor } from "@/components/retro/format-editor";
+import { parseCollectUntil } from "@/components/retro/collect-until";
 import {
   addPrompt,
   addStage,
@@ -69,14 +70,6 @@ import {
   defaultRetroName,
   keptByTeam,
 } from "@/convex/retroCopy";
-
-/** A `<input type="date">` value as the end of that local day, or undefined. */
-function parseCollectUntil(value: string): number | undefined {
-  if (!value) return undefined;
-  const [y, m, d] = value.split("-").map(Number);
-  if (!y || !m || !d) return undefined;
-  return new Date(y, m - 1, d, 23, 59, 59).getTime();
-}
 
 /** The picker's "New team" option value; never a Team id. */
 const NEW_TEAM_VALUE = "__new";
@@ -164,9 +157,6 @@ export function CreateRetroContent() {
     () => [preselected, ...RETRO_FORMATS.filter((entry) => entry.name !== preselected.name)],
     [preselected]
   );
-  /** The library entry the draft started from, by name; an edited name matches none. */
-  const [pickedName, setPickedName] = useState<string | null>(null);
-  const selectedName = pickedName ?? preselected.name;
   const edit = (reduce: (d: FormatDraft) => FormatDraft) => setDraft(reduce(current));
 
   const handleTeamChange = (value: string) => {
@@ -178,7 +168,6 @@ export function CreateRetroContent() {
     // A new Team brings its own pre-selection and seed; a pick or an edit
     // made for the old one does not carry over.
     setDraft(null);
-    setPickedName(null);
   };
 
   const handleCreate = useCallback(async () => {
@@ -278,7 +267,8 @@ export function CreateRetroContent() {
                       <div data-testid="format-library" className="space-y-2">
                         {library.map((entry) => {
                           const id = `format-${entry.name.replace(/\W+/g, "-").toLowerCase()}`;
-                          const selected = entry.name === selectedName;
+                          // The draft carries its entry's name until renamed; a renamed one matches none.
+                          const selected = entry.name === current.format.name;
                           return (
                             <label
                               key={entry.name}
@@ -297,10 +287,7 @@ export function CreateRetroContent() {
                                   name="format"
                                   value={entry.name}
                                   checked={selected}
-                                  onChange={() => {
-                                    setPickedName(entry.name);
-                                    setDraft(draftFromLibrary(entry, { hasTeam }));
-                                  }}
+                                  onChange={() => setDraft(draftFromLibrary(entry, { hasTeam }))}
                                   aria-label={entry.name}
                                   className="mt-0.5 accent-primary"
                                 />

--- a/src/app/retro/new/create-content.tsx
+++ b/src/app/retro/new/create-content.tsx
@@ -319,6 +319,7 @@ export function CreateRetroContent() {
                         })}
                         <FormatEditor
                           draft={current}
+                          canEditTint
                           onRenameFormat={(value) => edit((d) => renameFormat(d, value))}
                           onUpdatePrompt={(promptId, change) => edit((d) => updatePrompt(d, promptId, change))}
                           onAddPrompt={() => edit(addPrompt)}

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -56,7 +56,9 @@ vi.mock("@/components/retro/retro-board", () => ({
   ),
 }));
 vi.mock("@/components/retro/retro-menu", () => ({
-  RetroMenu: ({ role }: { role: string }) => <div data-testid="menu">{role}</div>,
+  RetroMenu: ({ role, settings }: { role: string; settings?: { name: string; decision: { allowed: boolean } } }) => (
+    <div data-testid="menu" data-settings={settings?.name} data-settings-allowed={String(settings?.decision.allowed)}>{role}</div>
+  ),
 }));
 
 import { RetroRoomContent } from "./retro-room-content";
@@ -110,6 +112,8 @@ describe("RetroRoomContent", () => {
     render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
     expect(screen.getByTestId("board").textContent).toContain("s1");
     expect(screen.getByTestId("menu").textContent).toBe("owner");
+    expect(screen.getByTestId("menu").getAttribute("data-settings")).toBe("Sprint 12");
+    expect(screen.getByTestId("menu").getAttribute("data-settings-allowed")).toBe("true");
     expect(screen.queryByTestId("join-form")).toBeNull();
     expect(screen.queryByTestId("team-reader-banner")).toBeNull();
   });

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -182,6 +182,8 @@ function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: Atten
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
+  const retroSettings =
+    permissions.ceremony === "retro" ? permissions.retroSettings : NOT_A_RETRO_DECISION;
   return (
     <RetroBoard
       name={roomData.room.name}
@@ -196,6 +198,12 @@ function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: Atten
           role={role}
           isOwnerAbsent={roomData.isOwnerAbsent}
           myTeams={myTeams}
+          settings={{
+            name: roomData.room.name,
+            joinPolicy: roomData.room.joinPolicy ?? "anyone",
+            retro,
+            decision: retroSettings,
+          }}
         />
       }
     />

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
-import usePresence from "@convex-dev/presence/react";
 import { api } from "@/convex/_generated/api";
 import { Doc, Id } from "@/convex/_generated/dataModel";
 import { useAuth } from "@/components/auth/auth-provider";
@@ -15,19 +14,17 @@ import type { RetroTeam } from "@/components/retro/retro-header";
 import type { StageControls } from "@/components/retro/stage-nav";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
-import { usePermissions } from "@/hooks/usePermissions";
-import { toast } from "@/lib/toast";
+import { useRetroPermissions } from "@/hooks/usePermissions";
+import { useRoomPresence, type UserWithPresence } from "@/hooks/useRoomPresence";
+import { runAct } from "@/lib/run-act";
 import {
   CHECKING_SESSION,
   JOIN_RETRO_BUTTON,
   LOADING_BOARD,
   LOADING_TITLE,
-  NOT_A_RETRO,
   STAGE_ACT_FAILED,
   readingAsTeamMember,
 } from "@/convex/retroCopy";
-
-const NOT_A_RETRO_DECISION = { allowed: false, message: NOT_A_RETRO } as const;
 
 /** What `api.users.getMyMembership` returns for a member. */
 export type MyMembership = { _id: Id<"users"> };
@@ -63,6 +60,11 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const canRead = isMember || isTeamMember;
   // The board read takes the reader guard; never subscribe before it passes.
   const retro = useQuery(api.retro.board, canRead ? { roomId } : "skip");
+  // A Team reader never heartbeats, so their roster reads everyone offline.
+  const offlineUsers = useMemo<UserWithPresence[]>(
+    () => roomData.users.map((user) => ({ ...user, isOnline: false, lastSeen: null })),
+    [roomData.users]
+  );
 
   if (
     authLoading ||
@@ -93,7 +95,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
       <RetroBoard
         name={room.name}
         retro={retro}
-        users={roomData.users}
+        users={offlineUsers}
         team={team}
         banner={
           <div
@@ -140,55 +142,45 @@ interface AttendeeBoardProps {
  * exists; a Team reader never heartbeats.
  */
 function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: AttendeeBoardProps) {
-  const presence = usePresence(api.presence, roomId, userId);
+  const users = useRoomPresence(roomId, userId, roomData.users);
   const setReadiness = useMutation(api.presence.setReadiness);
   const advance = useMutation(api.retro.advance);
   const setCardsVisible = useMutation(api.retro.setCardsVisible);
   const setTimebox = useMutation(api.retro.setTimebox);
-  const permissions = usePermissions(roomData, userId);
-  // The room is a retro here (this branch mounts under the retro type), so
-  // the poker arm is a routing bug rather than a state; deny rather than throw.
-  const stageFlow = permissions.ceremony === "retro" ? permissions.stageFlow : NOT_A_RETRO_DECISION;
+  const { stageFlow, retroSettings } = useRetroPermissions(roomData, userId);
   const currentStageId = currentStageOf(retro).id;
-
-  const run = useCallback(async (act: Promise<unknown>) => {
-    try {
-      await act;
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : STAGE_ACT_FAILED);
-    }
-  }, []);
 
   const controls = useMemo<StageControls>(
     () => ({
       stageFlow,
-      onAdvance: (toStageId) => void run(advance({ roomId, toStageId })),
+      onAdvance: (toStageId) => void runAct(advance({ roomId, toStageId }), STAGE_ACT_FAILED),
       onSetCardsVisible: (value) =>
-        void run(setCardsVisible({ roomId, stageId: currentStageId, value })),
+        void runAct(setCardsVisible({ roomId, stageId: currentStageId, value }), STAGE_ACT_FAILED),
       onSetTimebox: (minutes) =>
-        void run(setTimebox({ roomId, stageId: currentStageId, ...(minutes !== undefined ? { minutes } : {}) })),
+        void runAct(
+          setTimebox({ roomId, stageId: currentStageId, ...(minutes !== undefined ? { minutes } : {}) }),
+          STAGE_ACT_FAILED
+        ),
     }),
-    [stageFlow, run, advance, setCardsVisible, setTimebox, roomId, currentStageId]
+    [stageFlow, advance, setCardsVisible, setTimebox, roomId, currentStageId]
   );
 
   const viewer = useMemo<BoardViewer>(
     () => ({
       userId,
-      presence,
-      onSetReady: (ready) => void run(setReadiness({ roomId, userId, stageId: currentStageId, ready })),
+      onSetReady: (ready) =>
+        void runAct(setReadiness({ roomId, userId, stageId: currentStageId, ready }), STAGE_ACT_FAILED),
       controls,
     }),
-    [userId, presence, run, setReadiness, roomId, currentStageId, controls]
+    [userId, setReadiness, roomId, currentStageId, controls]
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
-  const retroSettings =
-    permissions.ceremony === "retro" ? permissions.retroSettings : NOT_A_RETRO_DECISION;
   return (
     <RetroBoard
       name={roomData.room.name}
       retro={retro}
-      users={roomData.users}
+      users={users}
       team={team}
       viewer={viewer}
       menu={

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -31,6 +31,7 @@ import { RetroRows } from "@/components/retro/retro-list";
 import { TEAM_RETROS_EMPTY, TEAM_RETROS_TITLE } from "@/convex/retroCopy";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
 import { toast } from "@/lib/toast";
+import { runAct } from "@/lib/run-act";
 
 function Centered({ title, body }: { title: string; body: string }) {
   return (
@@ -41,20 +42,6 @@ function Centered({ title, body }: { title: string; body: string }) {
       </div>
     </div>
   );
-}
-
-/**
- * Every write on this page fails the same way: the server's refusal copy
- * (the last-admin rule, a stale role) or a fallback, in a toast.
- */
-async function run(fn: () => Promise<unknown>, fallback: string): Promise<boolean> {
-  try {
-    await fn();
-    return true;
-  } catch (error) {
-    toast.error(error instanceof Error ? error.message : fallback);
-    return false;
-  }
 }
 
 /**
@@ -104,7 +91,7 @@ export function TeamContent() {
     const trimmed = name.trim();
     setDraft(null);
     if (!trimmed || trimmed === team.name) return;
-    if (await run(() => rename({ teamId, name: trimmed }), "Failed to rename team")) {
+    if (await runAct(rename({ teamId, name: trimmed }), "Failed to rename team")) {
       toast.success("Team renamed");
     }
   };
@@ -118,21 +105,21 @@ export function TeamContent() {
   };
 
   const handleRotate = async () => {
-    if (await run(() => rotateInvite({ teamId }), "Failed to rotate the invite link")) {
+    if (await runAct(rotateInvite({ teamId }), "Failed to rotate the invite link")) {
       toast.success("Invite link rotated", { description: "The old link no longer works." });
     }
   };
 
   const roleMutations = { promote, demote };
   const handleRole = async (action: keyof typeof roleMutations, userId: Id<"users">) => {
-    await run(() => roleMutations[action]({ teamId, targetUserId: userId }), "Failed to change role");
+    await runAct(roleMutations[action]({ teamId, targetUserId: userId }), "Failed to change role");
   };
 
   const handleConfirmRemove = async () => {
     if (!pendingRemove) return;
     const removed = pendingRemove;
     setPendingRemove(null);
-    if (await run(() => removeMember({ teamId, targetUserId: removed.userId }), "Failed to remove member")) {
+    if (await runAct(removeMember({ teamId, targetUserId: removed.userId }), "Failed to remove member")) {
       toast.success("Member removed", {
         description: `${removed.name} no longer has access to this team's retros.`,
       });
@@ -142,7 +129,7 @@ export function TeamContent() {
   // Confirmations stay open on failure (the last-admin rule, most often),
   // so the next attempt is one click away.
   const handleLeave = async () => {
-    if (await run(() => leave({ teamId }), "Failed to leave the team")) {
+    if (await runAct(leave({ teamId }), "Failed to leave the team")) {
       setConfirmLeave(false);
       router.push("/dashboard/retros");
     }
@@ -151,11 +138,11 @@ export function TeamContent() {
   // No success toast here on purpose: the control itself shows the new
   // value, and a failure rolls it back (the panel's contract) with a toast.
   const handleRetroDefaults = (next: RetroDefaults) =>
-    run(() => updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
+    runAct(updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
 
   const handleDelete = async () => {
     setIsDeleting(true);
-    if (await run(() => deleteTeam({ teamId }), "Failed to delete team")) {
+    if (await runAct(deleteTeam({ teamId }), "Failed to delete team")) {
       toast.success(`${team.name} deleted`);
       router.push("/dashboard/retros");
     } else {

--- a/src/components/retro/collect-until.ts
+++ b/src/components/retro/collect-until.ts
@@ -1,0 +1,11 @@
+/**
+ * The cards-due field's value (ADR-0020): a `<input type="date">` string as
+ * the end of that local day, or undefined when blank. The create form and
+ * the settings dialog share the one reading of "due on the 10th".
+ */
+export function parseCollectUntil(value: string): number | undefined {
+  if (!value) return undefined;
+  const [y, m, d] = value.split("-").map(Number);
+  if (!y || !m || !d) return undefined;
+  return new Date(y, m - 1, d, 23, 59, 59).getTime();
+}

--- a/src/components/retro/format-draft.test.ts
+++ b/src/components/retro/format-draft.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The create form's format draft (ADR-0021, spec §6.1): pure reducers that
+ * refuse what the server would refuse — the ten-prompt and ten-stage caps,
+ * the collect/discuss locks, the current entry's index — by returning the
+ * draft unchanged, so the form never sends a shape creation rejects.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  addPrompt,
+  addStage,
+  canAddPrompt,
+  draftFromLibrary,
+  movedOrder,
+  removePrompt,
+  removeStage,
+  reorderStages,
+  setCardsVisible,
+  updatePrompt,
+} from "./format-draft";
+import { DEFAULT_RETRO_FORMAT, RETRO_FORMATS, findFormat } from "@/convex/model/retroFormats";
+
+const shipped = JSON.stringify(RETRO_FORMATS);
+
+describe("draftFromLibrary", () => {
+  it("copies the stamp and the seed; a teamless draft has no review, a team draft does", () => {
+    const teamless = draftFromLibrary(DEFAULT_RETRO_FORMAT, { hasTeam: false });
+    expect(teamless.format).toEqual({ name: DEFAULT_RETRO_FORMAT.name, prompts: DEFAULT_RETRO_FORMAT.prompts });
+    expect(teamless.stages.map((s) => s.kind)).toEqual(["collect", "group", "vote", "discuss", "close"]);
+    const team = draftFromLibrary(findFormat("Lean Coffee")!, { hasTeam: true });
+    expect(team.stages.map((s) => s.kind)).toEqual(["collect", "review", "group", "vote", "discuss", "close"]);
+    expect(team.stages[0].cardsVisible).toBe("visible");
+  });
+});
+
+describe("prompts", () => {
+  it("renames, re-tints, adds up to ten with fresh ids and the next unused tint, and never removes the last", () => {
+    let draft = draftFromLibrary(DEFAULT_RETRO_FORMAT, { hasTeam: false });
+    draft = updatePrompt(draft, "went-well", { label: "What worked?", color: "teal", hint: "" });
+    expect(draft.format.prompts[0]).toEqual({ id: "went-well", label: "What worked?", color: "teal", order: 0 });
+
+    while (canAddPrompt(draft)) draft = addPrompt(draft);
+    expect(draft.format.prompts).toHaveLength(10);
+    expect(new Set(draft.format.prompts.map((p) => p.id)).size).toBe(10);
+    expect(draft.format.prompts.map((p) => p.order)).toEqual([...Array(10).keys()]);
+    expect(draft.format.prompts[3].color).toBe("red");
+    expect(addPrompt(draft)).toBe(draft);
+
+    for (const prompt of draft.format.prompts.slice(1)) draft = removePrompt(draft, prompt.id);
+    expect(draft.format.prompts).toHaveLength(1);
+    expect(removePrompt(draft, draft.format.prompts[0].id)).toBe(draft);
+    expect(JSON.stringify(RETRO_FORMATS)).toBe(shipped);
+  });
+});
+
+describe("stages", () => {
+  const base = draftFromLibrary(DEFAULT_RETRO_FORMAT, { hasTeam: false });
+  const ids = () => base.stages.map((s) => s.id);
+
+  it("adds up to ten, at an index or the end, and flips collect's reveal policy", () => {
+    let draft = addStage(base, "review", 1);
+    expect(draft.stages.map((s) => s.kind)).toEqual(["collect", "review", "group", "vote", "discuss", "close"]);
+    while (draft.stages.length < 10) draft = addStage(draft, "vote");
+    expect(addStage(draft, "close")).toBe(draft);
+    expect(setCardsVisible(base, ids()[0], "visible").stages[0].cardsVisible).toBe("visible");
+  });
+
+  it("removes any entry except the last collect or discuss, or the current one", () => {
+    const [collect, group, , discuss] = ids();
+    expect(removeStage(base, collect)).toBe(base);
+    expect(removeStage(base, discuss)).toBe(base);
+    expect(removeStage(base, group, group)).toBe(base);
+    expect(removeStage(base, group).stages.map((s) => s.kind)).toEqual(["collect", "vote", "discuss", "close"]);
+    const twoDiscuss = addStage(base, "discuss");
+    expect(removeStage(twoDiscuss, discuss).stages.filter((s) => s.kind === "discuss")).toHaveLength(1);
+  });
+
+  it("moves a free entry past discuss, never discuss past collect nor the current entry", () => {
+    const [collect, group, vote, discuss, close] = ids();
+    expect(movedOrder(base.stages, close, -1)).toEqual([collect, group, vote, close, discuss]);
+    expect(movedOrder(base.stages, collect, -1)).toBeNull();
+    expect(movedOrder(base.stages, collect, 1)).toEqual([group, collect, vote, discuss, close]);
+    const adjacent = reorderStages(base, [collect, discuss, group, vote, close]);
+    expect(adjacent.stages.map((s) => s.id)).toEqual([collect, discuss, group, vote, close]);
+    expect(movedOrder(adjacent.stages, collect, 1)).toBeNull();
+    expect(movedOrder(adjacent.stages, discuss, -1)).toBeNull();
+    expect(movedOrder(base.stages, vote, -1, group)).toBeNull();
+    expect(movedOrder(base.stages, vote, -1)).toEqual([collect, vote, group, discuss, close]);
+    expect(reorderStages(base, [discuss, group, vote, collect, close])).toBe(base);
+    expect(reorderStages(base, [collect, vote, group, discuss]).stages).toBe(base.stages);
+    expect(reorderStages(base, [collect, vote, group, discuss, close]).stages.map((s) => s.id)).toEqual([collect, vote, group, discuss, close]);
+  });
+});

--- a/src/components/retro/format-draft.test.ts
+++ b/src/components/retro/format-draft.test.ts
@@ -64,11 +64,10 @@ describe("stages", () => {
     expect(setCardsVisible(base, ids()[0], "visible").stages[0].cardsVisible).toBe("visible");
   });
 
-  it("removes any entry except the last collect or discuss, or the current one", () => {
+  it("removes any entry except the last collect or discuss", () => {
     const [collect, group, , discuss] = ids();
     expect(removeStage(base, collect)).toBe(base);
     expect(removeStage(base, discuss)).toBe(base);
-    expect(removeStage(base, group, group)).toBe(base);
     expect(removeStage(base, group).stages.map((s) => s.kind)).toEqual(["collect", "vote", "discuss", "close"]);
     const twoDiscuss = addStage(base, "discuss");
     expect(removeStage(twoDiscuss, discuss).stages.filter((s) => s.kind === "discuss")).toHaveLength(1);

--- a/src/components/retro/format-draft.ts
+++ b/src/components/retro/format-draft.ts
@@ -1,9 +1,11 @@
 import {
+  insertStage,
   isLockedKindEntry,
   MAX_PROMPTS,
   MAX_STAGES,
   newPromptId,
   newStageEntry,
+  orderStagesBy,
   renumberPrompts,
   reorderKeepsLocks,
   RETRO_TINTS,
@@ -16,6 +18,7 @@ import {
   type StampedFormat,
   type Visibility,
 } from "@/convex/model/retroFormats";
+import type { PromptEdit } from "@/convex/model/retro";
 import { NEW_PROMPT_LABEL } from "@/convex/retroCopy";
 
 /**
@@ -36,29 +39,14 @@ export function draftFromLibrary(entry: RetroFormat, options: { hasTeam: boolean
   return { format: stampFormat(entry), stages: seedStages(entry, options) };
 }
 
-/**
- * A fresh draft from a stamped format (a Team's edited last format): its
- * prompts copied, and the standard seed for the stages, since a stamped
- * format carries no stage list of its own.
- */
-export function draftFromStamped(format: StampedFormat, options: { hasTeam: boolean }): FormatDraft {
-  return {
-    format: { name: format.name, prompts: format.prompts.map((p) => ({ ...p })) },
-    stages: seedStages({ collectVisible: false }, options),
-  };
-}
-
 export function renameFormat(draft: FormatDraft, name: string): FormatDraft {
   return { ...draft, format: { ...draft.format, name } };
 }
 
-export interface PromptEdit {
-  label?: string;
-  hint?: string;
-  color?: string;
-}
+/** The server's prompt edit plus the tint, which only the create form changes (spec §6.1). */
+export type PromptDraftEdit = PromptEdit & { color?: string };
 
-export function updatePrompt(draft: FormatDraft, promptId: string, edit: PromptEdit): FormatDraft {
+export function updatePrompt(draft: FormatDraft, promptId: string, edit: PromptDraftEdit): FormatDraft {
   return {
     ...draft,
     format: {
@@ -119,10 +107,7 @@ export function canAddStage(draft: FormatDraft): boolean {
 
 export function addStage(draft: FormatDraft, kind: StageKind, index?: number): FormatDraft {
   if (!canAddStage(draft)) return draft;
-  const stages = [...draft.stages];
-  const at = index === undefined ? stages.length : Math.max(0, Math.min(index, stages.length));
-  stages.splice(at, 0, newStageEntry(kind));
-  return { ...draft, stages };
+  return { ...draft, stages: insertStage(draft.stages, newStageEntry(kind), index) };
 }
 
 /** Whether the entry may be removed or moved: not the last collect or discuss, not the current entry. */
@@ -157,8 +142,7 @@ export function movedOrder(
 
 export function reorderStages(draft: FormatDraft, stageIds: readonly string[], currentStageId?: string): FormatDraft {
   if (!reorderKeepsLocks(draft.stages, stageIds, currentStageId).ok) return draft;
-  const byId = new Map(draft.stages.map((s) => [s.id, s]));
-  return { ...draft, stages: stageIds.map((id) => byId.get(id)!) };
+  return { ...draft, stages: orderStagesBy(draft.stages, stageIds) };
 }
 
 export function setCardsVisible(draft: FormatDraft, stageId: string, value: Visibility): FormatDraft {

--- a/src/components/retro/format-draft.ts
+++ b/src/components/retro/format-draft.ts
@@ -119,8 +119,8 @@ export function isStageLocked(
   return isLockedKindEntry(stages, stageId) || stageId === currentStageId;
 }
 
-export function removeStage(draft: FormatDraft, stageId: string, currentStageId?: string): FormatDraft {
-  if (isStageLocked(draft.stages, stageId, currentStageId)) return draft;
+export function removeStage(draft: FormatDraft, stageId: string): FormatDraft {
+  if (isStageLocked(draft.stages, stageId)) return draft;
   return { ...draft, stages: draft.stages.filter((s) => s.id !== stageId) };
 }
 
@@ -140,8 +140,8 @@ export function movedOrder(
   return reorderKeepsLocks(stages, next, currentStageId).ok ? next : null;
 }
 
-export function reorderStages(draft: FormatDraft, stageIds: readonly string[], currentStageId?: string): FormatDraft {
-  if (!reorderKeepsLocks(draft.stages, stageIds, currentStageId).ok) return draft;
+export function reorderStages(draft: FormatDraft, stageIds: readonly string[]): FormatDraft {
+  if (!reorderKeepsLocks(draft.stages, stageIds).ok) return draft;
   return { ...draft, stages: orderStagesBy(draft.stages, stageIds) };
 }
 

--- a/src/components/retro/format-draft.ts
+++ b/src/components/retro/format-draft.ts
@@ -1,0 +1,169 @@
+import {
+  isLockedKindEntry,
+  MAX_PROMPTS,
+  MAX_STAGES,
+  newPromptId,
+  newStageEntry,
+  renumberPrompts,
+  reorderKeepsLocks,
+  RETRO_TINTS,
+  seedStages,
+  stampFormat,
+  type FormatPrompt,
+  type RetroFormat,
+  type StageEntry,
+  type StageKind,
+  type StampedFormat,
+  type Visibility,
+} from "@/convex/model/retroFormats";
+import { NEW_PROMPT_LABEL } from "@/convex/retroCopy";
+
+/**
+ * The create form's editable copy of a format (ADR-0021, spec §6.1): the
+ * prompts and the stage list, edited before stamping. Pure reducers over a
+ * plain value; every rule the server enforces at creation (the caps, the
+ * collect/discuss locks) is refused here by returning the draft unchanged,
+ * so the UI disables what would be refused. The shipped constant is copied
+ * on the way in and never read again.
+ */
+export interface FormatDraft {
+  format: StampedFormat;
+  stages: StageEntry[];
+}
+
+/** A fresh draft from a library entry: its stamp and the standard seed. */
+export function draftFromLibrary(entry: RetroFormat, options: { hasTeam: boolean }): FormatDraft {
+  return { format: stampFormat(entry), stages: seedStages(entry, options) };
+}
+
+/**
+ * A fresh draft from a stamped format (a Team's edited last format): its
+ * prompts copied, and the standard seed for the stages, since a stamped
+ * format carries no stage list of its own.
+ */
+export function draftFromStamped(format: StampedFormat, options: { hasTeam: boolean }): FormatDraft {
+  return {
+    format: { name: format.name, prompts: format.prompts.map((p) => ({ ...p })) },
+    stages: seedStages({ collectVisible: false }, options),
+  };
+}
+
+export function renameFormat(draft: FormatDraft, name: string): FormatDraft {
+  return { ...draft, format: { ...draft.format, name } };
+}
+
+export interface PromptEdit {
+  label?: string;
+  hint?: string;
+  color?: string;
+}
+
+export function updatePrompt(draft: FormatDraft, promptId: string, edit: PromptEdit): FormatDraft {
+  return {
+    ...draft,
+    format: {
+      ...draft.format,
+      prompts: draft.format.prompts.map((p) => {
+        if (p.id !== promptId) return p;
+        const next: FormatPrompt = { ...p, ...(edit.label !== undefined ? { label: edit.label } : {}), ...(edit.color !== undefined ? { color: edit.color } : {}) };
+        if (edit.hint !== undefined) {
+          if (edit.hint.trim()) next.hint = edit.hint;
+          else delete next.hint;
+        }
+        return next;
+      }),
+    },
+  };
+}
+
+/** The first palette tint no prompt uses yet, else the first tint. */
+export function nextTint(prompts: readonly FormatPrompt[]): string {
+  const used = new Set(prompts.map((p) => p.color));
+  return RETRO_TINTS.find((tint) => !used.has(tint)) ?? RETRO_TINTS[0];
+}
+
+export function canAddPrompt(draft: FormatDraft): boolean {
+  return draft.format.prompts.length < MAX_PROMPTS;
+}
+
+export function addPrompt(draft: FormatDraft): FormatDraft {
+  if (!canAddPrompt(draft)) return draft;
+  const prompts = draft.format.prompts;
+  const prompt: FormatPrompt = {
+    id: newPromptId(),
+    label: NEW_PROMPT_LABEL,
+    color: nextTint(prompts),
+    order: prompts.length,
+  };
+  return { ...draft, format: { ...draft.format, prompts: [...prompts, prompt] } };
+}
+
+export function canRemovePrompt(draft: FormatDraft): boolean {
+  return draft.format.prompts.length > 1;
+}
+
+export function removePrompt(draft: FormatDraft, promptId: string): FormatDraft {
+  if (!canRemovePrompt(draft)) return draft;
+  return {
+    ...draft,
+    format: {
+      ...draft.format,
+      prompts: renumberPrompts(draft.format.prompts.filter((p) => p.id !== promptId)),
+    },
+  };
+}
+
+export function canAddStage(draft: FormatDraft): boolean {
+  return draft.stages.length < MAX_STAGES;
+}
+
+export function addStage(draft: FormatDraft, kind: StageKind, index?: number): FormatDraft {
+  if (!canAddStage(draft)) return draft;
+  const stages = [...draft.stages];
+  const at = index === undefined ? stages.length : Math.max(0, Math.min(index, stages.length));
+  stages.splice(at, 0, newStageEntry(kind));
+  return { ...draft, stages };
+}
+
+/** Whether the entry may be removed or moved: not the last collect or discuss, not the current entry. */
+export function isStageLocked(
+  stages: readonly StageEntry[],
+  stageId: string,
+  currentStageId?: string
+): boolean {
+  return isLockedKindEntry(stages, stageId) || stageId === currentStageId;
+}
+
+export function removeStage(draft: FormatDraft, stageId: string, currentStageId?: string): FormatDraft {
+  if (isStageLocked(draft.stages, stageId, currentStageId)) return draft;
+  return { ...draft, stages: draft.stages.filter((s) => s.id !== stageId) };
+}
+
+/** The order after moving `stageId` one step, or null when a lock forbids it. */
+export function movedOrder(
+  stages: readonly StageEntry[],
+  stageId: string,
+  direction: -1 | 1,
+  currentStageId?: string
+): string[] | null {
+  const ids = stages.map((s) => s.id);
+  const from = ids.indexOf(stageId);
+  const to = from + direction;
+  if (from < 0 || to < 0 || to >= ids.length) return null;
+  const next = [...ids];
+  [next[from], next[to]] = [next[to], next[from]];
+  return reorderKeepsLocks(stages, next, currentStageId).ok ? next : null;
+}
+
+export function reorderStages(draft: FormatDraft, stageIds: readonly string[], currentStageId?: string): FormatDraft {
+  if (!reorderKeepsLocks(draft.stages, stageIds, currentStageId).ok) return draft;
+  const byId = new Map(draft.stages.map((s) => [s.id, s]));
+  return { ...draft, stages: stageIds.map((id) => byId.get(id)!) };
+}
+
+export function setCardsVisible(draft: FormatDraft, stageId: string, value: Visibility): FormatDraft {
+  return {
+    ...draft,
+    stages: draft.stages.map((s) => (s.id === stageId ? { ...s, cardsVisible: value } : s)),
+  };
+}

--- a/src/components/retro/format-editor.tsx
+++ b/src/components/retro/format-editor.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowDown, ArrowUp, Eye, EyeOff, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  RETRO_TINTS,
+  type StageEntry,
+  type StageKind,
+  type StampedFormat,
+  type Visibility,
+} from "@/convex/model/retroFormats";
+import {
+  ADD_PROMPT,
+  ADD_STAGE,
+  CURRENT_STAGE_TAG,
+  FORMAT_NAME_LABEL,
+  PROMPTS_TITLE,
+  PROMPT_HINT_FIELD,
+  PROMPT_HINT_PLACEHOLDER,
+  PROMPT_LABEL_FIELD,
+  STAGES_TITLE,
+  STAGE_LABELS,
+  TINT_FIELD,
+  cardsHiddenIn,
+  cardsVisibleIn,
+  moveStageDownLabel,
+  moveStageUpLabel,
+  removePromptLabel,
+  removeStageLabel,
+} from "@/convex/retroCopy";
+import { tintClasses } from "./tints";
+import { canAddPrompt, canAddStage, canRemovePrompt, isStageLocked, movedOrder, type FormatDraft, type PromptEdit } from "./format-draft";
+
+/** What the editor does when a person edits; the create form reduces a draft, the settings dialog calls mutations. */
+export interface FormatEditorActions {
+  /** Offered pre-stamp only: a running retro's format name is user-facing history. */
+  onRenameFormat?: (name: string) => void;
+  onUpdatePrompt: (promptId: string, edit: PromptEdit) => void;
+  onAddPrompt: () => void;
+  onRemovePrompt: (promptId: string) => void;
+  onAddStage: (kind: StageKind) => void;
+  onRemoveStage: (stageId: string) => void;
+  onReorderStages: (stageIds: string[]) => void;
+  /** Offered pre-stamp only: on a running retro the reveal toggle is the stageFlow act on the pill. */
+  onSetCardsVisible?: (stageId: string, value: Visibility) => void;
+}
+
+interface FormatEditorProps extends FormatEditorActions {
+  draft: FormatDraft;
+  /** The running retro's shared pointer, which locks its entry; absent on the create form. */
+  currentStageId?: string;
+  /** A denial: every control disabled with this copy. */
+  denial?: string;
+}
+
+const STAGE_KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
+
+/**
+ * The format editor (ADR-0021): prompts (label, hint, tint; add up to ten;
+ * remove) and the stage list (add, remove, reorder except collect, discuss
+ * and the current entry). One component for the create form and the
+ * running retro's settings; the locks are the same rules the server keeps.
+ */
+export function FormatEditor({ draft, currentStageId, denial, ...actions }: FormatEditorProps) {
+  const disabled = denial !== undefined;
+  const deny = disabled ? { disabled: true, title: denial } : {};
+  const [newKind, setNewKind] = useState<StageKind>("group");
+
+  return (
+    <div data-testid="format-editor" className="space-y-4">
+      {actions.onRenameFormat && (
+        <div className="space-y-1">
+          <label htmlFor="format-name" className="text-xs font-medium">
+            {FORMAT_NAME_LABEL}
+          </label>
+          <Input
+            id="format-name"
+            value={draft.format.name}
+            maxLength={60}
+            onChange={(e) => actions.onRenameFormat?.(e.target.value)}
+            {...deny}
+          />
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium">{PROMPTS_TITLE}</h3>
+        <ul className="space-y-2">
+          {draft.format.prompts.map((prompt) => (
+            <PromptRow
+              key={prompt.id}
+              prompt={prompt}
+              canRemove={canRemovePrompt(draft)}
+              denial={denial}
+              onUpdate={(edit) => actions.onUpdatePrompt(prompt.id, edit)}
+              onRemove={() => actions.onRemovePrompt(prompt.id)}
+            />
+          ))}
+        </ul>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={actions.onAddPrompt}
+          disabled={disabled || !canAddPrompt(draft)}
+          title={denial}
+        >
+          <Plus className="size-4" />
+          {ADD_PROMPT}
+        </Button>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium">{STAGES_TITLE}</h3>
+        <ul className="space-y-1">
+          {draft.stages.map((stage) => {
+            const label = STAGE_LABELS[stage.kind];
+            const locked = isStageLocked(draft.stages, stage.id, currentStageId);
+            const up = movedOrder(draft.stages, stage.id, -1, currentStageId);
+            const down = movedOrder(draft.stages, stage.id, 1, currentStageId);
+            return (
+              <li
+                key={stage.id}
+                data-testid="stage-row"
+                data-kind={stage.kind}
+                data-current={String(stage.id === currentStageId)}
+                className="flex items-center gap-1 rounded-md border px-2 py-1 text-sm"
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {label}
+                  {stage.id === currentStageId && (
+                    <span className="ml-1.5 text-xs text-muted-foreground">({CURRENT_STAGE_TAG})</span>
+                  )}
+                </span>
+                {stage.kind === "collect" && actions.onSetCardsVisible && (
+                  <CollectVisibilityToggle stage={stage} label={label} denial={denial} onSet={actions.onSetCardsVisible} />
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={moveStageUpLabel(label)}
+                  disabled={disabled || up === null}
+                  title={denial}
+                  onClick={() => up && actions.onReorderStages(up)}
+                >
+                  <ArrowUp className="size-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={moveStageDownLabel(label)}
+                  disabled={disabled || down === null}
+                  title={denial}
+                  onClick={() => down && actions.onReorderStages(down)}
+                >
+                  <ArrowDown className="size-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={removeStageLabel(label)}
+                  disabled={disabled || locked}
+                  title={denial}
+                  onClick={() => actions.onRemoveStage(stage.id)}
+                >
+                  <X className="size-3.5" />
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+        <div className="flex items-center gap-2">
+          <select
+            aria-label={ADD_STAGE}
+            value={newKind}
+            onChange={(e) => setNewKind(e.target.value as StageKind)}
+            className="h-8 rounded-lg border border-input bg-transparent px-2 text-sm dark:bg-input/30"
+            {...deny}
+          >
+            {STAGE_KINDS.map((kind) => (
+              <option key={kind} value={kind}>
+                {STAGE_LABELS[kind]}
+              </option>
+            ))}
+          </select>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => actions.onAddStage(newKind)}
+            disabled={disabled || !canAddStage(draft)}
+            title={denial}
+          >
+            <Plus className="size-4" />
+            {ADD_STAGE}
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function CollectVisibilityToggle({
+  stage,
+  label,
+  denial,
+  onSet,
+}: {
+  stage: StageEntry;
+  label: string;
+  denial?: string;
+  onSet: (stageId: string, value: Visibility) => void;
+}) {
+  const hidden = stage.cardsVisible === "hidden";
+  const text = hidden ? cardsHiddenIn(label) : cardsVisibleIn(label);
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      aria-label={text}
+      title={denial ?? text}
+      disabled={denial !== undefined}
+      onClick={() => onSet(stage.id, hidden ? "visible" : "hidden")}
+    >
+      {hidden ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+      <span className="text-xs">{hidden ? "hidden" : "visible"}</span>
+    </Button>
+  );
+}
+
+/** One prompt: label and hint commit on blur; the tint commits at once. */
+function PromptRow({
+  prompt,
+  canRemove,
+  denial,
+  onUpdate,
+  onRemove,
+}: {
+  prompt: StampedFormat["prompts"][number];
+  canRemove: boolean;
+  denial?: string;
+  onUpdate: (edit: PromptEdit) => void;
+  onRemove: () => void;
+}) {
+  const [label, setLabel] = useState(prompt.label);
+  const [hint, setHint] = useState(prompt.hint ?? "");
+  const disabled = denial !== undefined;
+  const tint = tintClasses(prompt.color);
+  return (
+    <li className={cn("flex flex-wrap items-center gap-2 rounded-md border p-2", tint.zone)}>
+      <Input
+        aria-label={PROMPT_LABEL_FIELD}
+        value={label}
+        maxLength={80}
+        className="h-8 min-w-40 flex-1 bg-white/70 dark:bg-surface-1/70"
+        onChange={(e) => setLabel(e.target.value)}
+        onBlur={() => {
+          const trimmed = label.trim();
+          if (!trimmed) setLabel(prompt.label);
+          else if (trimmed !== prompt.label) onUpdate({ label: trimmed });
+        }}
+        {...(disabled ? { readOnly: true, title: denial } : {})}
+      />
+      <Input
+        aria-label={PROMPT_HINT_FIELD}
+        placeholder={PROMPT_HINT_PLACEHOLDER}
+        value={hint}
+        maxLength={160}
+        className="h-8 min-w-48 flex-[2] bg-white/70 dark:bg-surface-1/70"
+        onChange={(e) => setHint(e.target.value)}
+        onBlur={() => {
+          if (hint.trim() !== (prompt.hint ?? "")) onUpdate({ hint: hint.trim() });
+        }}
+        {...(disabled ? { readOnly: true, title: denial } : {})}
+      />
+      <select
+        aria-label={TINT_FIELD}
+        value={prompt.color}
+        onChange={(e) => onUpdate({ color: e.target.value })}
+        className={cn("h-8 rounded-lg border border-input bg-white/70 px-2 text-sm capitalize dark:bg-surface-1/70", tint.label)}
+        disabled={disabled}
+        title={denial}
+      >
+        {RETRO_TINTS.map((color) => (
+          <option key={color} value={color}>
+            {color}
+          </option>
+        ))}
+      </select>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={removePromptLabel(prompt.label)}
+        disabled={disabled || !canRemove}
+        title={denial}
+        onClick={onRemove}
+      >
+        <X className="size-3.5" />
+      </Button>
+    </li>
+  );
+}

--- a/src/components/retro/format-editor.tsx
+++ b/src/components/retro/format-editor.tsx
@@ -11,6 +11,7 @@ import {
   type StageKind,
   type StampedFormat,
   type Visibility,
+  STAGE_KINDS,
 } from "@/convex/model/retroFormats";
 import {
   ADD_PROMPT,
@@ -60,8 +61,6 @@ interface FormatEditorProps extends FormatEditorActions {
   decision?: ResolvedDecision;
 }
 
-const STAGE_KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
-
 /**
  * The format editor (ADR-0021): prompts (label, hint, tint; add up to ten;
  * remove) and the stage list (add, remove, reorder except collect, discuss
@@ -75,7 +74,6 @@ export function FormatEditor({
   decision = RESOLVED_ALLOWED,
   ...actions
 }: FormatEditorProps) {
-  const disabled = !decision.allowed;
   const deny = permissionProps(decision);
   const denyInput = permissionInputProps(decision);
   const [newKind, setNewKind] = useState<StageKind>("group");
@@ -193,8 +191,7 @@ export function FormatEditor({
             value={newKind}
             onChange={(e) => setNewKind(e.target.value as StageKind)}
             className="h-8 rounded-lg border border-input bg-transparent px-2 text-sm dark:bg-input/30"
-            disabled={disabled}
-            title={decision.allowed ? undefined : decision.message}
+            {...deny}
           >
             {STAGE_KINDS.map((kind) => (
               <option key={kind} value={kind}>
@@ -301,8 +298,7 @@ function PromptRow({
           value={prompt.color}
           onChange={(e) => onUpdate({ color: e.target.value })}
           className={cn("h-8 rounded-lg border border-input bg-white/70 px-2 text-sm capitalize dark:bg-surface-1/70", tint.label)}
-          disabled={!decision.allowed}
-          title={decision.allowed ? undefined : decision.message}
+          {...permissionProps(decision)}
         >
           {RETRO_TINTS.map((color) => (
             <option key={color} value={color}>

--- a/src/components/retro/format-editor.tsx
+++ b/src/components/retro/format-editor.tsx
@@ -31,14 +31,16 @@ import {
   removePromptLabel,
   removeStageLabel,
 } from "@/convex/retroCopy";
+import { RESOLVED_ALLOWED, type ResolvedDecision } from "@/convex/permissions";
+import { permissionInputProps, permissionProps } from "@/hooks/usePermissions";
 import { tintClasses } from "./tints";
-import { canAddPrompt, canAddStage, canRemovePrompt, isStageLocked, movedOrder, type FormatDraft, type PromptEdit } from "./format-draft";
+import { canAddPrompt, canAddStage, canRemovePrompt, isStageLocked, movedOrder, type FormatDraft, type PromptDraftEdit } from "./format-draft";
 
 /** What the editor does when a person edits; the create form reduces a draft, the settings dialog calls mutations. */
 export interface FormatEditorActions {
   /** Offered pre-stamp only: a running retro's format name is user-facing history. */
   onRenameFormat?: (name: string) => void;
-  onUpdatePrompt: (promptId: string, edit: PromptEdit) => void;
+  onUpdatePrompt: (promptId: string, edit: PromptDraftEdit) => void;
   onAddPrompt: () => void;
   onRemovePrompt: (promptId: string) => void;
   onAddStage: (kind: StageKind) => void;
@@ -52,8 +54,10 @@ interface FormatEditorProps extends FormatEditorActions {
   draft: FormatDraft;
   /** The running retro's shared pointer, which locks its entry; absent on the create form. */
   currentStageId?: string;
-  /** A denial: every control disabled with this copy. */
-  denial?: string;
+  /** Whether a prompt's tint may change: the create form's choice (spec §6.1), never a running retro's. */
+  canEditTint?: boolean;
+  /** The `retroSettings` decision: denied renders every control disabled with the copy. */
+  decision?: ResolvedDecision;
 }
 
 const STAGE_KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
@@ -64,9 +68,16 @@ const STAGE_KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss
  * and the current entry). One component for the create form and the
  * running retro's settings; the locks are the same rules the server keeps.
  */
-export function FormatEditor({ draft, currentStageId, denial, ...actions }: FormatEditorProps) {
-  const disabled = denial !== undefined;
-  const deny = disabled ? { disabled: true, title: denial } : {};
+export function FormatEditor({
+  draft,
+  currentStageId,
+  canEditTint = false,
+  decision = RESOLVED_ALLOWED,
+  ...actions
+}: FormatEditorProps) {
+  const disabled = !decision.allowed;
+  const deny = permissionProps(decision);
+  const denyInput = permissionInputProps(decision);
   const [newKind, setNewKind] = useState<StageKind>("group");
 
   return (
@@ -81,7 +92,7 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
             value={draft.format.name}
             maxLength={60}
             onChange={(e) => actions.onRenameFormat?.(e.target.value)}
-            {...deny}
+            {...denyInput}
           />
         </div>
       )}
@@ -94,7 +105,8 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
               key={prompt.id}
               prompt={prompt}
               canRemove={canRemovePrompt(draft)}
-              denial={denial}
+              canEditTint={canEditTint}
+              decision={decision}
               onUpdate={(edit) => actions.onUpdatePrompt(prompt.id, edit)}
               onRemove={() => actions.onRemovePrompt(prompt.id)}
             />
@@ -105,8 +117,8 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
           variant="outline"
           size="sm"
           onClick={actions.onAddPrompt}
-          disabled={disabled || !canAddPrompt(draft)}
-          title={denial}
+          disabled={!canAddPrompt(draft)}
+          {...deny}
         >
           <Plus className="size-4" />
           {ADD_PROMPT}
@@ -136,16 +148,16 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
                   )}
                 </span>
                 {stage.kind === "collect" && actions.onSetCardsVisible && (
-                  <CollectVisibilityToggle stage={stage} label={label} denial={denial} onSet={actions.onSetCardsVisible} />
+                  <CollectVisibilityToggle stage={stage} label={label} decision={decision} onSet={actions.onSetCardsVisible} />
                 )}
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon-xs"
                   aria-label={moveStageUpLabel(label)}
-                  disabled={disabled || up === null}
-                  title={denial}
+                  disabled={up === null}
                   onClick={() => up && actions.onReorderStages(up)}
+                  {...deny}
                 >
                   <ArrowUp className="size-3.5" />
                 </Button>
@@ -154,9 +166,9 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
                   variant="ghost"
                   size="icon-xs"
                   aria-label={moveStageDownLabel(label)}
-                  disabled={disabled || down === null}
-                  title={denial}
+                  disabled={down === null}
                   onClick={() => down && actions.onReorderStages(down)}
+                  {...deny}
                 >
                   <ArrowDown className="size-3.5" />
                 </Button>
@@ -165,9 +177,9 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
                   variant="ghost"
                   size="icon-xs"
                   aria-label={removeStageLabel(label)}
-                  disabled={disabled || locked}
-                  title={denial}
+                  disabled={locked}
                   onClick={() => actions.onRemoveStage(stage.id)}
+                  {...deny}
                 >
                   <X className="size-3.5" />
                 </Button>
@@ -181,7 +193,8 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
             value={newKind}
             onChange={(e) => setNewKind(e.target.value as StageKind)}
             className="h-8 rounded-lg border border-input bg-transparent px-2 text-sm dark:bg-input/30"
-            {...deny}
+            disabled={disabled}
+            title={decision.allowed ? undefined : decision.message}
           >
             {STAGE_KINDS.map((kind) => (
               <option key={kind} value={kind}>
@@ -194,8 +207,8 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
             variant="outline"
             size="sm"
             onClick={() => actions.onAddStage(newKind)}
-            disabled={disabled || !canAddStage(draft)}
-            title={denial}
+            disabled={!canAddStage(draft)}
+            {...deny}
           >
             <Plus className="size-4" />
             {ADD_STAGE}
@@ -209,12 +222,12 @@ export function FormatEditor({ draft, currentStageId, denial, ...actions }: Form
 function CollectVisibilityToggle({
   stage,
   label,
-  denial,
+  decision,
   onSet,
 }: {
   stage: StageEntry;
   label: string;
-  denial?: string;
+  decision: ResolvedDecision;
   onSet: (stageId: string, value: Visibility) => void;
 }) {
   const hidden = stage.cardsVisible === "hidden";
@@ -225,9 +238,9 @@ function CollectVisibilityToggle({
       variant="ghost"
       size="xs"
       aria-label={text}
-      title={denial ?? text}
-      disabled={denial !== undefined}
+      title={text}
       onClick={() => onSet(stage.id, hidden ? "visible" : "hidden")}
+      {...permissionProps(decision)}
     >
       {hidden ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
       <span className="text-xs">{hidden ? "hidden" : "visible"}</span>
@@ -235,23 +248,25 @@ function CollectVisibilityToggle({
   );
 }
 
-/** One prompt: label and hint commit on blur; the tint commits at once. */
+/** One prompt: label and hint commit on blur; the tint, when editable, commits at once. */
 function PromptRow({
   prompt,
   canRemove,
-  denial,
+  canEditTint,
+  decision,
   onUpdate,
   onRemove,
 }: {
   prompt: StampedFormat["prompts"][number];
   canRemove: boolean;
-  denial?: string;
-  onUpdate: (edit: PromptEdit) => void;
+  canEditTint: boolean;
+  decision: ResolvedDecision;
+  onUpdate: (edit: PromptDraftEdit) => void;
   onRemove: () => void;
 }) {
   const [label, setLabel] = useState(prompt.label);
   const [hint, setHint] = useState(prompt.hint ?? "");
-  const disabled = denial !== undefined;
+  const denyInput = permissionInputProps(decision);
   const tint = tintClasses(prompt.color);
   return (
     <li className={cn("flex flex-wrap items-center gap-2 rounded-md border p-2", tint.zone)}>
@@ -266,7 +281,7 @@ function PromptRow({
           if (!trimmed) setLabel(prompt.label);
           else if (trimmed !== prompt.label) onUpdate({ label: trimmed });
         }}
-        {...(disabled ? { readOnly: true, title: denial } : {})}
+        {...denyInput}
       />
       <Input
         aria-label={PROMPT_HINT_FIELD}
@@ -278,30 +293,32 @@ function PromptRow({
         onBlur={() => {
           if (hint.trim() !== (prompt.hint ?? "")) onUpdate({ hint: hint.trim() });
         }}
-        {...(disabled ? { readOnly: true, title: denial } : {})}
+        {...denyInput}
       />
-      <select
-        aria-label={TINT_FIELD}
-        value={prompt.color}
-        onChange={(e) => onUpdate({ color: e.target.value })}
-        className={cn("h-8 rounded-lg border border-input bg-white/70 px-2 text-sm capitalize dark:bg-surface-1/70", tint.label)}
-        disabled={disabled}
-        title={denial}
-      >
-        {RETRO_TINTS.map((color) => (
-          <option key={color} value={color}>
-            {color}
-          </option>
-        ))}
-      </select>
+      {canEditTint && (
+        <select
+          aria-label={TINT_FIELD}
+          value={prompt.color}
+          onChange={(e) => onUpdate({ color: e.target.value })}
+          className={cn("h-8 rounded-lg border border-input bg-white/70 px-2 text-sm capitalize dark:bg-surface-1/70", tint.label)}
+          disabled={!decision.allowed}
+          title={decision.allowed ? undefined : decision.message}
+        >
+          {RETRO_TINTS.map((color) => (
+            <option key={color} value={color}>
+              {color}
+            </option>
+          ))}
+        </select>
+      )}
       <Button
         type="button"
         variant="ghost"
         size="icon-xs"
         aria-label={removePromptLabel(prompt.label)}
-        disabled={disabled || !canRemove}
-        title={denial}
+        disabled={!canRemove}
         onClick={onRemove}
+        {...permissionProps(decision)}
       >
         <X className="size-3.5" />
       </Button>

--- a/src/components/retro/readiness.ts
+++ b/src/components/retro/readiness.ts
@@ -1,4 +1,3 @@
-import type { RoomUserData } from "@/convex/model/users";
 import { orderUsersByPresence, type UserWithPresence } from "@/hooks/useRoomPresence";
 
 /**
@@ -12,14 +11,6 @@ import { orderUsersByPresence, type UserWithPresence } from "@/hooks/useRoomPres
 export interface ReadinessPayload {
   stageId: string;
   ready: boolean;
-}
-
-/** What `presence.list` returns per person; `data` is the readiness payload when set. */
-export interface PresenceEntry {
-  userId: string;
-  online: boolean;
-  lastDisconnected: number;
-  data?: unknown;
 }
 
 function isReadinessPayload(data: unknown): data is ReadinessPayload {
@@ -42,24 +33,11 @@ export interface RosterRow extends UserWithPresence {
 }
 
 /**
- * The roster: every member with presence and readiness merged on, in the
- * one ordering rule (online first, then by join time).
+ * The roster: every member (presence already merged by `useRoomPresence`)
+ * with readiness read from their payload, in the one ordering rule (online
+ * first, then by join time).
  */
-export function projectRoster(
-  users: readonly RoomUserData[],
-  presence: readonly PresenceEntry[] | undefined,
-  currentStageId: string
-): RosterRow[] {
-  const byUserId = new Map((presence ?? []).map((entry) => [entry.userId, entry]));
-  const rows: RosterRow[] = users.map((user) => {
-    const entry = byUserId.get(user._id);
-    const online = entry?.online ?? false;
-    return {
-      ...user,
-      isOnline: online,
-      lastSeen: online ? null : (entry?.lastDisconnected ?? null),
-      ready: readinessOf(entry?.data, currentStageId),
-    };
-  });
+export function projectRoster(users: readonly UserWithPresence[], currentStageId: string): RosterRow[] {
+  const rows = users.map((user) => ({ ...user, ready: readinessOf(user.data, currentStageId) }));
   return orderUsersByPresence(rows) as RosterRow[];
 }

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -5,7 +5,7 @@ import { ReactFlow, ReactFlowProvider, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Users } from "lucide-react";
 import type { Doc } from "@/convex/_generated/dataModel";
-import type { RoomUserData } from "@/convex/model/users";
+import type { UserWithPresence } from "@/hooks/useRoomPresence";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
 import { Button } from "@/components/ui/button";
 import { ROSTER_TITLE } from "@/convex/retroCopy";
@@ -16,13 +16,10 @@ import { layoutZones } from "./zones";
 import { StageNav, type StageControls } from "./stage-nav";
 import { StageEmptyState } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
-import type { PresenceEntry } from "./readiness";
 
 /** What an attendee brings to the board that a Team reader does not. */
 export interface BoardViewer {
   userId: string;
-  /** The room's presence list; undefined while loading. */
-  presence: readonly PresenceEntry[] | undefined;
   onSetReady: (ready: boolean) => void;
   controls: StageControls;
 }
@@ -31,8 +28,8 @@ interface RetroBoardProps {
   /** The room shell's name; the board reads nothing else from it. */
   name: string;
   retro: Doc<"retros">;
-  /** The roster's members, from the room shell. */
-  users: readonly RoomUserData[];
+  /** The roster's members with presence merged on; a Team reader sees everyone offline. */
+  users: readonly UserWithPresence[];
   /** The Team that keeps the retro (ADR-0008); undefined for a teamless one. */
   team?: RetroTeam;
   /** The attendee's presence and stageFlow wiring; absent for a Team reader. */
@@ -86,7 +83,7 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
     [retro.format.prompts]
   );
 
-  const onlineCount = viewer?.presence?.filter((entry) => entry.online).length;
+  const onlineCount = viewer ? users.filter((user) => user.isOnline).length : undefined;
 
   return (
     <div
@@ -154,7 +151,6 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
           <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">
             <RetroRoster
               users={users}
-              presence={viewer?.presence}
               currentStage={currentStage}
               myUserId={viewer?.userId}
               onSetReady={viewer?.onSetReady}

--- a/src/components/retro/retro-menu.test.tsx
+++ b/src/components/retro/retro-menu.test.tsx
@@ -77,6 +77,11 @@ vi.mock("@/components/ui/dialog", () => {
   };
 });
 
+vi.mock("./retro-settings-dialog", () => ({
+  RetroSettingsDialog: ({ open, name, hasTeam, decision }: { open: boolean; name: string; hasTeam: boolean; decision: { allowed: boolean } }) =>
+    open ? <div data-testid="settings" data-team={String(hasTeam)} data-allowed={String(decision.allowed)}>{name}</div> : null,
+}));
+
 import { RetroMenu } from "./retro-menu";
 import { deleteRetroConfirm, keptByTeam } from "@/convex/retroCopy";
 
@@ -186,5 +191,29 @@ describe("RetroMenu — keep with a team", () => {
     cleanup();
     render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} />);
     expect(screen.queryByRole("menuitem", { name: "Keep with a team…" })).toBeNull();
+  });
+});
+
+describe("RetroMenu — settings", () => {
+  const settings = {
+    name: "Sprint 12",
+    joinPolicy: "anyone" as const,
+    retro: {} as never,
+    decision: { allowed: false as const, message: "Only facilitators and the owner can do this" },
+  };
+
+  it("opens the settings dialog with the retro and the decision, for a team retro", () => {
+    render(<RetroMenu roomId={roomId} team={acme} role="participant" isOwnerAbsent={false} myTeams={[]} settings={settings} />);
+    expect(screen.queryByTestId("settings")).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Retro settings…" }));
+    const dialog = screen.getByTestId("settings");
+    expect(dialog.textContent).toBe("Sprint 12");
+    expect(dialog.getAttribute("data-team")).toBe("true");
+    expect(dialog.getAttribute("data-allowed")).toBe("false");
+  });
+
+  it("has no settings item when nothing is handed to it", () => {
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} />);
+    expect(screen.queryByRole("menuitem", { name: "Retro settings…" })).toBeNull();
   });
 });

--- a/src/components/retro/retro-menu.tsx
+++ b/src/components/retro/retro-menu.tsx
@@ -5,8 +5,15 @@ import { useRouter } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
 import { MoreHorizontal } from "lucide-react";
 import { api } from "@/convex/_generated/api";
-import type { Id } from "@/convex/_generated/dataModel";
-import { DEFAULT_RETRO_PERMISSIONS, resolve, type MemberRole, type TeamRole } from "@/convex/permissions";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
+import {
+  DEFAULT_RETRO_PERMISSIONS,
+  resolve,
+  type JoinPolicy,
+  type MemberRole,
+  type ResolvedDecision,
+  type TeamRole,
+} from "@/convex/permissions";
 import {
   ADOPT_BUTTON,
   ADOPT_CHOOSE_TEAM,
@@ -24,6 +31,7 @@ import {
   DELETE_TITLE,
   DELETING_BUTTON,
   RETRO_DELETED,
+  SETTINGS_MENU_ITEM,
   TEAM_LABEL,
   deleteRetroConfirm,
   keptByTeam,
@@ -56,6 +64,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { toast } from "@/lib/toast";
 import type { RetroTeam } from "./retro-header";
+import { RetroSettingsDialog } from "./retro-settings-dialog";
 
 /** One of the viewer's Teams, as `teams.listMine` returns it. */
 export interface MyTeam {
@@ -73,6 +82,13 @@ interface RetroMenuProps {
   isOwnerAbsent: boolean;
   /** The viewer's Teams; empty for an anonymous account. */
   myTeams: MyTeam[];
+  /** What the settings dialog edits (spec §6.4); absent hides the item. */
+  settings?: {
+    name: string;
+    joinPolicy: JoinPolicy;
+    retro: Doc<"retros">;
+    decision: ResolvedDecision;
+  };
 }
 
 /**
@@ -80,10 +96,12 @@ interface RetroMenuProps {
  * retro* behind the counted confirmation; *Claim ownership* for a team
  * admin who is not the owner (the server decides `owner-present`); *Keep
  * with a team…* for the owner of a teamless retro who has a Team to give it
- * to. Every item is a mutation on room-owned state, so the menu renders
- * only for an attendee.
+ * to; *Retro settings…* opens the settings dialog (spec §6.4), where a
+ * denied viewer reads the denial rather than finding the door gone. Every
+ * item is a mutation on room-owned state, so the menu renders only for an
+ * attendee.
  */
-export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroMenuProps) {
+export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings }: RetroMenuProps) {
   const router = useRouter();
   const remove = useMutation(api.retro.remove);
   const claim = useMutation(api.retro.claim);
@@ -94,6 +112,7 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
   const [adoptOpen, setAdoptOpen] = useState(false);
   const [adoptTeamId, setAdoptTeamId] = useState<string>("");
   const [isAdopting, setIsAdopting] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const counts = useQuery(api.retro.deleteCounts, confirmDelete ? { roomId } : "skip");
 
@@ -156,6 +175,9 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
           <MoreHorizontal className="size-4" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          {settings && (
+            <DropdownMenuItem onClick={() => setSettingsOpen(true)}>{SETTINGS_MENU_ITEM}</DropdownMenuItem>
+          )}
           {canAdopt && (
             <DropdownMenuItem onClick={() => setAdoptOpen(true)}>{ADOPT_MENU_ITEM}</DropdownMenuItem>
           )}
@@ -191,6 +213,19 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams }: RetroM
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {settings && (
+        <RetroSettingsDialog
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          roomId={roomId}
+          name={settings.name}
+          joinPolicy={settings.joinPolicy}
+          hasTeam={team !== undefined}
+          retro={settings.retro}
+          decision={settings.decision}
+        />
+      )}
 
       <Dialog open={adoptOpen} onOpenChange={(open) => !isAdopting && setAdoptOpen(open)}>
         <DialogContent className="sm:max-w-md">

--- a/src/components/retro/retro-roster.test.tsx
+++ b/src/components/retro/retro-roster.test.tsx
@@ -11,6 +11,7 @@ import { render, screen, cleanup, fireEvent, within } from "@testing-library/rea
 import { readinessOf, projectRoster } from "./readiness";
 import { RetroRoster } from "./retro-roster";
 import type { StageEntry } from "@/convex/model/retroFormats";
+import type { UserWithPresence } from "@/hooks/useRoomPresence";
 
 afterEach(cleanup);
 
@@ -19,6 +20,14 @@ const users = [
   { _id: "u2", name: "Ben", isSpectator: false, role: "participant", joinedAt: 2, membershipId: "m2" },
   { _id: "u3", name: "Cy", isSpectator: false, role: "participant", joinedAt: 3, membershipId: "m3" },
 ] as never[];
+
+/** The members as `useRoomPresence` hands them over: offline unless a payload says otherwise. */
+function withPresence(byId: Record<string, { online: boolean; data?: unknown }>): UserWithPresence[] {
+  return users.map((user: { _id: string }) => {
+    const entry = byId[user._id];
+    return { ...(user as UserWithPresence), isOnline: entry?.online ?? false, lastSeen: null, data: entry?.data };
+  });
+}
 
 const group: StageEntry = { id: "s-group", kind: "group", cardsVisible: "visible", tallyVisible: "visible" };
 const collect: StageEntry = { id: "s-collect", kind: "collect", cardsVisible: "hidden", tallyVisible: "visible" };
@@ -36,12 +45,11 @@ describe("readinessOf", () => {
 });
 
 describe("projectRoster", () => {
-  it("merges presence and readiness onto every member, online first", () => {
-    const presence = [
-      { userId: "u2", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: true } },
-      { userId: "u1", online: false, lastDisconnected: 500, data: { stageId: "s-group", ready: true } },
-    ];
-    const rows = projectRoster(users, presence, "s-group");
+  it("reads readiness from every member's payload, online first", () => {
+    const rows = projectRoster(
+      withPresence({ u2: { online: true, data: { stageId: "s-group", ready: true } }, u1: { online: false, data: { stageId: "s-group", ready: true } } }),
+      "s-group"
+    );
     expect(rows.map((r) => [r.name, r.isOnline, r.ready])).toEqual([
       ["Ben", true, true],
       ["Ada", false, true],
@@ -50,24 +58,20 @@ describe("projectRoster", () => {
   });
 
   it("reads everyone as not ready after the pointer moves", () => {
-    const presence = [
-      { userId: "u1", online: true, lastDisconnected: 0, data: { stageId: "s-collect", ready: true } },
-    ];
-    expect(projectRoster(users, presence, "s-group").every((r) => !r.ready)).toBe(true);
-    expect(projectRoster(users, undefined, "s-group").every((r) => !r.isOnline && !r.ready)).toBe(true);
+    const moved = withPresence({ u1: { online: true, data: { stageId: "s-collect", ready: true } } });
+    expect(projectRoster(moved, "s-group").every((r) => !r.ready)).toBe(true);
+    expect(projectRoster(withPresence({}), "s-group").every((r) => !r.isOnline && !r.ready)).toBe(true);
   });
 });
 
 describe("RetroRoster", () => {
   it("shows each person with readiness, and the viewer's toggle writes once per change", () => {
     const onSetReady = vi.fn();
-    const presence = [
-      { userId: "u1", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: false } },
-      { userId: "u2", online: true, lastDisconnected: 0, data: { stageId: "s-group", ready: true } },
-    ];
-    render(
-      <RetroRoster users={users} presence={presence} currentStage={group} myUserId="u1" onSetReady={onSetReady} />
-    );
+    const members = withPresence({
+      u1: { online: true, data: { stageId: "s-group", ready: false } },
+      u2: { online: true, data: { stageId: "s-group", ready: true } },
+    });
+    render(<RetroRoster users={members} currentStage={group} myUserId="u1" onSetReady={onSetReady} />);
     const rows = screen.getAllByRole("listitem");
     expect(rows).toHaveLength(3);
     const ben = rows.find((r) => r.textContent?.includes("Ben"))!;
@@ -85,7 +89,7 @@ describe("RetroRoster", () => {
 
   it("offers no readiness in collect", () => {
     render(
-      <RetroRoster users={users} presence={undefined} currentStage={collect} myUserId="u1" onSetReady={vi.fn()} />
+      <RetroRoster users={withPresence({})} currentStage={collect} myUserId="u1" onSetReady={vi.fn()} />
     );
     expect(screen.queryByRole("switch")).toBeNull();
     expect(screen.queryByText("Ready")).toBeNull();

--- a/src/components/retro/retro-roster.tsx
+++ b/src/components/retro/retro-roster.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 import { useMemo } from "react";
-import type { RoomUserData } from "@/convex/model/users";
 import type { StageEntry } from "@/convex/model/retroFormats";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { UserWithPresence } from "@/hooks/useRoomPresence";
+import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { getColorFromName, getInitial } from "@/lib/avatar-utils";
 import { READY_LABEL, READY_TOGGLE_LABEL, ROSTER_TITLE } from "@/convex/retroCopy";
-import { projectRoster, type PresenceEntry } from "./readiness";
+import { projectRoster } from "./readiness";
 
 interface RetroRosterProps {
-  users: readonly RoomUserData[];
-  /** The room's presence list; undefined while loading. */
-  presence: readonly PresenceEntry[] | undefined;
+  /** The members with presence merged on; offline while presence loads. */
+  users: readonly UserWithPresence[];
   currentStage: Pick<StageEntry, "id" | "kind">;
   /** The viewer, when attending; a Team reader has no row and no toggle. */
   myUserId?: string;
@@ -29,11 +27,8 @@ interface RetroRosterProps {
  * cards ticket adds — so nothing durable ever records who declared
  * themselves finished.
  */
-export function RetroRoster({ users, presence, currentStage, myUserId, onSetReady }: RetroRosterProps) {
-  const rows = useMemo(
-    () => projectRoster(users, presence, currentStage.id),
-    [users, presence, currentStage.id]
-  );
+export function RetroRoster({ users, currentStage, myUserId, onSetReady }: RetroRosterProps) {
+  const rows = useMemo(() => projectRoster(users, currentStage.id), [users, currentStage.id]);
   const offersReadiness = currentStage.kind !== "collect";
   const me = rows.find((row) => row._id === myUserId);
 
@@ -59,12 +54,12 @@ export function RetroRoster({ users, presence, currentStage, myUserId, onSetRead
             {...(offersReadiness ? { "data-ready": String(row.ready) } : {})}
             className="flex items-center gap-2 text-sm"
           >
-            <Avatar size="sm" className={cn("ring-2", row.isOnline ? "ring-green-500" : "ring-gray-400 grayscale")}>
-              {row.avatarUrl && <AvatarImage src={row.avatarUrl} alt={row.name} />}
-              <AvatarFallback className={getColorFromName(row.name)}>
-                <span className="text-xs font-medium text-white">{getInitial(row.name)}</span>
-              </AvatarFallback>
-            </Avatar>
+            <UserAvatar
+              name={row.name}
+              avatarUrl={row.avatarUrl}
+              size="sm"
+              className={cn("ring-2", row.isOnline ? "ring-green-500" : "ring-gray-400 grayscale")}
+            />
             <span className={cn("min-w-0 flex-1 truncate", !row.isOnline && "text-muted-foreground")}>
               {row.name}
             </span>

--- a/src/components/retro/retro-settings-dialog.test.tsx
+++ b/src/components/retro/retro-settings-dialog.test.tsx
@@ -115,11 +115,25 @@ describe("RetroSettingsDialog — the retro", () => {
       expect(calledWith("retro:setJoinPolicy")).toEqual([{ roomId, joinPolicy: "permanentAccounts" }])
     );
 
-    fireEvent.change(d.getByLabelText("Cards due"), { target: { value: "2026-09-10" } });
+    // The date commits on blur, once, and not when unchanged.
+    const dueField = d.getByLabelText("Cards due");
+    fireEvent.blur(dueField);
+    fireEvent.change(dueField, { target: { value: "2026-09-10" } });
+    fireEvent.blur(dueField);
     await waitFor(() => expect(calledWith("retro:setCollectUntil")).toHaveLength(1));
     const due = (calledWith("retro:setCollectUntil")[0] as { collectUntil: number }).collectUntil;
     expect(new Date(due).toISOString().slice(0, 10)).toBe("2026-09-10");
-    fireEvent.change(d.getByLabelText("Cards due"), { target: { value: "" } });
+    // Clearing commits once the server holds a date; against no date it is a no-op.
+    fireEvent.change(dueField, { target: { value: "" } });
+    fireEvent.blur(dueField);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calledWith("retro:setCollectUntil")).toHaveLength(1);
+    cleanup();
+    const d2 = renderDialog({ retro: { ...retro, collectUntil: due } });
+    const dueField2 = d2.getByLabelText("Cards due") as HTMLInputElement;
+    expect(dueField2.value).toBe("2026-09-10");
+    fireEvent.change(dueField2, { target: { value: "" } });
+    fireEvent.blur(dueField2);
     await waitFor(() => expect(calledWith("retro:setCollectUntil")[1]).toEqual({ roomId }));
   });
 

--- a/src/components/retro/retro-settings-dialog.test.tsx
+++ b/src/components/retro/retro-settings-dialog.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Retro settings (ADR-0021, spec §6.4): under retroSettings — rename, join
+ * policy (teamMembers only on a team retro), cards-due date, prompt edits
+ * at any stage, stage-list edits except collect, discuss and the current
+ * entry. Each edit is one mutation; a server refusal surfaces as its copy;
+ * a participant sees every control disabled with the denial copy.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as { fn: string; args: unknown }[],
+  fail: {} as Record<string, string>,
+  toasts: [] as { kind: "success" | "error"; message: string }[],
+}));
+
+vi.mock("convex/react", async () => {
+  const { getFunctionName } = await import("convex/server");
+  return {
+    useMutation: (ref: unknown) => {
+      const fn = getFunctionName(ref as never);
+      return async (args: unknown) => {
+        mocks.calls.push({ fn, args });
+        if (mocks.fail[fn]) throw new Error(mocks.fail[fn]);
+      };
+    },
+  };
+});
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (message: string) => mocks.toasts.push({ kind: "success", message }),
+    error: (message: string) => mocks.toasts.push({ kind: "error", message }),
+  },
+}));
+vi.mock("@/components/ui/dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Dialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="dialog">{children}</div> : null,
+    DialogContent: pass,
+    DialogHeader: pass,
+    DialogFooter: pass,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+  };
+});
+
+import { RetroSettingsDialog } from "./retro-settings-dialog";
+import { RESOLVED_ALLOWED } from "@/convex/permissions";
+import type { Doc } from "@/convex/_generated/dataModel";
+
+const roomId = "room-1" as never;
+const retro = {
+  _id: "retro-1",
+  roomId,
+  attribution: "named",
+  format: {
+    name: "Went well, Do differently, Ideas",
+    prompts: [
+      { id: "went-well", label: "What went well?", hint: "Keep it.", color: "green", order: 0 },
+      { id: "ideas", label: "Ideas", color: "blue", order: 1 },
+    ],
+  },
+  stages: [
+    { id: "s1", kind: "collect", cardsVisible: "hidden", tallyVisible: "visible" },
+    { id: "s2", kind: "group", cardsVisible: "visible", tallyVisible: "visible" },
+    { id: "s3", kind: "vote", cardsVisible: "visible", tallyVisible: "hidden", voteBudget: 5 },
+    { id: "s4", kind: "discuss", cardsVisible: "visible", tallyVisible: "visible" },
+    { id: "s5", kind: "close", cardsVisible: "visible", tallyVisible: "visible" },
+  ],
+  currentStageId: "s5",
+  currentStageEnteredAt: 0,
+} as unknown as Doc<"retros">;
+const denied = { allowed: false as const, message: "Only facilitators and the owner can do this" };
+const calledWith = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c) => c.args);
+
+function renderDialog(over: Partial<Parameters<typeof RetroSettingsDialog>[0]> = {}) {
+  render(
+    <RetroSettingsDialog
+      open
+      onOpenChange={vi.fn()}
+      roomId={roomId}
+      name="Sprint 12"
+      joinPolicy="anyone"
+      hasTeam={false}
+      retro={retro}
+      decision={RESOLVED_ALLOWED}
+      {...over}
+    />
+  );
+  return within(screen.getByRole("dialog"));
+}
+
+beforeEach(() => {
+  mocks.calls = [];
+  mocks.fail = {};
+  mocks.toasts = [];
+});
+afterEach(cleanup);
+
+describe("RetroSettingsDialog — the retro", () => {
+  it("renames on blur, edits the join policy and the cards-due date", async () => {
+    const d = renderDialog();
+    const name = d.getByLabelText("Retro name") as HTMLInputElement;
+    expect(name.value).toBe("Sprint 12");
+    fireEvent.change(name, { target: { value: "Sprint 13" } });
+    fireEvent.blur(name);
+    await waitFor(() => expect(calledWith("retro:rename")).toEqual([{ roomId, name: "Sprint 13" }]));
+
+    const policy = d.getByLabelText("Who can join") as HTMLSelectElement;
+    expect(Array.from(policy.options).map((o) => o.value)).toEqual(["anyone", "permanentAccounts"]);
+    fireEvent.change(policy, { target: { value: "permanentAccounts" } });
+    await waitFor(() =>
+      expect(calledWith("retro:setJoinPolicy")).toEqual([{ roomId, joinPolicy: "permanentAccounts" }])
+    );
+
+    fireEvent.change(d.getByLabelText("Cards due"), { target: { value: "2026-09-10" } });
+    await waitFor(() => expect(calledWith("retro:setCollectUntil")).toHaveLength(1));
+    const due = (calledWith("retro:setCollectUntil")[0] as { collectUntil: number }).collectUntil;
+    expect(new Date(due).toISOString().slice(0, 10)).toBe("2026-09-10");
+    fireEvent.change(d.getByLabelText("Cards due"), { target: { value: "" } });
+    await waitFor(() => expect(calledWith("retro:setCollectUntil")[1]).toEqual({ roomId }));
+  });
+
+  it("offers team members only on a team retro", () => {
+    const d = renderDialog({ hasTeam: true, joinPolicy: "teamMembers" });
+    const policy = d.getByLabelText("Who can join") as HTMLSelectElement;
+    expect(Array.from(policy.options).map((o) => o.value)).toEqual(["anyone", "permanentAccounts", "teamMembers"]);
+    expect(policy.value).toBe("teamMembers");
+  });
+});
+
+describe("RetroSettingsDialog — prompts and stages", () => {
+  it("edits a prompt's label, hint and tint as three mutations; adds and removes prompts", async () => {
+    const d = renderDialog();
+    const labels = d.getAllByLabelText("Prompt label") as HTMLInputElement[];
+    fireEvent.change(labels[0], { target: { value: "What worked?" } });
+    fireEvent.blur(labels[0]);
+    const hints = d.getAllByLabelText("Hint") as HTMLInputElement[];
+    fireEvent.change(hints[1], { target: { value: "Half-formed is fine." } });
+    fireEvent.blur(hints[1]);
+    fireEvent.change(d.getAllByLabelText("Tint")[0], { target: { value: "teal" } });
+    await waitFor(() =>
+      expect(calledWith("retro:updatePrompt")).toEqual([
+        { roomId, promptId: "went-well", label: "What worked?" },
+        { roomId, promptId: "ideas", hint: "Half-formed is fine." },
+        { roomId, promptId: "went-well", color: "teal" },
+      ])
+    );
+
+    fireEvent.click(d.getByRole("button", { name: "Add prompt" }));
+    await waitFor(() => expect(calledWith("retro:addPrompt")).toHaveLength(1));
+    expect(calledWith("retro:addPrompt")[0]).toMatchObject({ roomId, label: "New prompt" });
+
+    mocks.fail["retro:removePrompt"] = "Cards still answer this prompt";
+    fireEvent.click(d.getByRole("button", { name: "Remove Ideas" }));
+    await waitFor(() => expect(calledWith("retro:removePrompt")).toEqual([{ roomId, promptId: "ideas" }]));
+    await waitFor(() =>
+      expect(mocks.toasts.at(-1)).toEqual({ kind: "error", message: "Cards still answer this prompt" })
+    );
+  });
+
+  it("locks collect, discuss and the current entry; removes and reorders the rest; adds an entry", async () => {
+    const d = renderDialog();
+    const rows = d.getAllByTestId("stage-row");
+    expect(rows[4].getAttribute("data-current")).toBe("true");
+    expect((d.getByRole("button", { name: "Remove Collect" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Remove Discuss" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Remove Close" }) as HTMLButtonElement).disabled).toBe(true);
+    // A move that would shift discuss or the current entry is disabled.
+    expect((d.getByRole("button", { name: "Move Vote down" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Move Close up" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Move Collect down" }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(d.getByRole("button", { name: "Remove Group" }));
+    await waitFor(() => expect(calledWith("retro:removeStage")).toEqual([{ roomId, stageId: "s2" }]));
+
+    fireEvent.click(d.getByRole("button", { name: "Move Vote up" }));
+    await waitFor(() =>
+      expect(calledWith("retro:reorderStages")).toEqual([{ roomId, stageIds: ["s1", "s3", "s2", "s4", "s5"] }])
+    );
+
+    fireEvent.change(d.getByLabelText("Add stage"), { target: { value: "review" } });
+    fireEvent.click(d.getByRole("button", { name: "Add stage" }));
+    await waitFor(() => expect(calledWith("retro:addStage")).toEqual([{ roomId, kind: "review" }]));
+  });
+
+  it("a participant sees every control disabled with the denial copy and writes nothing", async () => {
+    const d = renderDialog({ decision: denied });
+    const name = d.getByLabelText("Retro name") as HTMLInputElement;
+    expect(name.readOnly).toBe(true);
+    expect(name.title).toBe(denied.message);
+    expect((d.getByLabelText("Who can join") as HTMLSelectElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Add prompt" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Remove Close" }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(name, { target: { value: "x" } });
+    fireEvent.blur(name);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.calls).toEqual([]);
+  });
+});

--- a/src/components/retro/retro-settings-dialog.test.tsx
+++ b/src/components/retro/retro-settings-dialog.test.tsx
@@ -132,7 +132,7 @@ describe("RetroSettingsDialog — the retro", () => {
 });
 
 describe("RetroSettingsDialog — prompts and stages", () => {
-  it("edits a prompt's label, hint and tint as three mutations; adds and removes prompts", async () => {
+  it("edits a prompt's label and hint as two mutations, offers no tint; adds and removes prompts", async () => {
     const d = renderDialog();
     const labels = d.getAllByLabelText("Prompt label") as HTMLInputElement[];
     fireEvent.change(labels[0], { target: { value: "What worked?" } });
@@ -140,12 +140,12 @@ describe("RetroSettingsDialog — prompts and stages", () => {
     const hints = d.getAllByLabelText("Hint") as HTMLInputElement[];
     fireEvent.change(hints[1], { target: { value: "Half-formed is fine." } });
     fireEvent.blur(hints[1]);
-    fireEvent.change(d.getAllByLabelText("Tint")[0], { target: { value: "teal" } });
+    // The tint is a create-form choice (spec §6.1), not a running retro's.
+    expect(d.queryAllByLabelText("Tint")).toHaveLength(0);
     await waitFor(() =>
       expect(calledWith("retro:updatePrompt")).toEqual([
         { roomId, promptId: "went-well", label: "What worked?" },
         { roomId, promptId: "ideas", hint: "Half-formed is fine." },
-        { roomId, promptId: "went-well", color: "teal" },
       ])
     );
 
@@ -168,10 +168,12 @@ describe("RetroSettingsDialog — prompts and stages", () => {
     expect((d.getByRole("button", { name: "Remove Collect" }) as HTMLButtonElement).disabled).toBe(true);
     expect((d.getByRole("button", { name: "Remove Discuss" }) as HTMLButtonElement).disabled).toBe(true);
     expect((d.getByRole("button", { name: "Remove Close" }) as HTMLButtonElement).disabled).toBe(true);
-    // A move that would shift discuss or the current entry is disabled.
-    expect((d.getByRole("button", { name: "Move Vote down" }) as HTMLButtonElement).disabled).toBe(true);
+    // A move that would shift the current entry's index is disabled; a free
+    // entry may pass discuss, and collect may not pass discuss.
     expect((d.getByRole("button", { name: "Move Close up" }) as HTMLButtonElement).disabled).toBe(true);
-    expect((d.getByRole("button", { name: "Move Collect down" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Move Discuss down" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((d.getByRole("button", { name: "Move Vote down" }) as HTMLButtonElement).disabled).toBe(false);
+    expect((d.getByRole("button", { name: "Move Collect down" }) as HTMLButtonElement).disabled).toBe(false);
 
     fireEvent.click(d.getByRole("button", { name: "Remove Group" }));
     await waitFor(() => expect(calledWith("retro:removeStage")).toEqual([{ roomId, stageId: "s2" }]));
@@ -192,8 +194,12 @@ describe("RetroSettingsDialog — prompts and stages", () => {
     expect(name.readOnly).toBe(true);
     expect(name.title).toBe(denied.message);
     expect((d.getByLabelText("Who can join") as HTMLSelectElement).disabled).toBe(true);
-    expect((d.getByRole("button", { name: "Add prompt" }) as HTMLButtonElement).disabled).toBe(true);
-    expect((d.getByRole("button", { name: "Remove Close" }) as HTMLButtonElement).disabled).toBe(true);
+    // Denied buttons read the denial as their accessible name (permissionProps).
+    expect(d.queryByRole("button", { name: "Add prompt" })).toBeNull();
+    expect(d.queryByRole("button", { name: "Remove Close" })).toBeNull();
+    const deniedButtons = d.getAllByRole("button", { name: denied.message }) as HTMLButtonElement[];
+    expect(deniedButtons.length).toBeGreaterThanOrEqual(2);
+    expect(deniedButtons.every((b) => b.disabled)).toBe(true);
     fireEvent.change(name, { target: { value: "x" } });
     fireEvent.blur(name);
     await new Promise((r) => setTimeout(r, 0));

--- a/src/components/retro/retro-settings-dialog.tsx
+++ b/src/components/retro/retro-settings-dialog.tsx
@@ -16,11 +16,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/lib/toast";
+import { permissionInputProps } from "@/hooks/usePermissions";
 import {
   COLLECT_UNTIL_DESCRIPTION,
   COLLECT_UNTIL_LABEL,
   JOIN_POLICY_LABEL,
   JOIN_POLICY_OPTIONS,
+  NEW_PROMPT_LABEL,
   RETRO_NAME_LABEL,
   SETTINGS_DESCRIPTION,
   SETTINGS_FAILED,
@@ -28,7 +30,6 @@ import {
 } from "@/convex/retroCopy";
 import { FormatEditor } from "./format-editor";
 import { nextTint, type FormatDraft } from "./format-draft";
-import { NEW_PROMPT_LABEL } from "@/convex/retroCopy";
 
 interface RetroSettingsDialogProps {
   open: boolean;
@@ -78,7 +79,7 @@ export function RetroSettingsDialog({
   const removeStage = useMutation(api.retro.removeStage);
   const reorderStages = useMutation(api.retro.reorderStages);
 
-  const denial = decision.allowed ? undefined : decision.message;
+  const denyInput = permissionInputProps(decision);
   const [nameDraft, setNameDraft] = useState(name);
   const dueValue = retro.collectUntil === undefined ? "" : formatDate(retro.collectUntil, "yyyy-MM-dd");
   // Drafted locally so the field reads what was typed until the write lands.
@@ -115,13 +116,13 @@ export function RetroSettingsDialog({
               onChange={(e) => setNameDraft(e.target.value)}
               onBlur={() => {
                 const trimmed = nameDraft.trim();
-                if (denial || !trimmed || trimmed === name) {
+                if (!decision.allowed || !trimmed || trimmed === name) {
                   setNameDraft(name);
                   return;
                 }
                 void run(rename({ roomId, name: trimmed }));
               }}
-              {...(denial ? { readOnly: true, title: denial } : {})}
+              {...denyInput}
             />
           </div>
           <div className="grid gap-1.5">
@@ -131,8 +132,8 @@ export function RetroSettingsDialog({
               value={joinPolicy}
               onChange={(e) => void run(setJoinPolicy({ roomId, joinPolicy: e.target.value as JoinPolicy }))}
               className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
-              disabled={denial !== undefined}
-              title={denial}
+              disabled={!decision.allowed}
+              title={decision.allowed ? undefined : decision.message}
             >
               {policies.map((o) => (
                 <option key={o.value} value={o.value}>
@@ -152,14 +153,14 @@ export function RetroSettingsDialog({
                 const due = parseDate(e.target.value);
                 void run(setCollectUntil({ roomId, ...(due !== undefined ? { collectUntil: due } : {}) }));
               }}
-              {...(denial ? { readOnly: true, title: denial } : {})}
+              {...denyInput}
             />
             <p className="text-xs text-muted-foreground">{COLLECT_UNTIL_DESCRIPTION}</p>
           </div>
           <FormatEditor
             draft={draft}
             currentStageId={retro.currentStageId}
-            denial={denial}
+            decision={decision}
             onUpdatePrompt={(promptId, edit) => void run(updatePrompt({ roomId, promptId, ...edit }))}
             onAddPrompt={() =>
               void run(addPrompt({ roomId, label: NEW_PROMPT_LABEL, color: nextTint(retro.format.prompts) }))

--- a/src/components/retro/retro-settings-dialog.tsx
+++ b/src/components/retro/retro-settings-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { useMutation } from "convex/react";
 import { format as formatDate } from "date-fns";
 import { api } from "@/convex/_generated/api";
@@ -15,8 +15,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { toast } from "@/lib/toast";
-import { permissionInputProps } from "@/hooks/usePermissions";
+import { runAct } from "@/lib/run-act";
+import { permissionInputProps, permissionProps } from "@/hooks/usePermissions";
 import {
   COLLECT_UNTIL_DESCRIPTION,
   COLLECT_UNTIL_LABEL,
@@ -29,7 +29,8 @@ import {
   SETTINGS_TITLE,
 } from "@/convex/retroCopy";
 import { FormatEditor } from "./format-editor";
-import { nextTint, type FormatDraft } from "./format-draft";
+import { nextTint } from "./format-draft";
+import { parseCollectUntil } from "./collect-until";
 
 interface RetroSettingsDialogProps {
   open: boolean;
@@ -43,14 +44,6 @@ interface RetroSettingsDialogProps {
   retro: Doc<"retros">;
   /** The `retroSettings` decision: denied renders every control disabled with the copy. */
   decision: ResolvedDecision;
-}
-
-/** A `<input type="date">` value as the end of that local day, or undefined. */
-function parseDate(value: string): number | undefined {
-  if (!value) return undefined;
-  const [y, m, d] = value.split("-").map(Number);
-  if (!y || !m || !d) return undefined;
-  return new Date(y, m - 1, d, 23, 59, 59).getTime();
 }
 
 /**
@@ -79,24 +72,14 @@ export function RetroSettingsDialog({
   const removeStage = useMutation(api.retro.removeStage);
   const reorderStages = useMutation(api.retro.reorderStages);
 
+  const deny = permissionProps(decision);
   const denyInput = permissionInputProps(decision);
+  const run = (act: Promise<unknown>) => void runAct(act, SETTINGS_FAILED);
   const [nameDraft, setNameDraft] = useState(name);
   const dueValue = retro.collectUntil === undefined ? "" : formatDate(retro.collectUntil, "yyyy-MM-dd");
   // Drafted locally so the field reads what was typed until the write lands.
   const [dueDraft, setDueDraft] = useState(dueValue);
 
-  const run = useCallback(async (act: Promise<unknown>) => {
-    try {
-      await act;
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : SETTINGS_FAILED);
-    }
-  }, []);
-
-  const draft = useMemo<FormatDraft>(
-    () => ({ format: retro.format, stages: retro.stages }),
-    [retro.format, retro.stages]
-  );
   const policies = JOIN_POLICY_OPTIONS.filter((o) => hasTeam || o.value !== "teamMembers");
 
   return (
@@ -120,7 +103,7 @@ export function RetroSettingsDialog({
                   setNameDraft(name);
                   return;
                 }
-                void run(rename({ roomId, name: trimmed }));
+                run(rename({ roomId, name: trimmed }));
               }}
               {...denyInput}
             />
@@ -130,10 +113,9 @@ export function RetroSettingsDialog({
             <select
               id="settings-join-policy"
               value={joinPolicy}
-              onChange={(e) => void run(setJoinPolicy({ roomId, joinPolicy: e.target.value as JoinPolicy }))}
+              onChange={(e) => run(setJoinPolicy({ roomId, joinPolicy: e.target.value as JoinPolicy }))}
               className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
-              disabled={!decision.allowed}
-              title={decision.allowed ? undefined : decision.message}
+              {...deny}
             >
               {policies.map((o) => (
                 <option key={o.value} value={o.value}>
@@ -148,27 +130,29 @@ export function RetroSettingsDialog({
               id="settings-collect-until"
               type="date"
               value={dueDraft}
-              onChange={(e) => {
-                setDueDraft(e.target.value);
-                const due = parseDate(e.target.value);
-                void run(setCollectUntil({ roomId, ...(due !== undefined ? { collectUntil: due } : {}) }));
+              onChange={(e) => setDueDraft(e.target.value)}
+              // Committed on blur, like the name: a date field fires change per segment.
+              onBlur={() => {
+                const due = parseCollectUntil(dueDraft);
+                if (!decision.allowed || due === retro.collectUntil) return;
+                run(setCollectUntil({ roomId, ...(due !== undefined ? { collectUntil: due } : {}) }));
               }}
               {...denyInput}
             />
             <p className="text-xs text-muted-foreground">{COLLECT_UNTIL_DESCRIPTION}</p>
           </div>
           <FormatEditor
-            draft={draft}
+            draft={{ format: retro.format, stages: retro.stages }}
             currentStageId={retro.currentStageId}
             decision={decision}
-            onUpdatePrompt={(promptId, edit) => void run(updatePrompt({ roomId, promptId, ...edit }))}
+            onUpdatePrompt={(promptId, edit) => run(updatePrompt({ roomId, promptId, ...edit }))}
             onAddPrompt={() =>
-              void run(addPrompt({ roomId, label: NEW_PROMPT_LABEL, color: nextTint(retro.format.prompts) }))
+              run(addPrompt({ roomId, label: NEW_PROMPT_LABEL, color: nextTint(retro.format.prompts) }))
             }
-            onRemovePrompt={(promptId) => void run(removePrompt({ roomId, promptId }))}
-            onAddStage={(kind) => void run(addStage({ roomId, kind }))}
-            onRemoveStage={(stageId) => void run(removeStage({ roomId, stageId }))}
-            onReorderStages={(stageIds) => void run(reorderStages({ roomId, stageIds }))}
+            onRemovePrompt={(promptId) => run(removePrompt({ roomId, promptId }))}
+            onAddStage={(kind) => run(addStage({ roomId, kind }))}
+            onRemoveStage={(stageId) => run(removeStage({ roomId, stageId }))}
+            onReorderStages={(stageIds) => run(reorderStages({ roomId, stageIds }))}
           />
         </div>
       </DialogContent>

--- a/src/components/retro/retro-settings-dialog.tsx
+++ b/src/components/retro/retro-settings-dialog.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useMutation } from "convex/react";
+import { format as formatDate } from "date-fns";
+import { api } from "@/convex/_generated/api";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
+import type { JoinPolicy, ResolvedDecision } from "@/convex/permissions";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/lib/toast";
+import {
+  COLLECT_UNTIL_DESCRIPTION,
+  COLLECT_UNTIL_LABEL,
+  JOIN_POLICY_LABEL,
+  JOIN_POLICY_OPTIONS,
+  RETRO_NAME_LABEL,
+  SETTINGS_DESCRIPTION,
+  SETTINGS_FAILED,
+  SETTINGS_TITLE,
+} from "@/convex/retroCopy";
+import { FormatEditor } from "./format-editor";
+import { nextTint, type FormatDraft } from "./format-draft";
+import { NEW_PROMPT_LABEL } from "@/convex/retroCopy";
+
+interface RetroSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  roomId: Id<"rooms">;
+  /** The room shell's name and join policy. */
+  name: string;
+  joinPolicy: JoinPolicy;
+  /** Whether a Team keeps the retro: `teamMembers` is offered only then. */
+  hasTeam: boolean;
+  retro: Doc<"retros">;
+  /** The `retroSettings` decision: denied renders every control disabled with the copy. */
+  decision: ResolvedDecision;
+}
+
+/** A `<input type="date">` value as the end of that local day, or undefined. */
+function parseDate(value: string): number | undefined {
+  if (!value) return undefined;
+  const [y, m, d] = value.split("-").map(Number);
+  if (!y || !m || !d) return undefined;
+  return new Date(y, m - 1, d, 23, 59, 59).getTime();
+}
+
+/**
+ * The running retro's settings (spec §6.4): rename, join policy, cards-due
+ * date, and the format editor over the stamped prompts and stage list with
+ * the shared pointer's entry locked. Every edit is one mutation, not
+ * optimistic (spec §10.7); a refusal surfaces as its copy.
+ */
+export function RetroSettingsDialog({
+  open,
+  onOpenChange,
+  roomId,
+  name,
+  joinPolicy,
+  hasTeam,
+  retro,
+  decision,
+}: RetroSettingsDialogProps) {
+  const rename = useMutation(api.retro.rename);
+  const setJoinPolicy = useMutation(api.retro.setJoinPolicy);
+  const setCollectUntil = useMutation(api.retro.setCollectUntil);
+  const updatePrompt = useMutation(api.retro.updatePrompt);
+  const addPrompt = useMutation(api.retro.addPrompt);
+  const removePrompt = useMutation(api.retro.removePrompt);
+  const addStage = useMutation(api.retro.addStage);
+  const removeStage = useMutation(api.retro.removeStage);
+  const reorderStages = useMutation(api.retro.reorderStages);
+
+  const denial = decision.allowed ? undefined : decision.message;
+  const [nameDraft, setNameDraft] = useState(name);
+  const dueValue = retro.collectUntil === undefined ? "" : formatDate(retro.collectUntil, "yyyy-MM-dd");
+  // Drafted locally so the field reads what was typed until the write lands.
+  const [dueDraft, setDueDraft] = useState(dueValue);
+
+  const run = useCallback(async (act: Promise<unknown>) => {
+    try {
+      await act;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : SETTINGS_FAILED);
+    }
+  }, []);
+
+  const draft = useMemo<FormatDraft>(
+    () => ({ format: retro.format, stages: retro.stages }),
+    [retro.format, retro.stages]
+  );
+  const policies = JOIN_POLICY_OPTIONS.filter((o) => hasTeam || o.value !== "teamMembers");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{SETTINGS_TITLE}</DialogTitle>
+          <DialogDescription>{SETTINGS_DESCRIPTION}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <div className="grid gap-1.5">
+            <Label htmlFor="settings-name">{RETRO_NAME_LABEL}</Label>
+            <Input
+              id="settings-name"
+              value={nameDraft}
+              maxLength={100}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={() => {
+                const trimmed = nameDraft.trim();
+                if (denial || !trimmed || trimmed === name) {
+                  setNameDraft(name);
+                  return;
+                }
+                void run(rename({ roomId, name: trimmed }));
+              }}
+              {...(denial ? { readOnly: true, title: denial } : {})}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="settings-join-policy">{JOIN_POLICY_LABEL}</Label>
+            <select
+              id="settings-join-policy"
+              value={joinPolicy}
+              onChange={(e) => void run(setJoinPolicy({ roomId, joinPolicy: e.target.value as JoinPolicy }))}
+              className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+              disabled={denial !== undefined}
+              title={denial}
+            >
+              {policies.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="settings-collect-until">{COLLECT_UNTIL_LABEL}</Label>
+            <Input
+              id="settings-collect-until"
+              type="date"
+              value={dueDraft}
+              onChange={(e) => {
+                setDueDraft(e.target.value);
+                const due = parseDate(e.target.value);
+                void run(setCollectUntil({ roomId, ...(due !== undefined ? { collectUntil: due } : {}) }));
+              }}
+              {...(denial ? { readOnly: true, title: denial } : {})}
+            />
+            <p className="text-xs text-muted-foreground">{COLLECT_UNTIL_DESCRIPTION}</p>
+          </div>
+          <FormatEditor
+            draft={draft}
+            currentStageId={retro.currentStageId}
+            denial={denial}
+            onUpdatePrompt={(promptId, edit) => void run(updatePrompt({ roomId, promptId, ...edit }))}
+            onAddPrompt={() =>
+              void run(addPrompt({ roomId, label: NEW_PROMPT_LABEL, color: nextTint(retro.format.prompts) }))
+            }
+            onRemovePrompt={(promptId) => void run(removePrompt({ roomId, promptId }))}
+            onAddStage={(kind) => void run(addStage({ roomId, kind }))}
+            onRemoveStage={(stageId) => void run(removeStage({ roomId, stageId }))}
+            onReorderStages={(stageIds) => void run(reorderStages({ roomId, stageIds }))}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/retro/stage-empty-state.test.tsx
+++ b/src/components/retro/stage-empty-state.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * Every stage kind renders an empty state, never a lock (ADR-0010): a
+ * line naming the stage and explaining what is not there yet, with the
+ * review line from the copy register.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { StageEmptyState } from "./stage-empty-state";
+import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
+import type { StageKind } from "@/convex/model/retroFormats";
+
+afterEach(cleanup);
+
+const KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
+
+describe("StageEmptyState", () => {
+  it.each(KINDS)("%s reads its label and its line", (kind) => {
+    render(<StageEmptyState kind={kind} />);
+    const state = screen.getByTestId("stage-empty-state");
+    expect(state.getAttribute("data-kind")).toBe(kind);
+    expect(state.textContent).toContain(STAGE_LABELS[kind]);
+    expect(state.textContent).toContain(STAGE_EMPTY[kind]);
+    expect(state.textContent?.toLowerCase()).not.toMatch(/lock/);
+  });
+
+  it("the review line is the register's", () => {
+    expect(STAGE_EMPTY.review).toBe("No open actions from earlier retros");
+  });
+});

--- a/src/components/retro/stage-nav.tsx
+++ b/src/components/retro/stage-nav.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import type { ResolvedDecision } from "@/convex/permissions";
-import { permissionProps } from "@/hooks/usePermissions";
+import { permissionInputProps, permissionProps } from "@/hooks/usePermissions";
 import type { StageEntry, Visibility } from "@/convex/model/retroFormats";
 import {
   BACK_TO_TEAM,
@@ -120,7 +120,7 @@ export function StageNav({
               key={`${current.id}:${current.timeboxMinutes ?? ""}`}
               minutes={current.timeboxMinutes}
               onCommit={controls.onSetTimebox}
-              denial={controls.stageFlow.allowed ? undefined : controls.stageFlow.message}
+              decision={controls.stageFlow}
             />
           </>
         )}
@@ -161,11 +161,11 @@ export function StageNav({
 function TimeboxField({
   minutes,
   onCommit,
-  denial,
+  decision,
 }: {
   minutes: number | undefined;
   onCommit: (minutes: number | undefined) => void;
-  denial?: string;
+  decision: ResolvedDecision;
 }) {
   const [draft, setDraft] = useState(minutes === undefined ? "" : String(minutes));
   const commit = () => {
@@ -199,7 +199,7 @@ function TimeboxField({
         onKeyDown={(e) => {
           if (e.key === "Enter") (e.target as HTMLInputElement).blur();
         }}
-        {...(denial ? { readOnly: true, title: denial } : {})}
+        {...permissionInputProps(decision)}
       />
     </div>
   );

--- a/src/components/retro/stage-nav.tsx
+++ b/src/components/retro/stage-nav.tsx
@@ -62,6 +62,7 @@ export function StageNav({
   const previous = stages[sharedIndex - 1];
   const next = stages[sharedIndex + 1];
   const deny = controls ? permissionProps(controls.stageFlow) : {};
+  const hidden = current.cardsVisible === "hidden";
 
   return (
     <div
@@ -108,12 +109,12 @@ export function StageNav({
               type="button"
               variant="ghost"
               size="sm"
-              aria-label={current.cardsVisible === "hidden" ? SHOW_CARDS : HIDE_CARDS}
-              onClick={() => controls.onSetCardsVisible(current.cardsVisible === "hidden" ? "visible" : "hidden")}
+              aria-label={hidden ? SHOW_CARDS : HIDE_CARDS}
+              onClick={() => controls.onSetCardsVisible(hidden ? "visible" : "hidden")}
               {...deny}
             >
-              {current.cardsVisible === "hidden" ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
-              {current.cardsVisible === "hidden" ? SHOW_CARDS : HIDE_CARDS}
+              {hidden ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+              {hidden ? SHOW_CARDS : HIDE_CARDS}
             </Button>
             <TimeboxField
               // Remount on a server change so the draft never fights the stored value.

--- a/src/components/retro/stage-pill.tsx
+++ b/src/components/retro/stage-pill.tsx
@@ -15,14 +15,18 @@ interface StagePillProps {
   enteredAt?: number;
 }
 
-/** A once-a-second clock, running only while a countdown is shown. */
-function useNow(active: boolean): number {
+/**
+ * A once-a-second clock, running only while a countdown is shown and not
+ * yet over: past `until` the label is a constant, so the ticking stops.
+ */
+function useNow(until: number | undefined): number {
   const [now, setNow] = useState(() => Date.now());
+  const ticking = until !== undefined && now < until;
   useEffect(() => {
-    if (!active) return;
+    if (!ticking) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [active]);
+  }, [ticking]);
   return now;
 }
 
@@ -33,7 +37,7 @@ function useNow(active: boolean): number {
  */
 export function StagePill({ kind, timeboxMinutes, enteredAt }: StagePillProps) {
   const hasTimebox = timeboxMinutes !== undefined && enteredAt !== undefined;
-  const now = useNow(hasTimebox);
+  const now = useNow(hasTimebox ? enteredAt + timeboxMinutes * 60_000 : undefined);
   const reading = hasTimebox ? timeboxReading(timeboxMinutes, enteredAt, now) : undefined;
   return (
     <Badge

--- a/src/components/retro/timebox.ts
+++ b/src/components/retro/timebox.ts
@@ -9,7 +9,6 @@ import { TIMEBOX_OVER } from "@/convex/retroCopy";
  * happens: the count never fires an advance.
  */
 export interface TimeboxReading {
-  remainingSeconds: number;
   over: boolean;
   /** MM:SS, or the "Timebox over" line. */
   label: string;
@@ -34,7 +33,6 @@ export function timeboxReading(
   const remainingSeconds = timeboxMinutes * 60 - elapsed;
   const over = remainingSeconds <= 0;
   return {
-    remainingSeconds,
     over,
     label: over ? TIMEBOX_OVER : formatTimerTime(remainingSeconds),
   };

--- a/src/components/team/retro-defaults-panel.tsx
+++ b/src/components/team/retro-defaults-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { PermissionLevel, RetroDefaults, RetroPermissionCategory } from "@/convex/permissions";
 import { cn } from "@/lib/utils";
+import { JOIN_POLICY_OPTIONS } from "@/convex/retroCopy";
 
 export type { RetroDefaults };
 
@@ -23,12 +24,6 @@ type Option<V extends string> = { value: V; label: string };
 const ATTRIBUTION_OPTIONS: Option<RetroDefaults["attribution"]>[] = [
   { value: "named", label: "Named" },
   { value: "anonymous", label: "Anonymous" },
-];
-
-const JOIN_POLICY_OPTIONS: Option<RetroDefaults["joinPolicy"]>[] = [
-  { value: "anyone", label: "Anyone with the link" },
-  { value: "permanentAccounts", label: "Signed-in accounts" },
-  { value: "teamMembers", label: "Team members" },
 ];
 
 const LEVEL_OPTIONS: Option<PermissionLevel>[] = [

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -266,6 +266,18 @@ function narrowToPoker(result: UsePermissionsReturn): PokerPermissionsReturn {
   return result;
 }
 
+/**
+ * The retro consumers' narrowing, the mirror of `narrowToPoker`: the retro
+ * arm, or a throw when the room is poker. The retro board mounts only under
+ * the retro room type, so the throw marks a routing bug.
+ */
+function narrowToRetro(result: UsePermissionsReturn): RetroPermissionsReturn {
+  if (result.ceremony !== "retro") {
+    throw new Error("Retro permissions requested for a non-retro room");
+  }
+  return result;
+}
+
 /** `computePermissions` narrowed to the poker arm; see `narrowToPoker`. */
 export function computePokerPermissions(
   roomData: RoomWithRelatedData | null | undefined,
@@ -298,4 +310,12 @@ export function usePokerPermissions(
   currentUserId: Id<"users"> | string | undefined
 ): PokerPermissionsReturn {
   return narrowToPoker(usePermissions(roomData, currentUserId));
+}
+
+/** `usePermissions` narrowed to the retro arm for the retro surfaces; see `narrowToRetro`. */
+export function useRetroPermissions(
+  roomData: RoomWithRelatedData | null | undefined,
+  currentUserId: Id<"users"> | string | undefined
+): RetroPermissionsReturn {
+  return narrowToRetro(usePermissions(roomData, currentUserId));
 }

--- a/src/hooks/useRoomPresence.ts
+++ b/src/hooks/useRoomPresence.ts
@@ -9,6 +9,8 @@ import { useDemoSimulation } from "@/components/room/demo/DemoSimulationProvider
 export interface UserWithPresence extends RoomUserData {
   isOnline: boolean;
   lastSeen: number | null; // Timestamp when user was last online (null if currently online)
+  /** The person's presence payload, when they wrote one (the retro's readiness). */
+  data?: unknown;
 }
 
 /**
@@ -101,6 +103,7 @@ function useConvexPresence(
         ...user,
         isOnline: presence?.online ?? false,
         lastSeen: presence?.online ? null : (presence?.lastDisconnected ?? null),
+        data: presence?.data,
       };
     });
   }, [users, presenceState]);

--- a/src/lib/run-act.ts
+++ b/src/lib/run-act.ts
@@ -1,0 +1,17 @@
+import { toast } from "@/lib/toast";
+
+/**
+ * Run one server act and surface a failure as its copy: the refusal's
+ * message when the server sent one (spec §4.5), else the caller's fallback.
+ * Resolves to whether the act went through, for callers that continue only
+ * on success.
+ */
+export async function runAct(act: Promise<unknown>, fallback: string): Promise<boolean> {
+  try {
+    await act;
+    return true;
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : fallback);
+    return false;
+  }
+}


### PR DESCRIPTION
Part (b) of #290, stacked on #312. Retarget to main once #312 merges.

Settings under `retroSettings`, all in the menu's "Retro settings…" dialog:

- Rename, join policy (`teamMembers` only on a team retro), cards-due date.
- Prompt label and hint edits at any stage, add a prompt up to ten, remove one only while no card answers it (`forbidden`, "Cards still answer this prompt"). Renaming a prompt touches no card.
- Add, remove or reorder stage entries. Collect and discuss keep their relative order and the current entry keeps its index; everything else moves freely. Removing the last collect or discuss, or the current entry, is refused.
- A denied viewer sees every control disabled with the denial copy, via the permission overlays.

Before stamping, on `/retro/new`, expanding a format opens the same editor: rename or add prompts up to ten, pick a tint, add/remove/reorder entries except collect and discuss, flip collect between hidden and visible, and rename an edited format. The edited copy is what `retro.create` stamps as `{ format, stages }`; an untouched library pick still sends `formatName`. The shipped constant is never mutated (proved).

One judgment call: when a Team's last-used format was itself edited, the form pre-selects that edited copy rather than falling back to the shipped default. Spec §6.1 says the stamped copy is the source of truth, so this seemed right, but it goes a step past the issue text. Easy to drop if you disagree.

Also adds a `by_room_prompt` index on `retroCards` for the remove-prompt check, so this needs a Convex push.

Every mutation bumps room activity (proved in `roomActivity.test.ts`). convex-test covers the locks, the prompt-removal rule, the caps and the independent stamped copy; node covers the draft reducers; jsdom covers the dialog, the editor on the create form and the menu item.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd