### PR TITLE
feat(retro): cards on the board — write, move, silhouettes, reveal, the hand (#291)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -40,6 +40,7 @@ import type * as model_issues from "../model/issues.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as model_refusal from "../model/refusal.js";
 import type * as model_retro from "../model/retro.js";
+import type * as model_retroCards from "../model/retroCards.js";
 import type * as model_retroFormats from "../model/retroFormats.js";
 import type * as model_roles from "../model/roles.js";
 import type * as model_roomAggregate from "../model/roomAggregate.js";
@@ -106,6 +107,7 @@ declare const fullApi: ApiFromModules<{
   "model/permissions": typeof model_permissions;
   "model/refusal": typeof model_refusal;
   "model/retro": typeof model_retro;
+  "model/retroCards": typeof model_retroCards;
   "model/retroFormats": typeof model_retroFormats;
   "model/roles": typeof model_roles;
   "model/roomAggregate": typeof model_roomAggregate;

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -9,6 +9,7 @@ import {
   categoryLevel,
   getEffectiveRole,
   TeamRole,
+  type ResolvedDecision,
 } from "../permissions";
 import { isRoomOwnerAbsent } from "./permissions";
 import { getMembership } from "./users";
@@ -295,10 +296,9 @@ export async function requireCanForUser(
 
 /**
  * The guard's shared IO assembly, given the actor's user and membership from
- * either authentication mode. Loads the room, assembles the precise Action,
- * fetches the target for target-constrained verbs, reads owner absence only
- * when an owner-level outcome could depend on it, calls resolve, and throws
- * the resolved decision's message on denial. Returns the loaded bundle.
+ * either authentication mode. Loads the room, resolves the action through
+ * `resolveRoomAction`, and throws the resolved decision's message on denial.
+ * Returns the loaded bundle.
  */
 async function guardRoomAction(
   ctx: QueryCtx | MutationCtx,
@@ -312,7 +312,39 @@ async function guardRoomAction(
   if (!room) {
     throw new Error("Room not found");
   }
+  const { decision, target } = await resolveRoomAction(
+    ctx,
+    user,
+    membership,
+    room,
+    spec,
+    targetUserId
+  );
+  if (!decision.allowed) {
+    throw new Error(decision.message);
+  }
+  return { user, membership, room, target };
+}
 
+/**
+ * The decision for an action in a loaded room, returned rather than thrown:
+ * the same IO assembly the guard uses — the precise Action, the target for
+ * target-constrained verbs, owner absence only when an owner-level outcome
+ * could depend on it, the Team inputs only for `claim` — for a caller whose
+ * denial is per target (a retro card, spec §8.1) and must be a coded
+ * refusal the client can tell from a failure. Throws only when the category
+ * has no level in this room's ceremony (ADR-0013) or a target is not a
+ * member, which are caller errors, not denials.
+ */
+export async function resolveRoomAction(
+  ctx: QueryCtx | MutationCtx,
+  user: Doc<"users">,
+  membership: Doc<"roomMemberships">,
+  room: Doc<"rooms">,
+  spec: RequireCanSpec,
+  targetUserId?: Id<"users">
+): Promise<{ decision: ResolvedDecision; target?: Doc<"roomMemberships"> }> {
+  const roomId = room._id;
   const effective = getEffectivePermissions(room);
   const actorRole = getEffectiveRole(membership);
 
@@ -381,11 +413,7 @@ async function guardRoomAction(
     ...(team.actorTeamRole ? { actorTeamRole: team.actorTeamRole } : {}),
     ownerInTeam: team.ownerInTeam,
   });
-  if (!decision.allowed) {
-    throw new Error(decision.message);
-  }
-
-  return { user, membership, room, target };
+  return { decision, target };
 }
 
 /**

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -237,18 +237,153 @@ async function getRetro(
     .unique();
 }
 
-/**
- * The retros row of a room, or a `missing` refusal for a poker room. Also
- * the board's structure read (spec §9): identity-free, so every viewer
- * shares one cached result; cards and clusters join it with the cards
- * ticket.
- */
+/** The retros row of a room, or a `missing` refusal for a poker room. */
 export async function requireRetro(ctx: QueryCtx, roomId: Id<"rooms">): Promise<Doc<"retros">> {
   const retro = await getRetro(ctx, roomId);
   if (!retro) {
     throw refusal("missing", NOT_A_RETRO);
   }
   return retro;
+}
+
+// --- The projection and the board reads (ADR-0015, spec §8.3, §9) ---
+
+/** A card as a reader may see it: position and tint only (ADR-0015). */
+export interface Silhouette {
+  _id: Id<"retroCards">;
+  clientId: string;
+  position: { x: number; y: number };
+  promptId: string;
+  clusterId?: Id<"retroClusters">;
+}
+
+/** A card in full; never the edit-key hash. `authorId` only in a named retro. */
+export type FullCard = Silhouette & {
+  text: string;
+  authorId?: Id<"users">;
+  createdAt: number;
+  updatedAt: number;
+  committedAt: number;
+};
+
+export type ProjectedCard = Silhouette | FullCard;
+
+/** Who is reading: a person, or nobody in particular (the identity-free board). */
+export type Reader = { userId: Id<"users"> } | null;
+
+function silhouetteOf(card: Doc<"retroCards">): Silhouette {
+  return {
+    _id: card._id,
+    clientId: card.clientId,
+    position: card.position,
+    promptId: card.promptId,
+    ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
+  };
+}
+
+function fullCardOf(card: Doc<"retroCards">): FullCard {
+  return {
+    ...silhouetteOf(card),
+    text: card.text,
+    ...(card.authorId !== undefined ? { authorId: card.authorId } : {}),
+    createdAt: card.createdAt,
+    updatedAt: card.updatedAt,
+    committedAt: card.committedAt,
+  };
+}
+
+/**
+ * The one projection (ADR-0015): when the entry hides cards and the card is
+ * not the reader's own, a silhouette; otherwise the card without its edit
+ * key hash. Pure. The entry is always the shared pointer's (the caller
+ * reads it from the retros row, never from a client argument); the reader
+ * is `null` for the identity-free board, so its bytes are the same for
+ * every viewer, and a person for `retro.mine` and the exports.
+ */
+export function projectCard(
+  entry: Pick<StageEntry, "cardsVisible">,
+  reader: Reader,
+  card: Doc<"retroCards">
+): ProjectedCard {
+  const own = reader !== null && card.authorId !== undefined && card.authorId === reader.userId;
+  if (entry.cardsVisible === "hidden" && !own) {
+    return silhouetteOf(card);
+  }
+  return fullCardOf(card);
+}
+
+/** How many cards and clusters one board read carries; a retro never approaches it. */
+const MAX_BOARD_ROWS = 2000;
+
+export interface BoardRead {
+  retro: Doc<"retros">;
+  clusters: Doc<"retroClusters">[];
+  cards: ProjectedCard[];
+  /**
+   * Who has written at least one card, in a named retro (the roster's
+   * "has written", ADR-0012); empty under `anonymous`, where the count is
+   * the only signal.
+   */
+  writers: Id<"users">[];
+}
+
+/**
+ * `retro.board` (spec §9): the retros row, every cluster and every card
+ * through the projection with no owner exception, so one cached result
+ * serves every viewer. The viewer's own hidden text comes only through
+ * `mine`, and the client merges the two.
+ */
+export async function board(ctx: QueryCtx, roomId: Id<"rooms">): Promise<BoardRead> {
+  const retro = await requireRetro(ctx, roomId);
+  const entry = currentStageOf(retro);
+  const [clusters, rows] = await Promise.all([
+    ctx.db
+      .query("retroClusters")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(MAX_BOARD_ROWS),
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(MAX_BOARD_ROWS),
+  ]);
+  const writers = new Set<Id<"users">>();
+  if (retro.attribution === "named") {
+    for (const row of rows) {
+      if (row.authorId !== undefined) writers.add(row.authorId);
+    }
+  }
+  return {
+    retro,
+    clusters,
+    cards: rows.map((row) => projectCard(entry, null, row)),
+    writers: [...writers],
+  };
+}
+
+/**
+ * `retro.mine` (spec §9): the viewer's own cards, by `by_room_author` in a
+ * named retro, through the one projection with the viewer as reader — so
+ * "own means full" is decided in `projectCard`, not here. The anonymous
+ * half (presented edit keys) joins with ADR-0012's edit-key ticket; until
+ * then an anonymous retro has no "mine".
+ */
+export async function mine(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  userId: Id<"users">
+): Promise<FullCard[]> {
+  const retro = await requireRetro(ctx, roomId);
+  const entry = currentStageOf(retro);
+  const rows = await ctx.db
+    .query("retroCards")
+    .withIndex("by_room_author", (q) => q.eq("roomId", roomId).eq("authorId", userId))
+    .take(MAX_BOARD_ROWS);
+  return rows.map((row) => {
+    const card = projectCard(entry, { userId }, row);
+    // The index is by author, so the projection can only answer in full.
+    if (!("text" in card)) throw new Error("retro.mine: own card projected as a silhouette");
+    return card;
+  });
 }
 
 // --- Stages (ADR-0010, spec §7) ---

--- a/convex/model/retroCards.ts
+++ b/convex/model/retroCards.ts
@@ -1,0 +1,199 @@
+import { MutationCtx, QueryCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import type { ResolvedDecision } from "../permissions";
+import { resolveRoomAction } from "./auth";
+import { updateRoomActivity } from "./rooms";
+import { requireRetro } from "./retro";
+import { refusal } from "./refusal";
+import {
+  ANONYMOUS_CARDS_NOT_YET,
+  CARD_NOT_FOUND,
+  CARD_TEXT_REQUIRED,
+  CARD_TEXT_TOO_LONG,
+  PROMPT_NOT_FOUND,
+} from "../retroCopy";
+
+/**
+ * Cards (spec §8.1, ADR-0012 named half, ADR-0022): writing, own-card
+ * rights, the one move batch, and the text edit and delete. Every act here
+ * is a person's and correct in every stage; the shared pointer never
+ * forbids one (ADR-0010). Every rule-based refusal is a `ConvexError` with
+ * one of the four codes (spec §4.5).
+ */
+
+export const MAX_CARD_TEXT = 2000;
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+/** The actor a card mutation runs as: their user and their membership, from the guard. */
+export interface CardActor {
+  user: Doc<"users">;
+  membership: Doc<"roomMemberships">;
+}
+
+/** The text a card stores: trimmed, non-empty, bounded. */
+function validateCardText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw refusal("forbidden", CARD_TEXT_REQUIRED);
+  }
+  if (trimmed.length > MAX_CARD_TEXT) {
+    throw refusal("forbidden", CARD_TEXT_TOO_LONG);
+  }
+  return trimmed;
+}
+
+/** A card of the room by its client-minted id, or null. */
+export async function getCardByClientId(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  clientId: string
+): Promise<Doc<"retroCards"> | null> {
+  return ctx.db
+    .query("retroCards")
+    .withIndex("by_room_client", (q) => q.eq("roomId", roomId).eq("clientId", clientId))
+    .unique();
+}
+
+async function requireCard(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  clientId: string
+): Promise<Doc<"retroCards">> {
+  const card = await getCardByClientId(ctx, roomId, clientId);
+  if (!card) {
+    throw refusal("missing", CARD_NOT_FOUND);
+  }
+  return card;
+}
+
+/**
+ * Write a card (spec §8.1). The client mints `clientId`, so a retried
+ * create finds its row and inserts nothing. In a named retro the caller
+ * becomes the author; the anonymous half (edit keys, ADR-0012) is not
+ * built yet, so an anonymous retro refuses the write rather than store an
+ * author it promised not to. `committedAt = createdAt = Date.now()` inside
+ * the mutation (spec §23.6).
+ */
+export async function createCard(
+  ctx: MutationCtx,
+  args: {
+    room: Doc<"rooms">;
+    actor: CardActor;
+    clientId: string;
+    text: string;
+    promptId: string;
+    position: Position;
+  }
+): Promise<Id<"retroCards">> {
+  const retro = await requireRetro(ctx, args.room._id);
+  if (!retro.format.prompts.some((p) => p.id === args.promptId)) {
+    throw refusal("missing", PROMPT_NOT_FOUND);
+  }
+  const text = validateCardText(args.text);
+  if (retro.attribution !== "named") {
+    throw refusal("forbidden", ANONYMOUS_CARDS_NOT_YET);
+  }
+  const existing = await getCardByClientId(ctx, args.room._id, args.clientId);
+  if (existing) {
+    return existing._id;
+  }
+  const now = Date.now();
+  const cardId = await ctx.db.insert("retroCards", {
+    roomId: args.room._id,
+    clientId: args.clientId,
+    text,
+    promptId: args.promptId,
+    position: args.position,
+    authorId: args.actor.user._id,
+    createdAt: now,
+    updatedAt: now,
+    committedAt: now,
+  });
+  await updateRoomActivity(ctx, args.room);
+  return cardId;
+}
+
+/**
+ * Own-card rights (spec §8.1): the author may edit, move and delete their
+ * card; anyone else needs `cardManagement`. The decision is the guard's own
+ * (`resolveRoomAction`), read back rather than thrown because whether the
+ * category applies depends on the card, and a denial must be a `forbidden`
+ * refusal the client can tell from a failure. One check per act: a batch
+ * resolves the category once and tests authorship per card.
+ */
+function cardRights(
+  ctx: QueryCtx,
+  room: Doc<"rooms">,
+  actor: CardActor
+): (card: Doc<"retroCards">) => Promise<void> {
+  let decision: Promise<ResolvedDecision> | undefined;
+  return async (card) => {
+    if (card.authorId !== undefined && card.authorId === actor.user._id) {
+      return;
+    }
+    decision ??= resolveRoomAction(ctx, actor.user, actor.membership, room, {
+      kind: "category",
+      category: "cardManagement",
+    }).then((r) => r.decision);
+    const verdict = await decision;
+    if (!verdict.allowed) {
+      throw refusal("forbidden", verdict.message);
+    }
+  };
+}
+
+/** Edit a card's text; the author is untouched and no editor is recorded (ADR-0012). */
+export async function updateCardText(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clientId: string; text: string }
+): Promise<void> {
+  const card = await requireCard(ctx, args.room._id, args.clientId);
+  await cardRights(ctx, args.room, args.actor)(card);
+  await ctx.db.patch(card._id, { text: validateCardText(args.text), updatedAt: Date.now() });
+  await updateRoomActivity(ctx, args.room);
+}
+
+export interface CardMove {
+  clientId: string;
+  position: Position;
+}
+
+/**
+ * The one move mutation (ADR-0022): a batch, one transaction and one
+ * invalidation whether it is a single drop, a marquee drag or a tidy. A
+ * move never changes a card's prompt (ADR-0016). Last write wins.
+ */
+export async function moveCards(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; moves: CardMove[] }
+): Promise<void> {
+  const cards = await Promise.all(
+    args.moves.map((move) => requireCard(ctx, args.room._id, move.clientId))
+  );
+  const mayTouch = cardRights(ctx, args.room, args.actor);
+  for (const card of cards) {
+    await mayTouch(card);
+  }
+  const now = Date.now();
+  await Promise.all(
+    cards.map((card, i) =>
+      ctx.db.patch(card._id, { position: args.moves[i].position, updatedAt: now })
+    )
+  );
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Delete a card: own, or under `cardManagement`. */
+export async function deleteCard(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clientId: string }
+): Promise<void> {
+  const card = await requireCard(ctx, args.room._id, args.clientId);
+  await cardRights(ctx, args.room, args.actor)(card);
+  await ctx.db.delete(card._id);
+  await updateRoomActivity(ctx, args.room);
+}

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -637,6 +637,21 @@ export async function linkAnonymousToPermanent(
       await ctx.db.patch(node._id, { lastUpdatedBy: existingPermanent._id });
     }
 
+    // Retro cards keep their author by reference (ADR-0012): re-point the
+    // anonymous account's cards in every room it attended. The index is
+    // (room, author), so the walk is per membership.
+    for (const membership of memberships) {
+      const cards = await ctx.db
+        .query("retroCards")
+        .withIndex("by_room_author", (q) =>
+          q.eq("roomId", membership.roomId).eq("authorId", user._id)
+        )
+        .collect();
+      for (const card of cards) {
+        await ctx.db.patch(card._id, { authorId: existingPermanent._id });
+      }
+    }
+
     // Delete the old anonymous user record
     await ctx.db.delete(user._id);
     return;

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -30,23 +30,30 @@ export const heartbeat = mutation({
 });
 
 /**
- * Readiness (ADR-0010, spec §7): a person's "I am done with this stage"
- * signal, held in the presence payload as `{ stageId, ready }` and never in
- * a table. One write per state change; a reader treats a payload whose
- * `stageId` is not the current entry as absent, so an advance clears every
- * signal with no write at all. The same guard as the heartbeat: the caller
- * must be this room member acting as themselves.
+ * The retro's presence payload (ADR-0010, ADR-0022, spec §7, §10.6):
+ * readiness — "I am done with this stage" as `{ stageId, ready }`, never
+ * in a table — and the editing indicator, the `clientId` of the card the
+ * person is typing into. One write per state change through the client's
+ * global single-flight; a reader treats a payload whose `stageId` is not
+ * the current entry as not ready, so an advance clears every signal with
+ * no write at all. The same guard as the heartbeat: the caller must be
+ * this room member acting as themselves.
  */
-export const setReadiness = mutation({
+export const setRetroPresence = mutation({
   args: {
     roomId: v.id("rooms"),
     userId: v.id("users"),
     stageId: v.string(),
     ready: v.boolean(),
+    editing: v.optional(v.string()),
   },
-  handler: async (ctx, { roomId, userId, stageId, ready }) => {
-    await requireActingUser(ctx, roomId, userId, "Cannot set readiness as another user");
-    await presence.updateRoomUser(ctx, roomId, userId, { stageId, ready });
+  handler: async (ctx, { roomId, userId, stageId, ready, editing }) => {
+    await requireActingUser(ctx, roomId, userId, "Cannot set presence as another user");
+    await presence.updateRoomUser(ctx, roomId, userId, {
+      stageId,
+      ready,
+      ...(editing !== undefined ? { editing } : {}),
+    });
     return null;
   },
 });

--- a/convex/retro.test.ts
+++ b/convex/retro.test.ts
@@ -186,11 +186,13 @@ describe("retro.board", () => {
       formatName: DEFAULT_RETRO_FORMAT.name,
     });
 
-    const board = await as(t, "owner").query(api.retro.board, { roomId });
+    const { retro: board, cards, clusters } = await as(t, "owner").query(api.retro.board, { roomId });
     expect(board.roomId).toBe(roomId);
     expect(board.currentStageId).toBe(board.stages[0].id);
     expect(board.stages[0].kind).toBe("collect");
     expect(board.format.name).toBe(DEFAULT_RETRO_FORMAT.name);
+    expect(cards).toEqual([]);
+    expect(clusters).toEqual([]);
 
     await expect(
       as(t, "stranger").query(api.retro.board, { roomId })

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -1,6 +1,8 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import * as Retro from "./model/retro";
+import * as RetroCards from "./model/retroCards";
 import {
   joinPolicyValidator,
   retroFormatValidator,
@@ -45,14 +47,24 @@ export const create = mutation({
 });
 
 /**
- * The board's structure (spec §9): the retros row — format, stages, the
- * shared pointer, `collectUntil`. Room access, not attendance (ADR-0009).
+ * The board (spec §9): the retros row, every cluster and every card through
+ * the projection, identical for every viewer. Room access, not attendance
+ * (ADR-0009).
  */
 export const board = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
     await requireRoomReader(ctx, args.roomId);
-    return await Retro.requireRetro(ctx, args.roomId);
+    return await Retro.board(ctx, args.roomId);
+  },
+});
+
+/** The viewer's own cards in full, whatever the shared pointer hides (spec §9). */
+export const mine = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user } = await requireRoomReader(ctx, args.roomId);
+    return await Retro.mine(ctx, args.roomId, user._id);
   },
 });
 
@@ -270,3 +282,66 @@ export const listMine = query({
     return await Retro.listMine(ctx, user._id);
   },
 });
+
+// --- Cards (spec §8.1, ADR-0022) ---
+
+const positionValidator = v.object({ x: v.number(), y: v.number() });
+
+/**
+ * Write a card. Attendance is the only guard: writing is never in the
+ * config (spec §4.2). The client mints `clientId`; a retry returns the row.
+ */
+export const createCard = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    clientId: v.string(),
+    text: v.string(),
+    promptId: v.string(),
+    position: positionValidator,
+  },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    return await RetroCards.createCard(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Edit a card's text: own, or under `cardManagement`; the model decides per card. */
+export const updateCard = mutation({
+  args: { roomId: v.id("rooms"), clientId: v.string(), text: v.string() },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroCards.updateCardText(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** The one move mutation: a batch of `{ clientId, position }` (ADR-0022). */
+export const moveCards = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    moves: v.array(v.object({ clientId: v.string(), position: positionValidator })),
+  },
+  handler: async (ctx, args) => {
+    await RetroCards.moveCards(ctx, { ...(await requireCardActor(ctx, args.roomId)), moves: args.moves });
+  },
+});
+
+/** Delete a card: own, or under `cardManagement`. */
+export const deleteCard = mutation({
+  args: { roomId: v.id("rooms"), clientId: v.string() },
+  handler: async (ctx, args) => {
+    await RetroCards.deleteCard(ctx, { ...(await requireCardActor(ctx, args.roomId)), clientId: args.clientId });
+  },
+});
+
+/**
+ * A card act's actor: the attendance guard (which does not load the room)
+ * and the room row the model needs.
+ */
+async function requireCardActor(ctx: QueryCtx, roomId: Id<"rooms">) {
+  const { user, membership } = await requireRoomMember(ctx, roomId);
+  const room = await ctx.db.get(roomId);
+  if (!room) {
+    throw refusal("missing", ROOM_NOT_FOUND);
+  }
+  return { room, actor: { user, membership } };
+}

--- a/convex/retroCards.test.ts
+++ b/convex/retroCards.test.ts
@@ -1,0 +1,360 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+import * as Users from "./model/users";
+
+// Cards on the board (spec §8.1, §8.3, §9; ADR-0012 named half, ADR-0015,
+// ADR-0022): writing, own-card rights, `cardManagement` on another's card,
+// `clientId` dedupe, the silhouette projection by the shared pointer, and
+// the four refusal codes on their paths. No stage ever forbids a card act.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string) => seedNamedUser(t, authUserId, authUserId);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+async function cardsOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function userId(t: T, authUserId: string): Promise<Id<"users">> {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("users")
+      .withIndex("by_auth_user", (q) => q.eq("authUserId", authUserId))
+      .unique()
+  ))!._id;
+}
+
+/** An owner and a participant in a fresh teamless (named) retro. */
+async function seedRetro(t: T) {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, {
+    name: "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+  });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  const retro = await retroRow(t, roomId);
+  return { roomId, stages: retro.stages, promptId: retro.format.prompts[0].id };
+}
+
+const POS = { x: 10, y: 20 };
+
+async function write(t: T, who: string, roomId: Id<"rooms">, promptId: string, clientId: string, text = "hello") {
+  return as(t, who).mutation(api.retro.createCard, { roomId, clientId, text, promptId, position: POS });
+}
+
+/** The refusal's code, or undefined for a plain error. */
+async function codeOf(p: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await p;
+    return "resolved";
+  } catch (error) {
+    return error instanceof ConvexError ? (error.data as { code: string }).code : undefined;
+  }
+}
+
+describe("retro.createCard", () => {
+  it("writes a card with the caller as author and the three stamps equal", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+
+    const cardId = await write(t, "guest", roomId, promptId, "c1", "  keep the demo  ");
+
+    const [card] = await cardsOf(t, roomId);
+    expect(card._id).toBe(cardId);
+    expect(card).toMatchObject({
+      clientId: "c1",
+      text: "keep the demo",
+      promptId,
+      position: POS,
+      authorId: await userId(t, "guest"),
+    });
+    expect(card.editKeyHash).toBeUndefined();
+    expect(card.createdAt).toBe(card.committedAt);
+    expect(card.updatedAt).toBe(card.createdAt);
+  });
+
+  it("a retried create with the same clientId returns the existing row and inserts nothing", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+
+    const first = await write(t, "guest", roomId, promptId, "c1", "one");
+    const again = await write(t, "guest", roomId, promptId, "c1", "changed");
+
+    expect(again).toBe(first);
+    const cards = await cardsOf(t, roomId);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("one");
+  });
+
+  it("refuses an unknown prompt with `missing`, blank text with `forbidden`, and a non-member with a guard error", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await seedUser(t, "stranger");
+
+    expect(await codeOf(write(t, "guest", roomId, "nope", "c1"))).toBe("missing");
+    expect(await codeOf(write(t, "guest", roomId, promptId, "c2", "   "))).toBe("forbidden");
+    await expect(write(t, "stranger", roomId, promptId, "c3")).rejects.toThrow("Not a member");
+    expect(await cardsOf(t, roomId)).toHaveLength(0);
+  });
+});
+
+describe("own-card rights and cardManagement (spec §8.1, §4.2)", () => {
+  it("the author edits, moves and deletes their own card; a participant is refused on another's with `forbidden`", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await write(t, "owner", roomId, promptId, "o1", "owner's");
+    await write(t, "guest", roomId, promptId, "g1", "guest's");
+
+    await as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "edited" });
+    await as(t, "guest").mutation(api.retro.moveCards, {
+      roomId,
+      moves: [{ clientId: "g1", position: { x: 99, y: 98 } }],
+    });
+    let cards = await cardsOf(t, roomId);
+    const mine = cards.find((c) => c.clientId === "g1")!;
+    expect(mine.text).toBe("edited");
+    expect(mine.position).toEqual({ x: 99, y: 98 });
+    expect(mine.authorId).toBe(await userId(t, "guest"));
+
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "o1", text: "x" }))
+    ).toBe("forbidden");
+    expect(
+      await codeOf(
+        as(t, "guest").mutation(api.retro.moveCards, {
+          roomId,
+          moves: [{ clientId: "g1", position: POS }, { clientId: "o1", position: POS }],
+        })
+      )
+    ).toBe("forbidden");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "o1" }))).toBe(
+      "forbidden"
+    );
+    cards = await cardsOf(t, roomId);
+    expect(cards.find((c) => c.clientId === "o1")).toMatchObject({ text: "owner's", position: POS });
+    // A refused batch moves nothing, the caller's own card included.
+    expect(cards.find((c) => c.clientId === "g1")!.position).toEqual({ x: 99, y: 98 });
+
+    await as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "g1" });
+    expect((await cardsOf(t, roomId)).map((c) => c.clientId)).toEqual(["o1"]);
+  });
+
+  it("a cardManagement holder touches another's card and the author never changes", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await write(t, "guest", roomId, promptId, "g1", "guest's");
+    const guestId = await userId(t, "guest");
+
+    await as(t, "owner").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "tidied" });
+    await as(t, "owner").mutation(api.retro.moveCards, {
+      roomId,
+      moves: [{ clientId: "g1", position: { x: 1, y: 2 } }],
+    });
+    const [card] = await cardsOf(t, roomId);
+    expect(card).toMatchObject({ text: "tidied", position: { x: 1, y: 2 }, authorId: guestId });
+
+    await as(t, "owner").mutation(api.retro.deleteCard, { roomId, clientId: "g1" });
+    expect(await cardsOf(t, roomId)).toHaveLength(0);
+  });
+
+  it("a card the room does not carry is `missing`; blank text on edit is `forbidden`", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await write(t, "guest", roomId, promptId, "g1");
+
+    expect(await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "zz", text: "x" }))).toBe("missing");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "zz" }))).toBe("missing");
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.moveCards, { roomId, moves: [{ clientId: "zz", position: POS }] }))
+    ).toBe("missing");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: " " }))).toBe("forbidden");
+  });
+
+  it("a marquee drag is one batch: every card in it moves in one call", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await write(t, "guest", roomId, promptId, "a");
+    await write(t, "guest", roomId, promptId, "b");
+
+    await as(t, "guest").mutation(api.retro.moveCards, {
+      roomId,
+      moves: [
+        { clientId: "a", position: { x: 1, y: 1 } },
+        { clientId: "b", position: { x: 2, y: 2 } },
+      ],
+    });
+    const cards = await cardsOf(t, roomId);
+    expect(cards.find((c) => c.clientId === "a")!.position).toEqual({ x: 1, y: 1 });
+    expect(cards.find((c) => c.clientId === "b")!.position).toEqual({ x: 2, y: 2 });
+  });
+});
+
+describe("the silhouette projection (ADR-0015, spec §8.3, §9)", () => {
+  /** Two members with a card each, the pointer at `collect` (hidden). */
+  async function seedTwoCards(t: T) {
+    const seeded = await seedRetro(t);
+    await write(t, "owner", seeded.roomId, seeded.promptId, "o1", "owner's text");
+    await write(t, "guest", seeded.roomId, seeded.promptId, "g1", "guest's text");
+    return seeded;
+  }
+
+  const byClient = (cards: { clientId: string }[], clientId: string) =>
+    cards.find((c) => c.clientId === clientId)! as Record<string, unknown>;
+
+  it("in a hidden entry the board carries silhouettes for everyone, the author included; `mine` carries the text", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedTwoCards(t);
+
+    const board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(board.retro.currentStageId).toBe(board.retro.stages[0].id);
+    expect(board.clusters).toEqual([]);
+    expect(board.cards).toHaveLength(2);
+    for (const card of board.cards) {
+      expect(Object.keys(card).sort()).toEqual(["_id", "clientId", "position", "promptId"]);
+      expect(card.promptId).toBe(promptId);
+    }
+    // Identical bytes for every viewer: the owner's read equals the guest's.
+    expect(await as(t, "owner").query(api.retro.board, { roomId })).toEqual(board);
+
+    const mine = await as(t, "guest").query(api.retro.mine, { roomId });
+    expect(mine.map((c) => c.clientId)).toEqual(["g1"]);
+    expect(mine[0].text).toBe("guest's text");
+    expect(mine[0].authorId).toBe(await userId(t, "guest"));
+    expect("editKeyHash" in mine[0]).toBe(false);
+  });
+
+  it("advancing to a visible entry reveals every card with its author; rewinding hides again", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedTwoCards(t);
+    const ownerId = await userId(t, "owner");
+
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+    let board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(byClient(board.cards, "o1")).toMatchObject({ text: "owner's text", authorId: ownerId });
+    expect(byClient(board.cards, "g1")).toMatchObject({ text: "guest's text" });
+    expect("editKeyHash" in byClient(board.cards, "o1")).toBe(false);
+
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[0].id });
+    board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect("text" in byClient(board.cards, "o1")).toBe(false);
+    expect("authorId" in byClient(board.cards, "o1")).toBe(false);
+  });
+
+  it("the in-place toggle reveals and hides without an advance, and a visible collect returns text", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedTwoCards(t);
+
+    await as(t, "owner").mutation(api.retro.setCardsVisible, { roomId, stageId: stages[0].id, value: "visible" });
+    let board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(byClient(board.cards, "o1").text).toBe("owner's text");
+
+    await as(t, "owner").mutation(api.retro.setCardsVisible, { roomId, stageId: stages[0].id, value: "hidden" });
+    board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect("text" in byClient(board.cards, "o1")).toBe(false);
+  });
+
+  it("the shared pointer governs: no client argument moves the projection, and no role peeks", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTwoCards(t);
+    // The owner is the facilitator here; their board is the guest's board.
+    const board = await as(t, "owner").query(api.retro.board, { roomId });
+    expect("text" in byClient(board.cards, "g1")).toBe(false);
+  });
+
+  it("a second collect entry later in the list hides again", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedTwoCards(t);
+    const second = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "collect", index: 2 });
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+    expect("text" in byClient((await as(t, "guest").query(api.retro.board, { roomId })).cards, "o1")).toBe(true);
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: second });
+    expect("text" in byClient((await as(t, "guest").query(api.retro.board, { roomId })).cards, "o1")).toBe(false);
+  });
+
+  it("the board names who has written in a named retro, silhouettes or not; a stranger reads nothing", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTwoCards(t);
+    await seedUser(t, "stranger");
+    const board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect([...board.writers].sort()).toEqual([await userId(t, "owner"), await userId(t, "guest")].sort());
+    await expect(as(t, "stranger").query(api.retro.board, { roomId })).rejects.toThrow("access");
+    await expect(as(t, "stranger").query(api.retro.mine, { roomId })).rejects.toThrow("access");
+  });
+});
+
+describe("a stage never forbids a card act (ADR-0010)", () => {
+  it("create, edit, move and delete succeed with the pointer at discuss and at close", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, promptId } = await seedRetro(t);
+    for (const kind of ["discuss", "close"] as const) {
+      const entry = stages.find((s) => s.kind === kind)!;
+      await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: entry.id });
+      const clientId = `card-${kind}`;
+      await write(t, "guest", roomId, promptId, clientId);
+      await as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId, text: "late thought" });
+      await as(t, "guest").mutation(api.retro.moveCards, { roomId, moves: [{ clientId, position: { x: 5, y: 5 } }] });
+      expect((await cardsOf(t, roomId)).find((c) => c.clientId === clientId)).toMatchObject({
+        text: "late thought",
+        position: { x: 5, y: 5 },
+      });
+      await as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId });
+    }
+    expect(await cardsOf(t, roomId)).toHaveLength(0);
+  });
+});
+
+describe("attribution (ADR-0012, named half)", () => {
+  it("an anonymous retro refuses a card with `forbidden` until the edit-key half ships", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    const retro = await retroRow(t, roomId);
+    await t.run((ctx) => ctx.db.patch(retro._id, { attribution: "anonymous" }));
+    expect(await codeOf(write(t, "guest", roomId, promptId, "c1"))).toBe("forbidden");
+    expect(await cardsOf(t, roomId)).toHaveLength(0);
+  });
+
+  it("linking an anonymous account to an existing permanent one re-points authorId", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    await write(t, "guest", roomId, promptId, "g1");
+    const anonId = await userId(t, "guest");
+    const permanentId = await seedNamedUser(t, "perm", "P", "permanent");
+
+    await t.run((ctx) =>
+      Users.linkAnonymousToPermanent(ctx, {
+        oldAuthUserId: "guest",
+        newAuthUserId: "perm",
+        email: "p@example.com",
+      })
+    );
+
+    const [card] = await cardsOf(t, roomId);
+    expect(card.authorId).toBe(permanentId);
+    expect(await t.run((ctx) => ctx.db.get(anonId))).toBeNull();
+    const mine = await as(t, "perm").query(api.retro.mine, { roomId });
+    expect(mine.map((c) => c.clientId)).toEqual(["g1"]);
+  });
+});

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -240,3 +240,37 @@ export const DELETING_BUTTON = "Deleting…";
 export const DELETE_FAILED = "Failed to delete this retro";
 export const RETRO_DELETED = "Retro deleted";
 
+
+// --- Cards (spec §8.1, §19; ADR-0012, ADR-0015, ADR-0022) ---
+
+/** A card act naming a `clientId` the room does not carry. */
+export const CARD_NOT_FOUND = "That card is no longer on the board";
+export const CARD_TEXT_REQUIRED = "A card needs some text";
+export const CARD_TEXT_TOO_LONG = "A card holds at most 2000 characters";
+/** `createCard` in an anonymous retro before the edit-key half of ADR-0012 ships. */
+export const ANONYMOUS_CARDS_NOT_YET = "Anonymous retros cannot take cards yet";
+
+/** Composer, named (ADR-0012). */
+export const postedAs = (name: string) => `Posted as ${name}. Your name stays with this card.`;
+/** Composer, hidden, named (ADR-0015); stacks under the attribution line. */
+export const COMPOSER_HIDDEN_NAMED =
+  "Only you can read this for now. Others can see you've added a card, not what it says. Everyone reads it once cards are revealed.";
+/** Composer, visible, either attribution. */
+export const COMPOSER_VISIBLE = "Everyone in the retro can read this now.";
+
+export const ADD_CARD = "Add card";
+export const COMPOSER_TITLE = "Write a card";
+export const COMPOSER_PROMPT_LABEL = "Prompt";
+export const COMPOSER_TEXT_LABEL = "Your card";
+export const COMPOSER_TEXT_PLACEHOLDER = "One thought per card";
+export const COMPOSER_SUBMIT = "Post card";
+export const CARD_TEXT_FIELD = "Card text";
+export const DELETE_CARD = "Delete card";
+export const UNSAVED_CHIP = "Unsaved";
+export const EDITING_CHIP = "Editing";
+export const HIDDEN_CARD_LABEL = "Hidden card";
+export const HAS_WRITTEN = "Has written";
+export const cardsCount = (n: number) => `${n} ${n === 1 ? "card" : "cards"}`;
+/** Missing user (spec §19). */
+export const FORMER_MEMBER = "Former member";
+export const CARD_ACT_FAILED = "That did not go through. Try again.";

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -598,6 +598,28 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     await expectBumped(t, roomId, stale);
   });
 
+  it("every card mutation bumps (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t, false);
+    const retro = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const me = as(t, "auth-member");
+    const promptId = retro.format.prompts[0].id;
+    const acts = [
+      () => me.mutation(api.retro.createCard, { roomId, clientId: "c1", text: "hi", promptId, position: { x: 0, y: 0 } }),
+      () => me.mutation(api.retro.updateCard, { roomId, clientId: "c1", text: "edited" }),
+      () => me.mutation(api.retro.moveCards, { roomId, moves: [{ clientId: "c1", position: { x: 1, y: 1 } }] }),
+      () => me.mutation(api.retro.deleteCard, { roomId, clientId: "c1" }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+  });
+
   it("claim bumps", async () => {
     const t = convexTest(schema, modules);
     const { roomId, memberId, stale } = await seedTeamRetro(t, true);

--- a/convex/teamRetro.test.ts
+++ b/convex/teamRetro.test.ts
@@ -477,7 +477,7 @@ describe("reading a team retro without attendance (ADR-0009)", () => {
     const roomId = await createRetro(t, "member", { teamId });
 
     const board = await as(t, "admin").query(api.retro.board, { roomId });
-    expect(board.roomId).toBe(roomId);
+    expect(board.retro.roomId).toBe(roomId);
     expect(await membershipOf(t, roomId, adminId)).toBeNull();
     expect(await as(t, "admin").query(api.users.getMyMembership, { roomId })).toBeNull();
   });
@@ -491,7 +491,7 @@ describe("reading a team retro without attendance (ADR-0009)", () => {
     await as(t, "member").mutation(api.users.remove, { roomId, userId: adminId });
 
     expect(await membershipOf(t, roomId, adminId)).toBeNull();
-    expect((await as(t, "admin").query(api.retro.board, { roomId })).roomId).toBe(roomId);
+    expect((await as(t, "admin").query(api.retro.board, { roomId })).retro.roomId).toBe(roomId);
   });
 
   it("the room shell names the owning Team for anyone with the link", async () => {

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -18,15 +18,29 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/convex/_generated/api", () => ({
   api: {
-    retro: { board: "retro.board", advance: "retro.advance", setCardsVisible: "retro.setCardsVisible", setTimebox: "retro.setTimebox" },
+    retro: {
+      board: "retro.board",
+      mine: "retro.mine",
+      advance: "retro.advance",
+      setCardsVisible: "retro.setCardsVisible",
+      setTimebox: "retro.setTimebox",
+      createCard: "retro.createCard",
+      updateCard: "retro.updateCard",
+      moveCards: "retro.moveCards",
+      deleteCard: "retro.deleteCard",
+    },
     teams: { listMine: "teams.listMine" },
-    presence: { setReadiness: "presence.setReadiness" },
+    presence: { setRetroPresence: "presence.setRetroPresence" },
   },
 }));
 vi.mock("convex/react", () => ({
   useQuery: (ref: string, args: unknown) => (args === "skip" ? undefined : mocks.queries[ref]),
-  useMutation: (ref: string) => async (args: unknown) => {
-    mocks.mutations.push({ fn: ref, args });
+  useMutation: (ref: string) => {
+    const fn = async (args: unknown) => {
+      mocks.mutations.push({ fn: ref, args });
+    };
+    // The card mutations carry optimistic functions; the recorder ignores them.
+    return Object.assign(fn, { withOptimisticUpdate: () => fn });
   },
 }));
 vi.mock("@convex-dev/presence/react", () => ({
@@ -45,13 +59,15 @@ vi.mock("@/components/retro/retro-join-form", () => ({
   ),
 }));
 vi.mock("@/components/retro/retro-board", () => ({
-  RetroBoard: ({ retro, team, menu, banner, viewer }: { retro: { currentStageId: string }; team?: { name: string }; menu?: React.ReactNode; banner?: React.ReactNode; viewer?: { userId: string; onSetReady: (ready: boolean) => void; controls: { onAdvance: (id: string) => void; stageFlow: { allowed: boolean } } } }) => (
-    <div data-testid="board" data-team={team?.name} data-viewer={viewer?.userId} data-stage-flow={String(viewer?.controls.stageFlow.allowed)}>
+  RetroBoard: ({ retro, cards, team, menu, banner, viewer }: { retro: { currentStageId: string }; cards: { clientId: string; hidden: boolean }[]; team?: { name: string }; menu?: React.ReactNode; banner?: React.ReactNode; viewer?: { userId: string; onSetReady: (ready: boolean) => void; onEditing: (clientId?: string) => void; controls: { onAdvance: (id: string) => void; stageFlow: { allowed: boolean } }; cards: { move: (moves: unknown[]) => void } } }) => (
+    <div data-testid="board" data-team={team?.name} data-viewer={viewer?.userId} data-stage-flow={String(viewer?.controls.stageFlow.allowed)} data-cards={cards.map((c) => `${c.clientId}:${c.hidden}`).join(",")}>
       {retro.currentStageId}
       {menu}
       {banner}
       {viewer && <button onClick={() => viewer.onSetReady(true)}>ready</button>}
+      {viewer && <button onClick={() => viewer.onEditing("c1")}>edit</button>}
       {viewer && <button onClick={() => viewer.controls.onAdvance("s2")}>advance</button>}
+      {viewer && <button onClick={() => viewer.cards.move([{ clientId: "c1", position: { x: 1, y: 1 } }])}>move</button>}
     </div>
   ),
 }));
@@ -85,7 +101,18 @@ beforeEach(() => {
   mocks.presenceCalls = [];
   mocks.auth.accountType = "anonymous";
   mocks.queries = {
-    "retro.board": { currentStageId: "s1", stages: [{ id: "s1", kind: "collect" }, { id: "s2", kind: "group" }] },
+    "retro.board": {
+      retro: { currentStageId: "s1", stages: [{ id: "s1", kind: "collect" }, { id: "s2", kind: "group" }] },
+      clusters: [],
+      cards: [
+        { _id: "id1", clientId: "c1", position: { x: 0, y: 0 }, promptId: "p1" },
+        { _id: "id2", clientId: "c2", position: { x: 0, y: 0 }, promptId: "p1" },
+      ],
+      writers: ["user1"],
+    },
+    "retro.mine": [
+      { _id: "id1", clientId: "c1", position: { x: 0, y: 0 }, promptId: "p1", text: "mine", authorId: "user1", createdAt: 1, updatedAt: 1, committedAt: 1 },
+    ],
     "teams.listMine": [],
   };
 });
@@ -118,7 +145,7 @@ describe("RetroRoomContent", () => {
     expect(screen.queryByTestId("team-reader-banner")).toBeNull();
   });
 
-  it("an attendee heartbeats as themselves, writes readiness keyed to the shared entry, and holds the stageFlow decision", async () => {
+  it("an attendee heartbeats as themselves, writes the presence payload keyed to the shared entry, and holds the stageFlow decision", async () => {
     render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
     expect(mocks.presenceCalls[0]?.slice(1)).toEqual([roomId, "user1"]);
     const board = screen.getByTestId("board");
@@ -126,12 +153,23 @@ describe("RetroRoomContent", () => {
     expect(board.getAttribute("data-stage-flow")).toBe("true");
 
     fireEvent.click(screen.getByRole("button", { name: "ready" }));
+    await new Promise((r) => setTimeout(r, 0));
+    // The editing write carries the readiness just toggled (one whole payload).
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
     fireEvent.click(screen.getByRole("button", { name: "advance" }));
+    fireEvent.click(screen.getByRole("button", { name: "move" }));
     await new Promise((r) => setTimeout(r, 0));
     expect(mocks.mutations).toEqual([
-      { fn: "presence.setReadiness", args: { roomId, userId: "user1", stageId: "s1", ready: true } },
+      { fn: "presence.setRetroPresence", args: { roomId, userId: "user1", stageId: "s1", ready: true } },
+      { fn: "presence.setRetroPresence", args: { roomId, userId: "user1", stageId: "s1", ready: true, editing: "c1" } },
       { fn: "retro.advance", args: { roomId, toStageId: "s2" } },
+      { fn: "retro.moveCards", args: { roomId, moves: [{ clientId: "c1", position: { x: 1, y: 1 } }] } },
     ]);
+  });
+
+  it("merges the board with mine: own silhouettes carry text, others stay hidden; a Team reader gets no mine", () => {
+    render(<RetroRoomContent roomId={roomId} roomData={teamless} membership={{ _id: "user1" as never }} />);
+    expect(screen.getByTestId("board").getAttribute("data-cards")).toBe("c1:false,c2:true");
   });
 
   it("a Team member who never joined reads the board with no menu, and joins only on their own click", async () => {
@@ -143,6 +181,8 @@ describe("RetroRoomContent", () => {
     expect(screen.queryByTestId("menu")).toBeNull();
     expect(screen.queryByTestId("join-form")).toBeNull();
     expect(screen.getByTestId("team-reader-banner").textContent).toContain("member of Acme Squad");
+    // No attendance, no `mine`: every card is a silhouette to a Team reader.
+    expect(board.getAttribute("data-cards")).toBe("c1:true,c2:true");
     // No attendance, no heartbeat: the presence hook never mounts.
     expect(mocks.presenceCalls).toEqual([]);
     expect(board.getAttribute("data-viewer")).toBeNull();

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -1,19 +1,24 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { Doc, Id } from "@/convex/_generated/dataModel";
+import { Id } from "@/convex/_generated/dataModel";
 import { useAuth } from "@/components/auth/auth-provider";
 import { CenteredMessage } from "@/components/centered-message";
 import { Button } from "@/components/ui/button";
 import { RetroJoinForm } from "@/components/retro/retro-join-form";
 import { RetroBoard, type BoardViewer } from "@/components/retro/retro-board";
+import { mergeCards, type BoardCard } from "@/components/retro/cards";
+import { readinessOf } from "@/components/retro/readiness";
+import { useCardActions } from "@/components/retro/use-card-actions";
+import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
 import type { RetroTeam } from "@/components/retro/retro-header";
 import type { StageControls } from "@/components/retro/stage-nav";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import type { BoardRead } from "@/convex/model/retro";
 import { useRetroPermissions } from "@/hooks/usePermissions";
 import { useRoomPresence, type UserWithPresence } from "@/hooks/useRoomPresence";
 import { runAct } from "@/lib/run-act";
@@ -59,7 +64,13 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const isTeamMember = team !== undefined && (myTeams ?? []).some((t) => t._id === team._id);
   const canRead = isMember || isTeamMember;
   // The board read takes the reader guard; never subscribe before it passes.
-  const retro = useQuery(api.retro.board, canRead ? { roomId } : "skip");
+  // `mine` is the attendee's own text (spec §9); a Team reader has none.
+  const board = useQuery(api.retro.board, canRead ? { roomId } : "skip");
+  const mine = useQuery(api.retro.mine, isMember ? { roomId } : "skip");
+  const cards = useMemo<BoardCard[]>(
+    () => (board ? mergeCards(board.cards, mine, membership?._id) : []),
+    [board, mine, membership?._id]
+  );
   // A Team reader never heartbeats, so their roster reads everyone offline.
   const offlineUsers = useMemo<UserWithPresence[]>(
     () => roomData.users.map((user) => ({ ...user, isOnline: false, lastSeen: null })),
@@ -86,7 +97,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     );
   }
 
-  if (retro === undefined) {
+  if (board === undefined) {
     return <CenteredMessage title={LOADING_TITLE} body={LOADING_BOARD} />;
   }
 
@@ -94,7 +105,9 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     return (
       <RetroBoard
         name={room.name}
-        retro={retro}
+        retro={board.retro}
+        cards={cards}
+        writers={board.writers}
         users={offlineUsers}
         team={team}
         banner={
@@ -118,7 +131,8 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
     <AttendeeBoard
       roomId={roomId}
       roomData={roomData}
-      retro={retro}
+      board={board}
+      cards={cards}
       team={team}
       userId={membership!._id}
       myTeams={(myTeams ?? []) as MyTeam[]}
@@ -129,7 +143,8 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
 interface AttendeeBoardProps {
   roomId: Id<"rooms">;
   roomData: RoomWithRelatedData;
-  retro: Doc<"retros">;
+  board: BoardRead;
+  cards: BoardCard[];
   team?: RetroTeam;
   userId: Id<"users">;
   myTeams: MyTeam[];
@@ -137,18 +152,49 @@ interface AttendeeBoardProps {
 
 /**
  * The attendee's board: one presence subscription (heartbeat as this
- * member), the readiness write, and the stageFlow wiring. Its own component
- * so the presence hook — which has no skip — mounts only once a membership
- * exists; a Team reader never heartbeats.
+ * member), the presence payload writes (readiness, the editing indicator)
+ * through one global single-flight, the card writes, and the stageFlow
+ * wiring. Its own component so the presence hook — which has no skip —
+ * mounts only once a membership exists; a Team reader never heartbeats.
  */
-function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: AttendeeBoardProps) {
+function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams }: AttendeeBoardProps) {
+  const { retro } = board;
   const users = useRoomPresence(roomId, userId, roomData.users);
-  const setReadiness = useMutation(api.presence.setReadiness);
+  const setRetroPresence = useSingleFlightMutation(
+    useMutation(api.presence.setRetroPresence),
+    () => "presence"
+  );
   const advance = useMutation(api.retro.advance);
   const setCardsVisible = useMutation(api.retro.setCardsVisible);
   const setTimebox = useMutation(api.retro.setTimebox);
-  const { stageFlow, retroSettings } = useRetroPermissions(roomData, userId);
+  const { stageFlow, cardManagement, retroSettings } = useRetroPermissions(roomData, userId);
+  const cardActions = useCardActions(roomId, userId);
   const currentStageId = currentStageOf(retro).id;
+  // The payload is written whole, so an editing write carries readiness
+  // too: the viewer's last toggle for this entry, else what their presence
+  // row already says. An advance drops the local value with the entry.
+  const me = users.find((u) => u._id === userId);
+  const myPresence = me?.data;
+  const [toggled, setToggled] = useState<{ stageId: string; ready: boolean } | null>(null);
+  const writePresence = useCallback(
+    (patch: { ready?: boolean; editing?: string }) => {
+      const ready =
+        patch.ready ??
+        (toggled?.stageId === currentStageId ? toggled.ready : readinessOf(myPresence, currentStageId));
+      if (patch.ready !== undefined) setToggled({ stageId: currentStageId, ready: patch.ready });
+      void runAct(
+        setRetroPresence({
+          roomId,
+          userId,
+          stageId: currentStageId,
+          ready,
+          ...(patch.editing !== undefined ? { editing: patch.editing } : {}),
+        }),
+        STAGE_ACT_FAILED
+      );
+    },
+    [setRetroPresence, roomId, userId, currentStageId, toggled, myPresence]
+  );
 
   const controls = useMemo<StageControls>(
     () => ({
@@ -168,11 +214,14 @@ function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: Atten
   const viewer = useMemo<BoardViewer>(
     () => ({
       userId,
-      onSetReady: (ready) =>
-        void runAct(setReadiness({ roomId, userId, stageId: currentStageId, ready }), STAGE_ACT_FAILED),
+      name: me?.name ?? "",
+      onSetReady: (ready) => writePresence({ ready }),
+      onEditing: (clientId) => writePresence({ editing: clientId }),
       controls,
+      cards: cardActions,
+      cardManagement,
     }),
-    [userId, setReadiness, roomId, currentStageId, controls]
+    [userId, me?.name, writePresence, controls, cardActions, cardManagement]
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
@@ -180,6 +229,8 @@ function AttendeeBoard({ roomId, roomData, retro, team, userId, myTeams }: Atten
     <RetroBoard
       name={roomData.room.name}
       retro={retro}
+      cards={cards}
+      writers={board.writers}
       users={users}
       team={team}
       viewer={viewer}

--- a/src/components/retro/card-composer.test.tsx
+++ b/src/components/retro/card-composer.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * The composer (spec §8.1, §19, ADR-0012, ADR-0015): picks a prompt and
+ * shows its hint (the one place a hint appears), carries the attribution
+ * line and the hidden-or-visible line, and posts with the chosen prompt.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { CardComposer } from "./card-composer";
+import type { FormatPrompt } from "@/convex/model/retroFormats";
+
+afterEach(cleanup);
+
+const prompts: FormatPrompt[] = [
+  { id: "p1", label: "What went well?", hint: "Something worth keeping.", color: "green", order: 0 },
+  { id: "p2", label: "Ideas", color: "blue", order: 1 },
+];
+
+describe("CardComposer", () => {
+  it("shows the prompt's hint, the attribution line and the hidden line, and posts with the chosen prompt", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    const onOpenChange = vi.fn();
+    render(
+      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" hidden onSubmit={onSubmit} />
+    );
+    expect(screen.getByText("Posted as Sam. Your name stays with this card.")).toBeTruthy();
+    expect(screen.getByTestId("reveal-copy").textContent).toContain("Only you can read this for now");
+    expect(screen.getByTestId("prompt-hint").textContent).toBe("Something worth keeping.");
+
+    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "p2" } });
+    expect(screen.queryByTestId("prompt-hint")).toBeNull();
+    fireEvent.change(screen.getByLabelText("Your card"), { target: { value: "  try mob programming " } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Post card" }));
+    });
+    expect(onSubmit).toHaveBeenCalledWith("p2", "try mob programming");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("stays open with the text kept when the write is refused, and reads the visible line in a visible entry", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(false);
+    const onOpenChange = vi.fn();
+    render(
+      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" hidden={false} onSubmit={onSubmit} />
+    );
+    expect(screen.getByTestId("reveal-copy").textContent).toBe("Everyone in the retro can read this now.");
+    expect((screen.getByRole("button", { name: "Post card" }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Your card"), { target: { value: "draft" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Post card" }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect((screen.getByLabelText("Your card") as HTMLTextAreaElement).value).toBe("draft");
+  });
+});

--- a/src/components/retro/card-composer.tsx
+++ b/src/components/retro/card-composer.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { FormatPrompt } from "@/convex/model/retroFormats";
+import { MAX_CARD_TEXT } from "@/convex/model/retroCards";
+import {
+  COMPOSER_HIDDEN_NAMED,
+  COMPOSER_PROMPT_LABEL,
+  COMPOSER_SUBMIT,
+  COMPOSER_TEXT_LABEL,
+  COMPOSER_TEXT_PLACEHOLDER,
+  COMPOSER_TITLE,
+  COMPOSER_VISIBLE,
+  postedAs,
+} from "@/convex/retroCopy";
+
+interface CardComposerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  prompts: readonly FormatPrompt[];
+  /** The viewer's display name for the attribution line (ADR-0012, named). */
+  viewerName: string;
+  /** Whether the shared pointer's entry hides cards right now (ADR-0015). */
+  hidden: boolean;
+  /** Resolves to whether the card was written; the dialog closes on success. */
+  onSubmit: (promptId: string, text: string) => Promise<boolean>;
+}
+
+/**
+ * The composer (spec §8.1, §19): pick a prompt and read its hint — the one
+ * place a hint shows, never on a card or a zone (§6.2) — write, and post.
+ * Above the button, the write-time copy: who the card is posted as, and
+ * who can read it now.
+ */
+export function CardComposer({ open, onOpenChange, prompts, viewerName, hidden, onSubmit }: CardComposerProps) {
+  const ordered = [...prompts].sort((a, b) => a.order - b.order);
+  const [promptId, setPromptId] = useState(ordered[0]?.id ?? "");
+  const [text, setText] = useState("");
+  const [posting, setPosting] = useState(false);
+  // A prompt removed under the composer falls back to the first.
+  const prompt = ordered.find((p) => p.id === promptId) ?? ordered[0];
+
+  const post = async () => {
+    if (!prompt || !text.trim() || posting) return;
+    setPosting(true);
+    const written = await onSubmit(prompt.id, text.trim());
+    setPosting(false);
+    if (written) {
+      setText("");
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="card-composer">
+        <DialogHeader>
+          <DialogTitle>{COMPOSER_TITLE}</DialogTitle>
+          <DialogDescription>{postedAs(viewerName)}</DialogDescription>
+        </DialogHeader>
+        <form
+          className="grid gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void post();
+          }}
+        >
+          <div className="grid gap-1.5">
+            <Label htmlFor="composer-prompt">{COMPOSER_PROMPT_LABEL}</Label>
+            <select
+              id="composer-prompt"
+              value={prompt?.id ?? ""}
+              onChange={(e) => setPromptId(e.target.value)}
+              className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+            >
+              {ordered.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+            {prompt?.hint && (
+              <p data-testid="prompt-hint" className="text-xs text-muted-foreground">
+                {prompt.hint}
+              </p>
+            )}
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="composer-text">{COMPOSER_TEXT_LABEL}</Label>
+            <Textarea
+              id="composer-text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder={COMPOSER_TEXT_PLACEHOLDER}
+              maxLength={MAX_CARD_TEXT}
+              rows={4}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  void post();
+                }
+              }}
+            />
+          </div>
+          <p data-testid="reveal-copy" data-hidden={String(hidden)} className="text-xs text-muted-foreground">
+            {hidden ? COMPOSER_HIDDEN_NAMED : COMPOSER_VISIBLE}
+          </p>
+          <DialogFooter>
+            <Button type="submit" disabled={!text.trim() || posting}>
+              {COMPOSER_SUBMIT}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/retro/card-node.test.tsx
+++ b/src/components/retro/card-node.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * A card node (spec §10.9, ADR-0015, ADR-0022): the data attributes the
+ * tests read, a silhouette when the viewer has no text, the author chip in
+ * a named retro, and the "Unsaved" state that keeps a failed draft.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
+import { CardNodeView, type CardNode } from "./card-node";
+import type { BoardCard } from "./cards";
+import type { Id } from "@/convex/_generated/dataModel";
+
+afterEach(cleanup);
+
+const base: BoardCard = {
+  _id: "id-a" as Id<"retroCards">,
+  clientId: "a",
+  promptId: "p1",
+  position: { x: 0, y: 0 },
+  hidden: false,
+  text: "keep the demo",
+  authorId: "u1" as Id<"users">,
+  own: true,
+};
+
+function renderCard(data: CardNode["data"], selected = false) {
+  const props = { id: data.card.clientId, data, selected } as unknown as NodeProps<CardNode>;
+  return render(<CardNodeView {...props} />);
+}
+
+describe("CardNodeView", () => {
+  it("carries the canvas contract's attributes and the author chip", () => {
+    renderCard({ card: base, color: "green", authorName: "Ada", editable: false });
+    const root = document.querySelector("[data-card-id='a']")!;
+    expect(root.getAttribute("data-hidden")).toBe("false");
+    expect(root.getAttribute("data-cluster-id")).toBe("");
+    expect(root.getAttribute("data-late")).toBe("false");
+    expect(screen.getByText("keep the demo")).toBeTruthy();
+    expect(screen.getByTestId("author-chip").textContent).toBe("Ada");
+    expect(screen.queryByLabelText("Card text")).toBeNull();
+  });
+
+  it("a silhouette shows no text and no author, and data-hidden is true", () => {
+    renderCard({ card: { ...base, hidden: true, text: undefined, authorId: undefined, own: false }, color: "green", editable: false });
+    const root = document.querySelector("[data-card-id='a']")!;
+    expect(root.getAttribute("data-hidden")).toBe("true");
+    expect(screen.getByRole("img", { name: "Hidden card" })).toBeTruthy();
+    expect(root.textContent).toBe("");
+  });
+
+  it("an editable card keeps a failed draft with the Unsaved chip and reports the editing indicator", async () => {
+    const onEditText = vi.fn().mockRejectedValueOnce(new Error("network")).mockResolvedValue(undefined);
+    const onEditing = vi.fn();
+    const onDelete = vi.fn();
+    renderCard({ card: base, color: "green", authorName: "Ada", editable: true, onEditText, onEditing, onDelete });
+    const field = screen.getByLabelText("Card text") as HTMLTextAreaElement;
+    fireEvent.focus(field);
+    expect(onEditing).toHaveBeenLastCalledWith("a");
+    fireEvent.change(field, { target: { value: "keep the demo!" } });
+    await act(async () => {
+      fireEvent.blur(field);
+    });
+    expect(onEditText).toHaveBeenCalledWith("a", "keep the demo!");
+    expect(onEditing).toHaveBeenLastCalledWith(undefined);
+    expect(field.value).toBe("keep the demo!");
+    expect(screen.getByTestId("unsaved-chip").textContent).toBe("Unsaved");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete card" }));
+    expect(onDelete).toHaveBeenCalledWith("a");
+  });
+
+  it("shows who else is editing", () => {
+    renderCard({ card: { ...base, own: false }, color: "green", authorName: "Ada", editingBy: "Ben", editable: false });
+    expect(screen.getByTestId("editing-chip").textContent).toContain("Ben");
+  });
+});

--- a/src/components/retro/card-node.tsx
+++ b/src/components/retro/card-node.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { memo } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
+import { Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  CARD_TEXT_FIELD,
+  DELETE_CARD,
+  EDITING_CHIP,
+  HIDDEN_CARD_LABEL,
+  UNSAVED_CHIP,
+} from "@/convex/retroCopy";
+import { tintClasses } from "./tints";
+import { CARD_WIDTH, type BoardCard } from "./cards";
+import { useCardDraft } from "./use-card-draft";
+
+// A type alias: React Flow node data must satisfy Record<string, unknown>.
+export type CardNodeData = {
+  card: BoardCard;
+  /** The prompt's tint. */
+  color: string;
+  /** The author's current display name in a named retro; "Former member" when gone. */
+  authorName?: string;
+  /** Who else is typing into this card, by name. */
+  editingBy?: string;
+  /** Own card, or another's under `cardManagement`. */
+  editable: boolean;
+  onEditText?: (clientId: string, text: string) => Promise<void>;
+  onDelete?: (clientId: string) => void;
+  /** The editing indicator: the card focused, or none. */
+  onEditing?: (clientId: string | undefined) => void;
+};
+
+export type CardNode = Node<CardNodeData, "card">;
+
+/**
+ * A card on the board (ADR-0011 at the detail level, ADR-0015, spec §10.9):
+ * text, tint and author chip, or a tint-only silhouette when the viewer has
+ * no text for it. Its data attributes are the canvas contract the tests
+ * read; `data-cluster-id` and `data-late` are placeholders until #293 and
+ * #295.
+ */
+export const CardNodeView = memo(function CardNodeView({ data, selected }: NodeProps<CardNode>) {
+  const { card, color, authorName, editingBy, editable } = data;
+  const tint = tintClasses(color);
+  return (
+    <div
+      data-card-id={card.clientId}
+      data-hidden={String(card.hidden)}
+      data-cluster-id={card.clusterId ?? ""}
+      data-late="false"
+      className={cn(
+        "flex flex-col gap-2 rounded-xl border p-3 text-sm shadow-sm",
+        tint.zone,
+        "bg-white/90 dark:bg-surface-2/90",
+        selected && "ring-2 ring-ring"
+      )}
+      style={{ width: CARD_WIDTH }}
+    >
+      {card.hidden ? (
+        <div
+          role="img"
+          aria-label={HIDDEN_CARD_LABEL}
+          className={cn("h-14 rounded-md opacity-60", tint.zone)}
+        />
+      ) : editable && data.onEditText ? (
+        <CardEditor
+          clientId={card.clientId}
+          text={card.text ?? ""}
+          onSave={data.onEditText}
+          onEditing={data.onEditing}
+        />
+      ) : (
+        <p className="whitespace-pre-wrap break-words">{card.text}</p>
+      )}
+      <div className="flex min-h-5 items-center gap-2 text-xs text-muted-foreground">
+        {authorName && (
+          <span data-testid="author-chip" className={cn("truncate font-medium", tint.label)}>
+            {authorName}
+          </span>
+        )}
+        {editingBy && (
+          <span data-testid="editing-chip" className="truncate italic">
+            {EDITING_CHIP} · {editingBy}
+          </span>
+        )}
+        {editable && data.onDelete && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={DELETE_CARD}
+            className="nodrag ml-auto"
+            onClick={() => data.onDelete?.(card.clientId)}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+});
+
+interface CardEditorProps {
+  clientId: string;
+  text: string;
+  onSave: (clientId: string, text: string) => Promise<void>;
+  onEditing?: (clientId: string | undefined) => void;
+}
+
+/** The editable text: the draft hook owns the debounce, the flush and the "Unsaved" state. */
+function CardEditor({ clientId, text, onSave, onEditing }: CardEditorProps) {
+  const draft = useCardDraft({ serverText: text, onSave: (value) => onSave(clientId, value) });
+  return (
+    <div className="flex flex-col gap-1">
+      <Textarea
+        aria-label={CARD_TEXT_FIELD}
+        value={draft.text}
+        onChange={(e) => draft.onChange(e.target.value)}
+        onFocus={() => {
+          draft.onFocus();
+          onEditing?.(clientId);
+        }}
+        onBlur={() => {
+          draft.onBlur();
+          onEditing?.(undefined);
+        }}
+        rows={3}
+        className="nodrag nowheel min-h-0 resize-none border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+      />
+      {draft.unsaved && (
+        <span
+          data-testid="unsaved-chip"
+          className="self-start rounded-full bg-amber-50 px-2 py-0.5 text-xs text-amber-700 dark:bg-status-warning-bg dark:text-status-warning-fg"
+        >
+          {UNSAVED_CHIP}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/retro/cards.test.ts
+++ b/src/components/retro/cards.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The board and mine merge (spec §9, §10.9): `retro.board` carries every
+ * card as a silhouette or in full, `retro.mine` carries the viewer's own in
+ * full; the client merges them, and `hidden` is true iff the viewer has no
+ * text for the card after the merge.
+ */
+import { describe, it, expect } from "vitest";
+import { mergeCards, placeNewCard } from "./cards";
+import type { ProjectedCard, FullCard } from "@/convex/model/retro";
+import type { Id } from "@/convex/_generated/dataModel";
+
+const me = "u-me" as Id<"users">;
+const other = "u-other" as Id<"users">;
+const pos = { x: 1, y: 2 };
+
+const silhouette = (clientId: string): ProjectedCard =>
+  ({ _id: `id-${clientId}` as Id<"retroCards">, clientId, position: pos, promptId: "p1" });
+const full = (clientId: string, authorId: Id<"users">, text = clientId): FullCard => ({
+  ...silhouette(clientId),
+  text,
+  authorId,
+  createdAt: 1,
+  updatedAt: 1,
+  committedAt: 1,
+});
+
+describe("mergeCards", () => {
+  it("in a hidden entry: own silhouettes take their text from mine, others stay hidden", () => {
+    const merged = mergeCards([silhouette("a"), silhouette("b")], [full("a", me, "my text")], me);
+    expect(merged.map((c) => [c.clientId, c.hidden, c.text, c.own])).toEqual([
+      ["a", false, "my text", true],
+      ["b", true, undefined, false],
+    ]);
+  });
+
+  it("in a visible entry: every card is readable and own is by author", () => {
+    const merged = mergeCards([full("a", me), full("b", other)], [full("a", me)], me);
+    expect(merged.map((c) => [c.clientId, c.hidden, c.own, c.authorId])).toEqual([
+      ["a", false, true, me],
+      ["b", false, false, other],
+    ]);
+  });
+
+  it("keeps the board's order and position, and tolerates mine still loading", () => {
+    const moved = { ...silhouette("a"), position: { x: 50, y: 60 } };
+    const merged = mergeCards([silhouette("b"), moved], undefined, me);
+    expect(merged.map((c) => c.clientId)).toEqual(["b", "a"]);
+    expect(merged[1].position).toEqual({ x: 50, y: 60 });
+    expect(merged[1].hidden).toBe(true);
+  });
+});
+
+describe("placeNewCard", () => {
+  it("lands inside the prompt's zone and staggers by how many cards it already holds", () => {
+    const zone = { x: 100, y: 200, width: 480, height: 640 };
+    const first = placeNewCard(zone, 0);
+    const second = placeNewCard(zone, 1);
+    for (const p of [first, second, placeNewCard(zone, 7)]) {
+      expect(p.x).toBeGreaterThanOrEqual(zone.x);
+      expect(p.x).toBeLessThan(zone.x + zone.width);
+      expect(p.y).toBeGreaterThanOrEqual(zone.y);
+      expect(p.y).toBeLessThan(zone.y + zone.height);
+    }
+    expect(first).not.toEqual(second);
+  });
+});

--- a/src/components/retro/cards.ts
+++ b/src/components/retro/cards.ts
@@ -1,0 +1,79 @@
+import type { Id } from "@/convex/_generated/dataModel";
+import type { FullCard, ProjectedCard } from "@/convex/model/retro";
+
+/**
+ * A card as the board renders it, after the `retro.board` and `retro.mine`
+ * merge (spec §9, §10.9). `hidden` is true iff the viewer has no text for
+ * the card after the merge — a silhouette the viewer did not write.
+ */
+export interface BoardCard {
+  _id: Id<"retroCards">;
+  clientId: string;
+  promptId: string;
+  position: { x: number; y: number };
+  clusterId?: Id<"retroClusters">;
+  hidden: boolean;
+  text?: string;
+  authorId?: Id<"users">;
+  /** The viewer wrote it: full text in `mine`, or the author in a visible entry. */
+  own: boolean;
+}
+
+function isFull(card: ProjectedCard): card is FullCard {
+  return "text" in card;
+}
+
+/**
+ * The merge: the board's order and positions, the viewer's own text from
+ * `mine` where the board carries a silhouette. `mine` may still be loading.
+ */
+export function mergeCards(
+  boardCards: readonly ProjectedCard[],
+  mine: readonly FullCard[] | undefined,
+  viewerId: Id<"users"> | undefined
+): BoardCard[] {
+  const own = new Map((mine ?? []).map((card) => [card.clientId, card]));
+  return boardCards.map((card) => {
+    const base = {
+      _id: card._id,
+      clientId: card.clientId,
+      promptId: card.promptId,
+      position: card.position,
+      ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
+    };
+    const full = isFull(card) ? card : own.get(card.clientId);
+    if (!full) {
+      return { ...base, hidden: true, own: false };
+    }
+    return {
+      ...base,
+      hidden: false,
+      text: full.text,
+      ...(full.authorId !== undefined ? { authorId: full.authorId } : {}),
+      own: own.has(card.clientId) || (full.authorId !== undefined && full.authorId === viewerId),
+    };
+  });
+}
+
+export const CARD_WIDTH = 200;
+export const CARD_MIN_HEIGHT = 96;
+
+/**
+ * Where a new card lands: inside its prompt's zone, staggered by how many
+ * cards the zone already holds so a burst of writing does not stack. The
+ * stored prompt is the composer's choice; the position is only a start.
+ */
+export function placeNewCard(
+  zone: { x: number; y: number; width: number; height: number },
+  existingCount: number
+): { x: number; y: number } {
+  const pad = 24;
+  const columns = Math.max(1, Math.floor((zone.width - pad) / (CARD_WIDTH + pad)));
+  const rows = Math.max(1, Math.floor((zone.height - 64) / (CARD_MIN_HEIGHT + pad)));
+  const slot = existingCount % (columns * rows);
+  const cycle = Math.floor(existingCount / (columns * rows));
+  return {
+    x: zone.x + pad + (slot % columns) * (CARD_WIDTH + pad) + cycle * 12,
+    y: zone.y + 64 + Math.floor(slot / columns) * (CARD_MIN_HEIGHT + pad) + cycle * 12,
+  };
+}

--- a/src/components/retro/optimistic.test.ts
+++ b/src/components/retro/optimistic.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Optimistic functions (ADR-0022, spec §10.7): one synchronous pure function
+ * per optimistic mutation, patching exactly the named queries through
+ * `getAllQueries` and leaving every other cached query untouched. A create
+ * in `collect` inserts a silhouette into `retro.board` and full text into
+ * `retro.mine`; a text edit in `collect` never touches `retro.board`.
+ */
+import { describe, it, expect } from "vitest";
+import type { OptimisticLocalStore } from "convex/browser";
+import { getFunctionName, type FunctionReference } from "convex/server";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { BoardRead, FullCard } from "@/convex/model/retro";
+import { applyCreate, applyDelete, applyMove, applyTextEdit } from "./optimistic";
+
+const roomId = "room-1" as Id<"rooms">;
+const me = "u-me" as Id<"users">;
+const other = "u-other" as Id<"users">;
+
+/** A fake local store: values keyed by query name, one instance per args. */
+function fakeStore(initial: Record<string, unknown>) {
+  const values = new Map(Object.entries(initial));
+  const writes: string[] = [];
+  const nameOf = (ref: FunctionReference<"query">) => getFunctionName(ref).split(/[:.]/).pop()!;
+  const store = {
+    getQuery: (ref: FunctionReference<"query">) => values.get(nameOf(ref)),
+    getAllQueries: (ref: FunctionReference<"query">) => {
+      const value = values.get(nameOf(ref));
+      return value === undefined ? [] : [{ args: { roomId }, value }];
+    },
+    setQuery: (ref: FunctionReference<"query">, _args: unknown, value: unknown) => {
+      writes.push(nameOf(ref));
+      values.set(nameOf(ref), value);
+    },
+  } as unknown as OptimisticLocalStore;
+  return { store, writes, value: <T>(name: string) => values.get(name) as T };
+}
+
+function board(cardsVisible: "hidden" | "visible", cards: BoardRead["cards"] = []): BoardRead {
+  return {
+    retro: {
+      currentStageId: "s1",
+      stages: [{ id: "s1", kind: "collect", cardsVisible, tallyVisible: "visible" }],
+      attribution: "named",
+    } as unknown as BoardRead["retro"],
+    clusters: [],
+    cards,
+    writers: [],
+  };
+}
+
+const full = (clientId: string, authorId: Id<"users">, text = clientId): FullCard => ({
+  _id: `id-${clientId}` as Id<"retroCards">,
+  clientId,
+  position: { x: 0, y: 0 },
+  promptId: "p1",
+  text,
+  authorId,
+  createdAt: 1,
+  updatedAt: 1,
+  committedAt: 1,
+});
+
+// `api.retro.board` names "retro:board"; the fake keys on the last segment.
+const BOARD = getFunctionName(api.retro.board).split(/[:.]/).pop()!;
+const MINE = getFunctionName(api.retro.mine).split(/[:.]/).pop()!;
+
+describe("applyCreate", () => {
+  it("in collect inserts a silhouette into board, the full card into mine, and names the writer", () => {
+    const { store, writes, value } = fakeStore({ [BOARD]: board("hidden"), [MINE]: [], tally: {} });
+    applyCreate(store, { roomId, clientId: "c1", text: "hi", promptId: "p1", position: { x: 3, y: 4 } }, { userId: me, now: 9 });
+
+    expect(writes.sort()).toEqual([BOARD, MINE].sort());
+    const [card] = value<BoardRead>(BOARD).cards;
+    expect(card).toEqual({ _id: expect.any(String), clientId: "c1", position: { x: 3, y: 4 }, promptId: "p1" });
+    expect(value<BoardRead>(BOARD).writers).toEqual([me]);
+    expect(value<FullCard[]>(MINE)[0]).toMatchObject({ clientId: "c1", text: "hi", authorId: me, createdAt: 9 });
+    expect(value("tally")).toEqual({});
+  });
+
+  it("in a visible entry inserts the full card into board", () => {
+    const { store, value } = fakeStore({ [BOARD]: board("visible"), [MINE]: [] });
+    applyCreate(store, { roomId, clientId: "c1", text: "hi", promptId: "p1", position: { x: 3, y: 4 } }, { userId: me, now: 9 });
+    expect(value<BoardRead>(BOARD).cards[0]).toMatchObject({ clientId: "c1", text: "hi", authorId: me });
+  });
+
+  it("does nothing to a query that is not cached", () => {
+    const { store, writes } = fakeStore({});
+    applyCreate(store, { roomId, clientId: "c1", text: "hi", promptId: "p1", position: { x: 3, y: 4 } }, { userId: me, now: 9 });
+    expect(writes).toEqual([]);
+  });
+});
+
+describe("applyMove", () => {
+  it("patches positions in board only, by clientId, and touches nothing else", () => {
+    const { store, writes, value } = fakeStore({
+      [BOARD]: board("visible", [full("a", me), full("b", other)]),
+      [MINE]: [full("a", me)],
+      tally: {},
+    });
+    applyMove(store, { roomId, moves: [{ clientId: "a", position: { x: 7, y: 8 } }, { clientId: "zz", position: { x: 1, y: 1 } }] });
+    expect(writes).toEqual([BOARD]);
+    expect(value<BoardRead>(BOARD).cards.map((c) => c.position)).toEqual([{ x: 7, y: 8 }, { x: 0, y: 0 }]);
+  });
+});
+
+describe("applyTextEdit", () => {
+  it("in collect patches mine and never touches board", () => {
+    const silhouette = { _id: "id-a" as Id<"retroCards">, clientId: "a", position: { x: 0, y: 0 }, promptId: "p1" };
+    const { store, writes, value } = fakeStore({ [BOARD]: board("hidden", [silhouette]), [MINE]: [full("a", me)] });
+    applyTextEdit(store, { roomId, clientId: "a", text: "new" });
+    expect(writes).toEqual([MINE]);
+    expect(value<FullCard[]>(MINE)[0].text).toBe("new");
+    expect(value<BoardRead>(BOARD).cards[0]).toEqual(silhouette);
+  });
+
+  it("in a visible entry patches both", () => {
+    const { store, writes, value } = fakeStore({ [BOARD]: board("visible", [full("a", me)]), [MINE]: [full("a", me)] });
+    applyTextEdit(store, { roomId, clientId: "a", text: "new" });
+    expect(writes.sort()).toEqual([BOARD, MINE].sort());
+    expect((value<BoardRead>(BOARD).cards[0] as FullCard).text).toBe("new");
+  });
+});
+
+describe("applyDelete", () => {
+  it("removes the card from board and mine", () => {
+    const { store, value } = fakeStore({ [BOARD]: board("visible", [full("a", me), full("b", other)]), [MINE]: [full("a", me)] });
+    applyDelete(store, { roomId, clientId: "a" });
+    expect(value<BoardRead>(BOARD).cards.map((c) => c.clientId)).toEqual(["b"]);
+    expect(value<FullCard[]>(MINE)).toEqual([]);
+  });
+});

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -1,0 +1,118 @@
+import type { OptimisticLocalStore } from "convex/browser";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { BoardRead, FullCard, ProjectedCard } from "@/convex/model/retro";
+import { currentStageOf } from "@/convex/model/retroFormats";
+
+/**
+ * Optimistic functions (ADR-0022, spec §10.7): one synchronous pure
+ * function per optimistic card mutation, patching every cached instance of
+ * the named query through `getAllQueries`, so argument variance never
+ * matters. A move patches `retro.board` and `retro.mine`; a create inserts
+ * into both (a silhouette or the full card by the current entry's reveal);
+ * a text edit patches `retro.mine` and `retro.board` only where the board
+ * already carries the text; a delete removes from both.
+ */
+
+export interface CreateCardArgs {
+  roomId: Id<"rooms">;
+  clientId: string;
+  text: string;
+  promptId: string;
+  position: { x: number; y: number };
+}
+
+export interface MoveCardsArgs {
+  roomId: Id<"rooms">;
+  moves: { clientId: string; position: { x: number; y: number } }[];
+}
+
+export interface UpdateCardArgs {
+  roomId: Id<"rooms">;
+  clientId: string;
+  text: string;
+}
+
+export interface DeleteCardArgs {
+  roomId: Id<"rooms">;
+  clientId: string;
+}
+
+function patchBoard(store: OptimisticLocalStore, patch: (board: BoardRead) => BoardRead): void {
+  for (const { args, value } of store.getAllQueries(api.retro.board)) {
+    if (value === undefined) continue;
+    store.setQuery(api.retro.board, args, patch(value));
+  }
+}
+
+function patchMine(store: OptimisticLocalStore, patch: (mine: FullCard[]) => FullCard[]): void {
+  for (const { args, value } of store.getAllQueries(api.retro.mine)) {
+    if (value === undefined) continue;
+    store.setQuery(api.retro.mine, args, patch(value));
+  }
+}
+
+/** A create: the row as the server will write it, with a placeholder id until the result lands. */
+export function applyCreate(
+  store: OptimisticLocalStore,
+  args: CreateCardArgs,
+  viewer: { userId: Id<"users">; now?: number }
+): void {
+  const now = viewer.now ?? Date.now();
+  const full: FullCard = {
+    _id: `optimistic-${args.clientId}` as Id<"retroCards">,
+    clientId: args.clientId,
+    position: args.position,
+    promptId: args.promptId,
+    text: args.text,
+    authorId: viewer.userId,
+    createdAt: now,
+    updatedAt: now,
+    committedAt: now,
+  };
+  patchBoard(store, (board) => {
+    if (board.cards.some((card) => card.clientId === args.clientId)) return board;
+    const hidden = currentStageOf(board.retro).cardsVisible === "hidden";
+    const card: ProjectedCard = hidden
+      ? { _id: full._id, clientId: full.clientId, position: full.position, promptId: full.promptId }
+      : full;
+    const writers = board.writers.includes(viewer.userId)
+      ? board.writers
+      : [...board.writers, viewer.userId];
+    return { ...board, cards: [...board.cards, card], writers };
+  });
+  patchMine(store, (mine) =>
+    mine.some((card) => card.clientId === args.clientId) ? mine : [...mine, full]
+  );
+}
+
+export function applyMove(store: OptimisticLocalStore, args: MoveCardsArgs): void {
+  const target = new Map(args.moves.map((move) => [move.clientId, move.position]));
+  const move = <C extends ProjectedCard>(card: C): C => {
+    const position = target.get(card.clientId);
+    return position ? { ...card, position } : card;
+  };
+  patchBoard(store, (board) => ({ ...board, cards: board.cards.map(move) }));
+}
+
+export function applyTextEdit(store: OptimisticLocalStore, args: UpdateCardArgs): void {
+  patchMine(store, (mine) =>
+    mine.map((card) => (card.clientId === args.clientId ? { ...card, text: args.text } : card))
+  );
+  for (const { args: queryArgs, value } of store.getAllQueries(api.retro.board)) {
+    if (value === undefined) continue;
+    const index = value.cards.findIndex((card) => card.clientId === args.clientId);
+    if (index === -1 || !("text" in value.cards[index])) continue;
+    const cards = value.cards.slice();
+    cards[index] = { ...value.cards[index], text: args.text };
+    store.setQuery(api.retro.board, queryArgs, { ...value, cards });
+  }
+}
+
+export function applyDelete(store: OptimisticLocalStore, args: DeleteCardArgs): void {
+  patchBoard(store, (board) => ({
+    ...board,
+    cards: board.cards.filter((card) => card.clientId !== args.clientId),
+  }));
+  patchMine(store, (mine) => mine.filter((card) => card.clientId !== args.clientId));
+}

--- a/src/components/retro/readiness.ts
+++ b/src/components/retro/readiness.ts
@@ -11,6 +11,15 @@ import { orderUsersByPresence, type UserWithPresence } from "@/hooks/useRoomPres
 export interface ReadinessPayload {
   stageId: string;
   ready: boolean;
+  /** The `clientId` of the card the person is typing into (ADR-0022). */
+  editing?: string;
+}
+
+/** The card a person is editing, from their payload; undefined when none. */
+export function editingOf(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const editing = (data as { editing?: unknown }).editing;
+  return typeof editing === "string" ? editing : undefined;
 }
 
 function isReadinessPayload(data: unknown): data is ReadinessPayload {

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -1,33 +1,51 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { ReactFlow, ReactFlowProvider, type NodeTypes } from "@xyflow/react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { ReactFlow, ReactFlowProvider, type Node, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Users } from "lucide-react";
+import { Plus, Users } from "lucide-react";
 import type { Doc } from "@/convex/_generated/dataModel";
+import type { ResolvedDecision } from "@/convex/permissions";
 import type { UserWithPresence } from "@/hooks/useRoomPresence";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
 import { Button } from "@/components/ui/button";
-import { ROSTER_TITLE } from "@/convex/retroCopy";
+import { ADD_CARD, FORMER_MEMBER, ROSTER_TITLE } from "@/convex/retroCopy";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
 import { layoutZones } from "./zones";
 import { StageNav, type StageControls } from "./stage-nav";
-import { StageEmptyState } from "./stage-empty-state";
+import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
+import { CardNodeView, type CardNode } from "./card-node";
+import { CardComposer } from "./card-composer";
+import { placeNewCard, type BoardCard } from "./cards";
+import { useHand } from "./use-hand";
+import { editingOf } from "./readiness";
+import type { CardActions } from "./use-card-actions";
 
 /** What an attendee brings to the board that a Team reader does not. */
 export interface BoardViewer {
   userId: string;
+  /** The viewer's display name, for the composer's attribution line. */
+  name: string;
   onSetReady: (ready: boolean) => void;
+  /** The editing indicator: one presence write per state change (ADR-0022). */
+  onEditing: (clientId: string | undefined) => void;
   controls: StageControls;
+  cards: CardActions;
+  /** Another person's card is touchable only under this decision (spec §4.2). */
+  cardManagement: ResolvedDecision;
 }
 
 interface RetroBoardProps {
   /** The room shell's name; the board reads nothing else from it. */
   name: string;
   retro: Doc<"retros">;
+  /** Every card after the board and mine merge (spec §9). */
+  cards: readonly BoardCard[];
+  /** Who has written, in a named retro (ADR-0012); empty under `anonymous`. */
+  writers: readonly string[];
   /** The roster's members with presence merged on; a Team reader sees everyone offline. */
   users: readonly UserWithPresence[];
   /** The Team that keeps the retro (ADR-0008); undefined for a teamless one. */
@@ -41,24 +59,38 @@ interface RetroBoardProps {
 }
 
 // Outside the component so React Flow sees one stable object.
-const nodeTypes: NodeTypes = { zone: PromptZoneNodeView };
+const nodeTypes: NodeTypes = { zone: PromptZoneNodeView, card: CardNodeView };
+
+const noMoves = () => {};
 
 /**
- * The retro board shell (ADR-0011, spec §10.1): its own React Flow
+ * The retro board (ADR-0011, ADR-0022, spec §10): its own React Flow
  * integration, sharing tokens and shadcn components with the poker room and
  * no canvas code. No translateExtent (no cage), pan on the primary button
- * and trackpad, only visible elements rendered. The prompt soft zones are
- * drawn from the stamped format; cards, clusters and the hand arrive with
- * their tickets.
+ * and trackpad, marquee selection, only visible elements rendered. Nodes
+ * are derived by memo from the query values; the only local canvas state
+ * is the hand (the override map) and the selection.
  *
  * The root shows the shared stage (`data-stage`); the viewer's own view may
- * sit on another entry (`data-view-stage`) without moving anyone (ADR-0010).
+ * sit on another entry (`data-view-stage`) without moving anyone
+ * (ADR-0010). `data-zoom-level` is fixed to `detail` until #293.
  */
-export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: RetroBoardProps) {
+export function RetroBoard({
+  name,
+  retro,
+  cards,
+  writers,
+  users,
+  team,
+  viewer,
+  menu,
+  banner,
+}: RetroBoardProps) {
   const currentStage = currentStageOf(retro);
   /** The viewer's own view; null follows the shared pointer. */
   const [viewStageId, setViewStageId] = useState<string | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
+  const [composing, setComposing] = useState(false);
   const viewStage = retro.stages.find((stage) => stage.id === viewStageId) ?? currentStage;
 
   // The page is titled by the retro's name (spec §18.1). Set here rather than
@@ -68,9 +100,11 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
     document.title = `${name} | AgileKit`;
   }, [name]);
 
-  const nodes = useMemo<PromptZoneNode[]>(
+  const zones = useMemo(() => layoutZones(retro.format.prompts), [retro.format.prompts]);
+
+  const zoneNodes = useMemo<PromptZoneNode[]>(
     () =>
-      layoutZones(retro.format.prompts).map((zone) => ({
+      zones.map((zone) => ({
         id: `zone-${zone.promptId}`,
         type: "zone",
         position: { x: zone.x, y: zone.y },
@@ -80,10 +114,74 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
         focusable: false,
         zIndex: -1,
       })),
+    [zones]
+  );
+
+  const hand = useHand({ cards, onDrop: viewer?.cards.move ?? noMoves });
+
+  const namesById = useMemo(() => new Map(users.map((user) => [user._id as string, user.name])), [users]);
+  const tintByPrompt = useMemo(
+    () => new Map(retro.format.prompts.map((prompt) => [prompt.id, prompt.color])),
     [retro.format.prompts]
+  );
+  /** Who else is typing into which card, from the presence payloads. */
+  const editingBy = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const user of users) {
+      const clientId = editingOf(user.data);
+      if (clientId && user._id !== viewer?.userId) map.set(clientId, user.name);
+    }
+    return map;
+  }, [users, viewer?.userId]);
+
+  const named = retro.attribution === "named";
+  const cardNodes = useMemo<CardNode[]>(
+    () =>
+      cards.map((card) => {
+        const editable = viewer !== undefined && (card.own || viewer.cardManagement.allowed);
+        return {
+          id: card.clientId,
+          type: "card",
+          position: hand.positions.get(card.clientId) ?? card.position,
+          ...(hand.measured.has(card.clientId) ? { measured: hand.measured.get(card.clientId) } : {}),
+          selected: hand.selected.has(card.clientId),
+          draggable: editable,
+          data: {
+            card,
+            color: tintByPrompt.get(card.promptId) ?? "",
+            ...(named && card.authorId !== undefined
+              ? { authorName: namesById.get(card.authorId) ?? FORMER_MEMBER }
+              : {}),
+            ...(editingBy.has(card.clientId) ? { editingBy: editingBy.get(card.clientId) } : {}),
+            editable,
+            ...(viewer && editable
+              ? { onEditText: viewer.cards.editText, onDelete: viewer.cards.remove, onEditing: viewer.onEditing }
+              : {}),
+          },
+        };
+      }),
+    [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy]
+  );
+
+  const nodes = useMemo<Node[]>(() => [...zoneNodes, ...cardNodes], [zoneNodes, cardNodes]);
+
+  const onSubmitCard = useCallback(
+    async (promptId: string, text: string) => {
+      if (!viewer) return false;
+      const zone = zones.find((z) => z.promptId === promptId) ?? zones[0];
+      const inZone = cards.filter((card) => card.promptId === promptId).length;
+      return viewer.cards.create({
+        clientId: crypto.randomUUID(),
+        text,
+        promptId,
+        position: placeNewCard(zone, inZone),
+      });
+    },
+    [viewer, zones, cards]
   );
 
   const onlineCount = viewer ? users.filter((user) => user.isOnline).length : undefined;
+  const writerSet = useMemo(() => (named ? new Set(writers) : undefined), [named, writers]);
 
   return (
     <div
@@ -91,6 +189,7 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
       data-testid="retro-board"
       data-stage={currentStage.kind}
       data-view-stage={viewStage.kind}
+      data-zoom-level="detail"
     >
       <RetroHeader
         name={name}
@@ -126,11 +225,13 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
       />
       <div className="relative flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1">
-          <StageEmptyState kind={viewStage.kind} />
+          {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
           <ReactFlowProvider>
             <ReactFlow
               nodes={nodes}
               nodeTypes={nodeTypes}
+              onNodesChange={hand.onNodesChange}
+              onNodeDragStop={hand.onNodeDragStop}
               fitView
               fitViewOptions={{ padding: 0.1, maxZoom: 1 }}
               proOptions={{ hideAttribution: true }}
@@ -146,6 +247,16 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
               <CanvasDotsBackground />
             </ReactFlow>
           </ReactFlowProvider>
+          {viewer && (
+            <Button
+              type="button"
+              className="absolute right-4 bottom-4 shadow-lg"
+              onClick={() => setComposing(true)}
+            >
+              <Plus className="size-4" />
+              {ADD_CARD}
+            </Button>
+          )}
         </div>
         {rosterOpen && (
           <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">
@@ -154,10 +265,22 @@ export function RetroBoard({ name, retro, users, team, viewer, menu, banner }: R
               currentStage={currentStage}
               myUserId={viewer?.userId}
               onSetReady={viewer?.onSetReady}
+              writers={writerSet}
+              cardCount={cards.length}
             />
           </aside>
         )}
       </div>
+      {viewer && (
+        <CardComposer
+          open={composing}
+          onOpenChange={setComposing}
+          prompts={retro.format.prompts}
+          viewerName={viewer.name}
+          hidden={currentStage.cardsVisible === "hidden"}
+          onSubmit={onSubmitCard}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/retro/retro-roster.test.tsx
+++ b/src/components/retro/retro-roster.test.tsx
@@ -97,3 +97,27 @@ describe("RetroRoster", () => {
     expect(screen.getAllByRole("listitem")[0].hasAttribute("data-ready")).toBe(false);
   });
 });
+
+describe("RetroRoster — has written (ADR-0012, spec §7)", () => {
+  it("in collect names who has written in a named retro, and shows only a total under anonymous", () => {
+    const present = withPresence({ u1: { online: true }, u2: { online: true } });
+    const { unmount } = render(
+      <RetroRoster users={present} currentStage={collect} writers={new Set(["u2"])} cardCount={3} />
+    );
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.map((row) => row.getAttribute("data-written"))).toEqual(["false", "true", "false"]);
+    expect(within(rows[1]).getByText("Has written")).toBeTruthy();
+    expect(screen.queryByTestId("card-count")).toBeNull();
+    unmount();
+
+    render(<RetroRoster users={present} currentStage={collect} cardCount={3} />);
+    expect(screen.getByTestId("card-count").textContent).toBe("3 cards");
+    expect(screen.getAllByRole("listitem")[1].getAttribute("data-written")).toBeNull();
+  });
+
+  it("outside collect the written signal is not shown", () => {
+    render(<RetroRoster users={withPresence({})} currentStage={group} writers={new Set(["u2"])} cardCount={3} />);
+    expect(screen.queryByText("Has written")).toBeNull();
+    expect(screen.getAllByRole("listitem")[1].getAttribute("data-written")).toBeNull();
+  });
+});

--- a/src/components/retro/retro-roster.tsx
+++ b/src/components/retro/retro-roster.tsx
@@ -7,7 +7,7 @@ import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { READY_LABEL, READY_TOGGLE_LABEL, ROSTER_TITLE } from "@/convex/retroCopy";
+import { HAS_WRITTEN, READY_LABEL, READY_TOGGLE_LABEL, ROSTER_TITLE, cardsCount } from "@/convex/retroCopy";
 import { projectRoster } from "./readiness";
 
 interface RetroRosterProps {
@@ -18,23 +18,43 @@ interface RetroRosterProps {
   myUserId?: string;
   /** The viewer's readiness write: one call per state change. */
   onSetReady?: (ready: boolean) => void;
+  /**
+   * Who has written a card, in a named retro (ADR-0012); undefined under
+   * `anonymous`, where the roster shows only the total.
+   */
+  writers?: ReadonlySet<string>;
+  /** The board's card count, shown in `collect` when nobody is named. */
+  cardCount?: number;
 }
 
 /**
  * The roster panel (spec §7): presence and names for every member, with
  * readiness named per person and the viewer's own toggle. `collect` offers
- * none — there the only signal is whether a person has written, which the
- * cards ticket adds — so nothing durable ever records who declared
- * themselves finished.
+ * none — there the only signal is whether a person has written, named per
+ * person in a named retro and a total under `anonymous` (ADR-0012) — so
+ * nothing durable ever records who declared themselves finished.
  */
-export function RetroRoster({ users, currentStage, myUserId, onSetReady }: RetroRosterProps) {
+export function RetroRoster({
+  users,
+  currentStage,
+  myUserId,
+  onSetReady,
+  writers,
+  cardCount,
+}: RetroRosterProps) {
   const rows = useMemo(() => projectRoster(users, currentStage.id), [users, currentStage.id]);
   const offersReadiness = currentStage.kind !== "collect";
+  const showsWritten = currentStage.kind === "collect";
   const me = rows.find((row) => row._id === myUserId);
 
   return (
     <section data-testid="retro-roster" aria-label={ROSTER_TITLE} className="flex flex-col gap-3">
       <h2 className="text-sm font-semibold">{ROSTER_TITLE}</h2>
+      {showsWritten && writers === undefined && cardCount !== undefined && (
+        <p data-testid="card-count" className="text-xs text-muted-foreground">
+          {cardsCount(cardCount)}
+        </p>
+      )}
       {offersReadiness && me && onSetReady && (
         <div className="flex items-center gap-2">
           <Switch
@@ -52,6 +72,7 @@ export function RetroRoster({ users, currentStage, myUserId, onSetReady }: Retro
             key={row._id}
             data-online={String(row.isOnline)}
             {...(offersReadiness ? { "data-ready": String(row.ready) } : {})}
+            {...(showsWritten && writers ? { "data-written": String(writers.has(row._id)) } : {})}
             className="flex items-center gap-2 text-sm"
           >
             <UserAvatar
@@ -66,6 +87,11 @@ export function RetroRoster({ users, currentStage, myUserId, onSetReady }: Retro
             {offersReadiness && row.ready && (
               <span className="rounded-full bg-green-50 px-2 py-0.5 text-xs text-green-700 dark:bg-status-success-bg dark:text-status-success-fg">
                 {READY_LABEL}
+              </span>
+            )}
+            {showsWritten && writers?.has(row._id) && (
+              <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700 dark:bg-status-info-bg dark:text-status-info-fg">
+                {HAS_WRITTEN}
               </span>
             )}
           </li>

--- a/src/components/retro/stage-empty-state.test.tsx
+++ b/src/components/retro/stage-empty-state.test.tsx
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
-import { StageEmptyState } from "./stage-empty-state";
+import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
 import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
 
@@ -25,5 +25,13 @@ describe("StageEmptyState", () => {
 
   it("the review line is the register's", () => {
     expect(STAGE_EMPTY.review).toBe("No open actions from earlier retros");
+  });
+
+  it("a card stage is empty only with no cards; review and close read empty until action items land (spec §7)", () => {
+    expect(isStageEmpty("collect", 0)).toBe(true);
+    expect(isStageEmpty("collect", 1)).toBe(false);
+    expect(isStageEmpty("group", 2)).toBe(false);
+    expect(isStageEmpty("review", 5)).toBe(true);
+    expect(isStageEmpty("close", 5)).toBe(true);
   });
 });

--- a/src/components/retro/stage-empty-state.tsx
+++ b/src/components/retro/stage-empty-state.tsx
@@ -1,10 +1,22 @@
 import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
 
+/** The kinds whose line is about cards; the others speak of action items. */
+const CARD_KINDS: ReadonlySet<StageKind> = new Set(["collect", "group", "vote", "discuss"]);
+
+/**
+ * Whether the viewed entry has nothing in it (spec §7): no cards for a
+ * card stage; for `review` and `close` the line is about action items,
+ * which arrive with their own ticket, so until then those entries always
+ * read empty.
+ */
+export function isStageEmpty(kind: StageKind, cardCount: number): boolean {
+  return CARD_KINDS.has(kind) ? cardCount === 0 : true;
+}
+
 /**
  * A stage with nothing in it (ADR-0010): an explanation over the canvas,
- * never a lock. The cards ticket conditions it on the board being empty
- * for the viewed entry; until then every entry reads its line.
+ * never a lock.
  */
 export function StageEmptyState({ kind }: { kind: StageKind }) {
   return (

--- a/src/components/retro/use-card-actions.test.tsx
+++ b/src/components/retro/use-card-actions.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * The card writes (ADR-0022): a create that fails transiently is retried
+ * with the same `clientId`, so the server's dedupe makes the retry a no-op
+ * rather than a second card; a refusal is not retried and toasts its reason.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { ConvexError } from "convex/values";
+import type { Id } from "@/convex/_generated/dataModel";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as { fn: string; args: unknown }[],
+  outcomes: [] as (() => Promise<unknown>)[],
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/convex/_generated/api", () => ({
+  api: {
+    retro: {
+      createCard: "retro.createCard",
+      updateCard: "retro.updateCard",
+      moveCards: "retro.moveCards",
+      deleteCard: "retro.deleteCard",
+    },
+  },
+}));
+vi.mock("convex/react", () => ({
+  useMutation: (ref: string) => {
+    const fn = async (args: unknown) => {
+      mocks.calls.push({ fn: ref, args });
+      const next = mocks.outcomes.shift();
+      return next ? await next() : undefined;
+    };
+    return Object.assign(fn, { withOptimisticUpdate: () => fn });
+  },
+}));
+vi.mock("@/lib/toast", () => ({ toast: mocks.toast }));
+
+import { useCardActions } from "./use-card-actions";
+
+const roomId = "room1" as Id<"rooms">;
+const userId = "user1" as Id<"users">;
+const card = { clientId: "c-1", text: "hi", promptId: "p1", position: { x: 1, y: 2 } };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.calls.length = 0;
+  mocks.outcomes.length = 0;
+  mocks.toast.error.mockClear();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("useCardActions.create", () => {
+  it("retries a transient failure with the same clientId and resolves true", async () => {
+    mocks.outcomes.push(() => Promise.reject(new Error("network")), () => Promise.resolve("id-1"));
+    const { result } = renderHook(() => useCardActions(roomId, userId));
+    const outcome = result.current.create(card);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(await outcome).toBe(true);
+    expect(mocks.calls.map((c) => c.fn)).toEqual(["retro.createCard", "retro.createCard"]);
+    expect(mocks.calls.map((c) => (c.args as { clientId: string }).clientId)).toEqual(["c-1", "c-1"]);
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a refusal, toasts its reason and resolves false", async () => {
+    mocks.outcomes.push(() =>
+      Promise.reject(new ConvexError({ code: "forbidden", message: "Not in a named retro" }))
+    );
+    const { result } = renderHook(() => useCardActions(roomId, userId));
+    const outcome = result.current.create(card);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(await outcome).toBe(false);
+    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith("Not in a named retro");
+  });
+});

--- a/src/components/retro/use-card-actions.ts
+++ b/src/components/retro/use-card-actions.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
+import { refusalOf, retryWrite } from "@/lib/write-retry";
+import { toast } from "@/lib/toast";
+import { CARD_ACT_FAILED } from "@/convex/retroCopy";
+import { applyCreate, applyDelete, applyMove, applyTextEdit, type MoveCardsArgs } from "./optimistic";
+import type { Move } from "./use-hand";
+
+export interface CardActions {
+  /** Resolves to whether the card was written; the same `clientId` rides every retry. */
+  create: (args: { clientId: string; text: string; promptId: string; position: { x: number; y: number } }) => Promise<boolean>;
+  /** One batch per gesture; fire and forget, the board settles by itself. */
+  move: (moves: Move[]) => void;
+  /** Rejects on failure so the draft keeps its "Unsaved" state (spec §10.8). */
+  editText: (clientId: string, text: string) => Promise<void>;
+  remove: (clientId: string) => void;
+}
+
+/** The refusal's reason, or the fallback for a failure that outlived its retries. */
+function surface(error: unknown, fallback: string): void {
+  toast.error(refusalOf(error)?.message || fallback);
+}
+
+/** The batch key: the sorted id set (ADR-0022). */
+const moveKey = (args: MoveCardsArgs) => args.moves.map((m) => m.clientId).sort().join("\n");
+
+/**
+ * The card writes (ADR-0022, spec §10.6 to §10.8): each mutation carries its
+ * optimistic function, moves and text edits are keyed single-flight, and a
+ * failure is retried with backoff while a refusal drops the value at once
+ * and toasts its reason.
+ */
+export function useCardActions(roomId: Id<"rooms">, userId: Id<"users">): CardActions {
+  const createCard = useMutation(api.retro.createCard);
+  const moveCards = useMutation(api.retro.moveCards);
+  const updateCard = useMutation(api.retro.updateCard);
+  const deleteCard = useMutation(api.retro.deleteCard);
+
+  const optimisticCreate = useMemo(
+    () =>
+      createCard.withOptimisticUpdate((store, args) => applyCreate(store, args, { userId })),
+    [createCard, userId]
+  );
+  const optimisticMove = useMemo(() => moveCards.withOptimisticUpdate(applyMove), [moveCards]);
+  const optimisticUpdate = useMemo(() => updateCard.withOptimisticUpdate(applyTextEdit), [updateCard]);
+  const optimisticDelete = useMemo(() => deleteCard.withOptimisticUpdate(applyDelete), [deleteCard]);
+
+  const moveInFlight = useSingleFlightMutation(optimisticMove, moveKey);
+  const updateInFlight = useSingleFlightMutation(optimisticUpdate, (args) => args.clientId);
+
+  const create = useCallback<CardActions["create"]>(
+    async (args) => {
+      try {
+        await retryWrite(() => optimisticCreate({ roomId, ...args }));
+        return true;
+      } catch (error) {
+        surface(error, CARD_ACT_FAILED);
+        return false;
+      }
+    },
+    [optimisticCreate, roomId]
+  );
+
+  const move = useCallback<CardActions["move"]>(
+    (moves) => {
+      void retryWrite(() => moveInFlight({ roomId, moves })).catch((error) =>
+        surface(error, CARD_ACT_FAILED)
+      );
+    },
+    [moveInFlight, roomId]
+  );
+
+  const editText = useCallback<CardActions["editText"]>(
+    async (clientId, text) => {
+      try {
+        await updateInFlight({ roomId, clientId, text });
+      } catch (error) {
+        // A refusal is final and says why; a failure waits for the next
+        // keystroke or blur (the draft hook retries), so it is not toasted.
+        const refusal = refusalOf(error);
+        if (refusal) toast.error(refusal.message);
+        throw error;
+      }
+    },
+    [updateInFlight, roomId]
+  );
+
+  const remove = useCallback<CardActions["remove"]>(
+    (clientId) => {
+      void retryWrite(() => optimisticDelete({ roomId, clientId })).catch((error) =>
+        surface(error, CARD_ACT_FAILED)
+      );
+    },
+    [optimisticDelete, roomId]
+  );
+
+  return useMemo(() => ({ create, move, editText, remove }), [create, move, editText, remove]);
+}

--- a/src/components/retro/use-card-draft.test.tsx
+++ b/src/components/retro/use-card-draft.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Own-card text edits (ADR-0022, spec §10.6, §10.8): a 300 ms idle debounce
+ * plus flush on blur; text never rolls back — a failed save keeps the draft
+ * with an "Unsaved" state and retries on the next keystroke or blur; an
+ * incoming server value replaces the draft only while the editor is
+ * unfocused.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCardDraft, TEXT_DEBOUNCE_MS } from "./use-card-draft";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("useCardDraft", () => {
+  it("debounces keystrokes and saves once after the idle window", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCardDraft({ serverText: "one", onSave: save }));
+    act(() => result.current.onFocus());
+    act(() => result.current.onChange("tw"));
+    act(() => result.current.onChange("two"));
+    expect(save).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(TEXT_DEBOUNCE_MS);
+    });
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith("two");
+    expect(result.current.unsaved).toBe(false);
+  });
+
+  it("flushes on blur without waiting", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCardDraft({ serverText: "one", onSave: save }));
+    act(() => result.current.onFocus());
+    act(() => result.current.onChange("two"));
+    await act(async () => {
+      result.current.onBlur();
+    });
+    expect(save).toHaveBeenCalledWith("two");
+  });
+
+  it("keeps the draft and marks it unsaved when the save fails, then retries on the next keystroke", async () => {
+    const save = vi.fn().mockRejectedValueOnce(new Error("network")).mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCardDraft({ serverText: "one", onSave: save }));
+    act(() => result.current.onFocus());
+    act(() => result.current.onChange("two"));
+    await act(async () => {
+      result.current.onBlur();
+    });
+    expect(result.current.text).toBe("two");
+    expect(result.current.unsaved).toBe(true);
+
+    act(() => result.current.onFocus());
+    act(() => result.current.onChange("two!"));
+    await act(async () => {
+      vi.advanceTimersByTime(TEXT_DEBOUNCE_MS);
+    });
+    expect(save).toHaveBeenLastCalledWith("two!");
+    expect(result.current.unsaved).toBe(false);
+  });
+
+  it("takes an incoming server value only while unfocused", () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ serverText }) => useCardDraft({ serverText, onSave: save }),
+      { initialProps: { serverText: "one" } }
+    );
+    act(() => result.current.onFocus());
+    act(() => result.current.onChange("mine"));
+    rerender({ serverText: "theirs" });
+    expect(result.current.text).toBe("mine");
+    act(() => {
+      vi.advanceTimersByTime(TEXT_DEBOUNCE_MS);
+    });
+    act(() => result.current.onBlur());
+    rerender({ serverText: "theirs again" });
+    expect(result.current.text).toBe("theirs again");
+  });
+});

--- a/src/components/retro/use-card-draft.ts
+++ b/src/components/retro/use-card-draft.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLatest } from "@/hooks/use-latest";
+
+/** The idle window before a text edit is written (spec §10.6). */
+export const TEXT_DEBOUNCE_MS = 300;
+
+interface UseCardDraftArgs {
+  serverText: string;
+  /** The write; keyed single-flight and the optimistic patch are the caller's. */
+  onSave: (text: string) => Promise<unknown>;
+}
+
+/**
+ * A card's text draft (ADR-0022): debounced keystrokes, flush on blur, and
+ * never a rollback — a failed save keeps the draft as "Unsaved" and the
+ * next keystroke or blur retries it. The server value replaces the draft
+ * only while the editor is unfocused, so a facilitator's edit never
+ * overwrites what the author is typing.
+ */
+export function useCardDraft({ serverText, onSave }: UseCardDraftArgs) {
+  const [text, setText] = useState(serverText);
+  const [unsaved, setUnsaved] = useState(false);
+  const [focused, setFocused] = useState(false);
+  // The server value the draft last took; a new one replaces the draft
+  // while unfocused (derived during render, never in an effect).
+  const [taken, setTaken] = useState(serverText);
+  if (serverText !== taken) {
+    setTaken(serverText);
+    if (!focused) setText(serverText);
+  }
+
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const save = useLatest(onSave);
+  /** The draft as the handlers see it: written on change, synced after a server take. */
+  const latestText = useRef(text);
+  useEffect(() => {
+    latestText.current = text;
+  }, [text]);
+  /** What the server holds as far as this editor knows; handlers only. */
+  const lastSaved = useRef(serverText);
+  useEffect(() => {
+    if (!focused) lastSaved.current = serverText;
+  }, [serverText, focused]);
+
+  const clearTimer = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  const flush = useCallback(async () => {
+    clearTimer();
+    const value = latestText.current;
+    if (value === lastSaved.current || !value.trim()) return;
+    try {
+      await save.current(value);
+      lastSaved.current = value;
+      setUnsaved(false);
+    } catch {
+      setUnsaved(true);
+    }
+  }, [save]);
+
+  const onChange = useCallback(
+    (value: string) => {
+      setText(value);
+      latestText.current = value;
+      clearTimer();
+      timer.current = setTimeout(() => void flush(), TEXT_DEBOUNCE_MS);
+    },
+    [flush]
+  );
+
+  const onFocus = useCallback(() => setFocused(true), []);
+
+  const onBlur = useCallback(() => {
+    setFocused(false);
+    void flush();
+  }, [flush]);
+
+  useEffect(() => clearTimer, []);
+
+  return { text, unsaved, onChange, onFocus, onBlur };
+}

--- a/src/components/retro/use-hand.test.tsx
+++ b/src/components/retro/use-hand.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The hand (ADR-0022, spec §10.5): the only local canvas state is the
+ * override map `{ clientId → position }`, written from React Flow position
+ * changes while dragging, read ahead of the query value, and cleared on
+ * drop in the same tick the move is issued. Nothing is written on
+ * pointer-move; the derived position equals the optimistic value in the
+ * same render as the drop. Selection is local too (spec §10.4).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useState } from "react";
+import type { Node } from "@xyflow/react";
+import { useHand, type Move } from "./use-hand";
+import type { BoardCard } from "./cards";
+import type { Id } from "@/convex/_generated/dataModel";
+
+const card = (clientId: string, x = 0, y = 0): BoardCard => ({
+  _id: `id-${clientId}` as Id<"retroCards">,
+  clientId,
+  promptId: "p1",
+  position: { x, y },
+  hidden: false,
+  own: true,
+});
+
+const node = (id: string, x: number, y: number): Node => ({ id, position: { x, y }, data: {} });
+
+/**
+ * The board as the hook sees it: the cards prop, and a drop handler that
+ * applies the optimistic value to the cards synchronously — what
+ * `withOptimisticUpdate` does before the request leaves.
+ */
+function harness(initial: BoardCard[]) {
+  const drops: Move[][] = [];
+  return {
+    drops,
+    hook: renderHook(() => {
+      const [cards, setCards] = useState(initial);
+      const hand = useHand({
+        cards,
+        onDrop: (moves) => {
+          drops.push(moves);
+          setCards((prev) =>
+            prev.map((c) => {
+              const move = moves.find((m) => m.clientId === c.clientId);
+              return move ? { ...c, position: move.position } : c;
+            })
+          );
+        },
+      });
+      return { ...hand, cards };
+    }),
+  };
+}
+
+describe("useHand", () => {
+  it("a position change while dragging goes to the override map, never to a write", () => {
+    const { drops, hook } = harness([card("a")]);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "position", id: "a", position: { x: 5, y: 6 }, dragging: true }]);
+    });
+    expect(hook.result.current.positions.get("a")).toEqual({ x: 5, y: 6 });
+    expect(hook.result.current.cards[0].position).toEqual({ x: 0, y: 0 });
+    expect(drops).toEqual([]);
+  });
+
+  it("on drop the override clears and the derived position equals the optimistic value in the same render", () => {
+    const { drops, hook } = harness([card("a")]);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "position", id: "a", position: { x: 5, y: 6 }, dragging: true }]);
+    });
+    const renders = vi.fn();
+    act(() => {
+      hook.result.current.onNodeDragStop({} as never, node("a", 9, 9), [node("a", 9, 9)]);
+      renders();
+    });
+    expect(drops).toEqual([[{ clientId: "a", position: { x: 9, y: 9 } }]]);
+    expect(hook.result.current.overrides.size).toBe(0);
+    expect(hook.result.current.positions.get("a")).toEqual({ x: 9, y: 9 });
+  });
+
+  it("a multi-node drop is one batch, and a query update mid-drag never moves the hand", () => {
+    const { drops, hook } = harness([card("a"), card("b", 1, 1)]);
+    act(() => {
+      hook.result.current.onNodesChange([
+        { type: "position", id: "a", position: { x: 5, y: 5 }, dragging: true },
+        { type: "position", id: "b", position: { x: 6, y: 6 }, dragging: true },
+      ]);
+    });
+    hook.rerender();
+    expect(hook.result.current.positions.get("b")).toEqual({ x: 6, y: 6 });
+    act(() => {
+      hook.result.current.onNodeDragStop({} as never, node("a", 7, 7), [node("a", 7, 7), node("b", 8, 8)]);
+    });
+    expect(drops).toEqual([
+      [
+        { clientId: "a", position: { x: 7, y: 7 } },
+        { clientId: "b", position: { x: 8, y: 8 } },
+      ],
+    ]);
+  });
+
+  it("keeps what React Flow measured, so a rebuilt node is not hidden", () => {
+    const { hook } = harness([card("a")]);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "dimensions", id: "a", dimensions: { width: 200, height: 96 } }]);
+    });
+    expect(hook.result.current.measured.get("a")).toEqual({ width: 200, height: 96 });
+  });
+
+  it("selection changes are held locally", () => {
+    const { hook } = harness([card("a"), card("b")]);
+    act(() => {
+      hook.result.current.onNodesChange([
+        { type: "select", id: "a", selected: true },
+        { type: "select", id: "b", selected: true },
+      ]);
+    });
+    expect([...hook.result.current.selected].sort()).toEqual(["a", "b"]);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "select", id: "a", selected: false }]);
+    });
+    expect([...hook.result.current.selected]).toEqual(["b"]);
+  });
+});

--- a/src/components/retro/use-hand.ts
+++ b/src/components/retro/use-hand.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { Node, NodeChange } from "@xyflow/react";
+import type { BoardCard } from "./cards";
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface Move {
+  clientId: string;
+  position: Position;
+}
+
+export interface Measured {
+  width: number;
+  height: number;
+}
+
+interface UseHandArgs {
+  cards: readonly BoardCard[];
+  /**
+   * The drop: one batch per gesture, issued in the same tick the override
+   * clears. The caller applies the optimistic value synchronously
+   * (`withOptimisticUpdate`), so the derived position never jumps.
+   */
+  onDrop: (moves: Move[]) => void;
+}
+
+/**
+ * The hand (ADR-0022, spec §10.5): the override map is the only local
+ * canvas state besides selection. Nodes are derived from the query value
+ * with the override read ahead of it; nothing is written on pointer-move,
+ * and every drop is one write.
+ */
+export function useHand({ cards, onDrop }: UseHandArgs) {
+  const [overrides, setOverrides] = useState<ReadonlyMap<string, Position>>(new Map());
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  // What React Flow measured per node. Derived nodes are rebuilt from the
+  // query value, and a controlled node rebuilt without its measurement is
+  // hidden until it is measured again — which never happens on its own.
+  const [measured, setMeasured] = useState<ReadonlyMap<string, Measured>>(new Map());
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    const moved: [string, Position][] = [];
+    const selection: [string, boolean][] = [];
+    const sized: [string, Measured][] = [];
+    for (const change of changes) {
+      if (change.type === "position" && change.dragging && change.position) {
+        moved.push([change.id, change.position]);
+      } else if (change.type === "select") {
+        selection.push([change.id, change.selected]);
+      } else if (change.type === "dimensions" && change.dimensions) {
+        sized.push([change.id, change.dimensions]);
+      }
+    }
+    if (sized.length > 0) {
+      setMeasured((prev) => {
+        const next = new Map(prev);
+        for (const [id, size] of sized) next.set(id, size);
+        return next;
+      });
+    }
+    if (moved.length > 0) {
+      setOverrides((prev) => {
+        const next = new Map(prev);
+        for (const [id, position] of moved) next.set(id, position);
+        return next;
+      });
+    }
+    if (selection.length > 0) {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const [id, isSelected] of selection) {
+          if (isSelected) next.add(id);
+          else next.delete(id);
+        }
+        return next;
+      });
+    }
+  }, []);
+
+  const onNodeDragStop = useCallback(
+    (_event: MouseEvent | TouchEvent, _node: Node, nodes: Node[]) => {
+      const moves = nodes.map((n) => ({ clientId: n.id, position: n.position }));
+      setOverrides((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Map(prev);
+        for (const move of moves) next.delete(move.clientId);
+        return next;
+      });
+      onDrop(moves);
+    },
+    [onDrop]
+  );
+
+  const positions = useMemo(() => {
+    const map = new Map<string, Position>();
+    for (const card of cards) map.set(card.clientId, overrides.get(card.clientId) ?? card.position);
+    return map;
+  }, [cards, overrides]);
+
+  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop };
+}

--- a/src/hooks/useSingleFlightMutation.test.tsx
+++ b/src/hooks/useSingleFlightMutation.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Keyed single-flight (ADR-0022, spec §10.6): one request in flight per key,
+ * the latest pending args replacing any queued ones for that key, and keys
+ * independent of one another. Two drops of card A while one is in flight
+ * send two writes with the last position; a drop of card B during A's
+ * flight is not delayed.
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSingleFlightMutation } from "./useSingleFlightMutation";
+
+type Args = { id: string; x: number };
+
+function deferredMutation() {
+  const calls: Args[] = [];
+  const pending: Array<() => void> = [];
+  const mutation = (args: Args) =>
+    new Promise<void>((resolve) => {
+      calls.push(args);
+      pending.push(resolve);
+    });
+  return { calls, mutation, settle: () => pending.shift()?.() };
+}
+
+describe("useSingleFlightMutation", () => {
+  it("collapses a flurry on one key to the in-flight write plus one with the latest args", async () => {
+    const { calls, mutation, settle } = deferredMutation();
+    const { result } = renderHook(() => useSingleFlightMutation(mutation, (a: Args) => a.id));
+
+    let first!: Promise<void>, second!: Promise<void>, third!: Promise<void>;
+    act(() => {
+      first = result.current({ id: "A", x: 1 });
+      second = result.current({ id: "A", x: 2 });
+      third = result.current({ id: "A", x: 3 });
+    });
+    expect(calls).toEqual([{ id: "A", x: 1 }]);
+
+    await act(async () => {
+      settle();
+      await first;
+    });
+    expect(calls).toEqual([{ id: "A", x: 1 }, { id: "A", x: 3 }]);
+    await act(async () => {
+      settle();
+      await Promise.all([second, third]);
+    });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("a write on another key is not delayed by an in-flight one", async () => {
+    const { calls, mutation, settle } = deferredMutation();
+    const { result } = renderHook(() => useSingleFlightMutation(mutation, (a: Args) => a.id));
+
+    act(() => {
+      void result.current({ id: "A", x: 1 });
+      void result.current({ id: "B", x: 9 });
+    });
+    expect(calls).toEqual([{ id: "A", x: 1 }, { id: "B", x: 9 }]);
+    settle();
+    settle();
+  });
+
+  it("a failure on the in-flight write still lets the queued one go, and rejects the caller", async () => {
+    const calls: Args[] = [];
+    let fail = true;
+    const mutation = (args: Args) => {
+      calls.push(args);
+      return fail ? Promise.reject(new Error("boom")) : Promise.resolve();
+    };
+    const { result } = renderHook(() => useSingleFlightMutation(mutation, (a: Args) => a.id));
+
+    let first!: Promise<void>, second!: Promise<void>;
+    act(() => {
+      first = result.current({ id: "A", x: 1 });
+      fail = false;
+      second = result.current({ id: "A", x: 2 });
+    });
+    await expect(first).rejects.toThrow("boom");
+    await second;
+    expect(calls).toEqual([{ id: "A", x: 1 }, { id: "A", x: 2 }]);
+  });
+
+  it("keeps a stable identity across re-renders", () => {
+    const { mutation } = deferredMutation();
+    const { result, rerender } = renderHook(() => useSingleFlightMutation(mutation, (a: Args) => a.id));
+    const before = result.current;
+    rerender();
+    expect(result.current).toBe(before);
+  });
+});

--- a/src/hooks/useSingleFlightMutation.ts
+++ b/src/hooks/useSingleFlightMutation.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useLatest } from "./use-latest";
+
+/**
+ * Keyed single-flight (ADR-0022, spec §10.6): one request in flight per
+ * key, with the latest pending args replacing any queued ones for that key.
+ * Keys are independent, so card B's drop never waits behind card A's. The
+ * presence package's global single-flight is the reference, generalised by
+ * key; a global single-flight is `keyOf: () => "global"`.
+ *
+ * A call that is superseded before it runs resolves (or rejects) with the
+ * result of the call that ran in its place, so a caller awaiting a drop
+ * always learns how the board settled.
+ */
+export function useSingleFlightMutation<Args, Result>(
+  mutation: (args: Args) => Promise<Result>,
+  keyOf: (args: Args) => string
+): (args: Args) => Promise<Result> {
+  type Waiter = { resolve: (value: Result) => void; reject: (error: unknown) => void };
+  type Flight = { upNext: { args: Args; waiters: Waiter[] } | null };
+  const flights = useRef(new Map<string, Flight>());
+  const latestMutation = useLatest(mutation);
+  const latestKeyOf = useLatest(keyOf);
+
+  return useCallback((args: Args) => {
+    const key = latestKeyOf.current(args);
+    const flight = flights.current.get(key);
+    if (flight) {
+      return new Promise<Result>((resolve, reject) => {
+        const waiters = flight.upNext?.waiters ?? [];
+        waiters.push({ resolve, reject });
+        flight.upNext = { args, waiters };
+      });
+    }
+    const mine: Flight = { upNext: null };
+    flights.current.set(key, mine);
+    const first = latestMutation.current(args);
+    void (async () => {
+      try {
+        await first;
+      } catch {
+        // The caller of `first` hears the failure; the queue moves on.
+      }
+      while (mine.upNext) {
+        const { args: next, waiters } = mine.upNext;
+        mine.upNext = null;
+        try {
+          const value = await latestMutation.current(next);
+          for (const w of waiters) w.resolve(value);
+        } catch (error) {
+          for (const w of waiters) w.reject(error);
+        }
+      }
+      flights.current.delete(key);
+    })();
+    return first;
+  }, [latestKeyOf, latestMutation]);
+}

--- a/src/lib/write-retry.test.ts
+++ b/src/lib/write-retry.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Rollback by error kind (ADR-0022, spec §10.8): a refusal — a ConvexError
+ * carrying one of the four codes — is never retried and surfaces its
+ * reason; anything else is retried three times with backoff before it is
+ * given up.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConvexError } from "convex/values";
+import { defaultDelayMs, refusalOf, retryWrite, RETRY_ATTEMPTS } from "./write-retry";
+
+describe("refusalOf", () => {
+  it("reads the code and message off a ConvexError, and nothing off a plain error", () => {
+    expect(refusalOf(new ConvexError({ code: "forbidden", message: "Not yours" }))).toEqual({
+      code: "forbidden",
+      message: "Not yours",
+    });
+    expect(refusalOf(new Error("network"))).toBeNull();
+    expect(refusalOf(new ConvexError("odd shape"))).toBeNull();
+  });
+});
+
+describe("retryWrite", () => {
+  it("a refusal is thrown at once, with no retry", async () => {
+    const write = vi.fn().mockRejectedValue(new ConvexError({ code: "budget", message: "Full" }));
+    await expect(retryWrite(write, { delayMs: () => 0 })).rejects.toBeInstanceOf(ConvexError);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("a transient failure is retried three times, then thrown", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("network"));
+    const delays: number[] = [];
+    await expect(
+      retryWrite(write, {
+        delayMs: (attempt) => {
+          delays.push(attempt);
+          return 0;
+        },
+      })
+    ).rejects.toThrow("network");
+    expect(write).toHaveBeenCalledTimes(1 + RETRY_ATTEMPTS);
+    expect(delays).toEqual([1, 2, 3]);
+  });
+
+  it("a retry that succeeds resolves with its value", async () => {
+    const write = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce("ok");
+    await expect(retryWrite(write, { delayMs: () => 0 })).resolves.toBe("ok");
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+
+  it("the default backoff grows with the attempt", () => {
+    expect(defaultDelayMs(1)).toBeLessThan(defaultDelayMs(2));
+    expect(defaultDelayMs(2)).toBeLessThan(defaultDelayMs(3));
+  });
+});

--- a/src/lib/write-retry.ts
+++ b/src/lib/write-retry.ts
@@ -1,0 +1,55 @@
+import { ConvexError } from "convex/values";
+import type { Refusal, RefusalCode } from "@/convex/model/refusal";
+
+/**
+ * Rollback by error kind (ADR-0022, spec §4.5, §10.8). The retro model
+ * layer throws `ConvexError({ code, message })` for every rule-based
+ * refusal; anything else is a transient failure. A refusal is final; a
+ * failure is retried with backoff, then given up.
+ */
+
+const REFUSAL_CODES: ReadonlySet<string> = new Set<RefusalCode>([
+  "forbidden",
+  "budget",
+  "missing",
+  "stage",
+]);
+
+/** The refusal an error carries, or null for a transient failure. */
+export function refusalOf(error: unknown): Refusal | null {
+  if (!(error instanceof ConvexError)) return null;
+  const data = error.data as Partial<Refusal> | string | undefined;
+  if (typeof data !== "object" || data === null) return null;
+  if (typeof data.code !== "string" || !REFUSAL_CODES.has(data.code)) return null;
+  return { code: data.code as RefusalCode, message: data.message ?? "" };
+}
+
+/** How many times a transient failure is retried before the value is dropped. */
+export const RETRY_ATTEMPTS = 3;
+
+/** The default backoff: 300 ms, 600 ms, 1200 ms. */
+export function defaultDelayMs(attempt: number): number {
+  return 300 * 2 ** (attempt - 1);
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Run a write, retrying a transient failure `RETRY_ATTEMPTS` times with
+ * backoff and throwing a refusal at once. `delayMs` takes the retry number
+ * (1-based) and returns the wait before it.
+ */
+export async function retryWrite<T>(
+  write: () => Promise<T>,
+  options: { delayMs?: (attempt: number) => number } = {}
+): Promise<T> {
+  const delayMs = options.delayMs ?? defaultDelayMs;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await write();
+    } catch (error) {
+      if (refusalOf(error) || attempt >= RETRY_ATTEMPTS) throw error;
+      await sleep(delayMs(attempt + 1));
+    }
+  }
+}


### PR DESCRIPTION
Closes #291. Part of the retro map #253.

## What

**Backend**
- `convex/model/retroCards.ts`: create (client-minted `clientId`, dedupe returns the existing row), text edit, one `moveCards` batch, delete. Attendance is the only guard on writing; own-card rights or `cardManagement` on someone else's card, resolved through the guard's own decision (`resolveRoomAction`, new in `model/auth.ts`) and thrown as a `forbidden` refusal. Every card mutation bumps the activity chokepoint and is correct in every stage (ADR-0010).
- `retro.board` projects every card by the shared pointer (ADR-0015): identity-free, silhouettes in a hidden entry, identical bytes for every viewer. `retro.mine` returns the viewer's own cards in full through the same projection. Writers ride the board read in a named retro (ADR-0012); anonymous retros refuse cards with `ANONYMOUS_CARDS_NOT_YET` until the edit-key half lands.
- Presence payload carries the editing indicator beside readiness (`setRetroPresence`). Account linking re-points card authorship.

**Client**
- The hand (ADR-0022): override map, keyed single-flight, one move batch per gesture, optimistic functions on the named queries, retry with backoff for failures, refusals dropped at once with a toast, text never rolled back ("Unsaved").
- Card nodes with silhouettes, the composer, the roster's "has written" signal, the stage empty state gated per viewed entry, and the board's data attributes (`data-zoom-level`, `data-stage`, `data-card-id`, `data-hidden`, `data-cluster-id`, `data-late`).

## Verification

- convex-test: ADR-0015 cases in named mode, own-card rights, cardManagement on another's card, clientId dedupe, refusal codes, every card mutation in an unexpected stage, chokepoint bumps.
- jsdom: override clears on drop with the derived position equal to the optimistic one in the same render, keyed single-flight, rollback by error kind, retried create reuses its `clientId`, optimistic functions patch exactly the named queries, text draft survives a failed save.
- By hand in one browser: post, drag, inline edit, delete, reveal toggle, all persisting across reload. The two-browser silhouette check (second member sees a silhouette, advance reveals, rewind hides, in-place toggle hides) was not done and needs a human pass.

## Notes for review

- `measured` in `use-hand.ts` is a React Flow measurement cache, not domain state; without it a node rebuilt from a query update flashes hidden until re-measured.
- `data-cluster-id` is empty and `data-late` is `"false"` until #292 and #293; `data-zoom-level` is fixed to `detail`.
- Card paths only raise `forbidden` and `missing`; `budget` and `stage` have no card path.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd
