### PR TITLE
feat(retro): anonymous attribution — edit keys and the ratchet (#292)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -35,6 +35,7 @@ import type * as model_analytics from "../model/analytics.js";
 import type * as model_auth from "../model/auth.js";
 import type * as model_canvas from "../model/canvas.js";
 import type * as model_cleanup from "../model/cleanup.js";
+import type * as model_editKeys from "../model/editKeys.js";
 import type * as model_integrations from "../model/integrations.js";
 import type * as model_issues from "../model/issues.js";
 import type * as model_permissions from "../model/permissions.js";
@@ -102,6 +103,7 @@ declare const fullApi: ApiFromModules<{
   "model/auth": typeof model_auth;
   "model/canvas": typeof model_canvas;
   "model/cleanup": typeof model_cleanup;
+  "model/editKeys": typeof model_editKeys;
   "model/integrations": typeof model_integrations;
   "model/issues": typeof model_issues;
   "model/permissions": typeof model_permissions;

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import * as Cleanup from "./model/cleanup";
 import * as RoomAggregate from "./model/roomAggregate";
+import * as Retro from "./model/retro";
 import * as Teams from "./model/teams";
 
 /**
@@ -58,6 +59,24 @@ export const deleteTeamChunk = internalMutation({
         teamId: args.teamId,
       });
     }
+    return step;
+  },
+});
+
+/**
+ * One bounded step of the ratchet's author strip (ADR-0012, spec §4.3);
+ * reschedules itself until the step reports done. The flag was flipped and
+ * the first batch stripped by the pressing mutation, which also bumped the
+ * activity clock; this continuation never does (spec §14).
+ */
+export const stripCardAuthorsChunk = internalMutation({
+  args: {
+    roomId: v.id("rooms"),
+    after: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const step = await Retro.stripCardAuthorsChunk(ctx, args.roomId, args.after);
+    await Retro.continueStrip(ctx, args.roomId, step);
     return step;
   },
 });

--- a/convex/model/editKeys.ts
+++ b/convex/model/editKeys.ts
@@ -1,0 +1,43 @@
+import type { Doc } from "../_generated/dataModel";
+
+/**
+ * Edit keys (ADR-0012): the browser-held capability that makes an
+ * anonymous card its writer's. The server mints one per card, stores only
+ * its SHA-256 and returns the plaintext once; the client keeps it and
+ * presents it to read, edit, move or delete. Its own module so the card
+ * model and the board read share one hash without an import cycle.
+ */
+
+/** How many random bytes an edit key carries: 128 bits, hex-encoded. */
+const EDIT_KEY_BYTES = 16;
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** A fresh edit key: random, unguessable, returned to the writer once. */
+export function mintEditKey(): string {
+  const bytes = new Uint8Array(EDIT_KEY_BYTES);
+  crypto.getRandomValues(bytes);
+  return toHex(bytes);
+}
+
+/** What the row stores of a key: its SHA-256, hex. */
+export async function hashEditKey(editKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(editKey));
+  return toHex(new Uint8Array(digest));
+}
+
+/** The hashes of a presented key set, for matching against rows. */
+export async function hashEditKeys(editKeys: readonly string[]): Promise<Set<string>> {
+  return new Set(await Promise.all(editKeys.map(hashEditKey)));
+}
+
+/** Whether a presented key opens a keyed card. A card without a hash is never opened by a key. */
+export async function editKeyOpens(
+  card: Pick<Doc<"retroCards">, "editKeyHash">,
+  editKey: string | undefined
+): Promise<boolean> {
+  if (card.editKeyHash === undefined || editKey === undefined) return false;
+  return (await hashEditKey(editKey)) === card.editKeyHash;
+}

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -55,6 +55,7 @@ import {
   VOTE_BUDGET_INVALID,
 } from "../retroCopy";
 import { refusal } from "./refusal";
+import { hashEditKeys } from "./editKeys";
 
 /**
  * The retro (ADR-0016): one room with its ceremony state in a `retros` row
@@ -268,8 +269,29 @@ export type FullCard = Silhouette & {
 
 export type ProjectedCard = Silhouette | FullCard;
 
-/** Who is reading: a person, or nobody in particular (the identity-free board). */
-export type Reader = { userId: Id<"users"> } | null;
+export type Attribution = Doc<"retros">["attribution"];
+
+/**
+ * What the projection reads from the retro: the shared pointer's reveal
+ * policy (ADR-0015) and the attribution (ADR-0012). The attribution is
+ * consulted so that between the ratchet's first batch and its last, a row
+ * still carrying an author is never read as named.
+ */
+export interface ProjectionPolicy {
+  cardsVisible: Visibility;
+  attribution: Attribution;
+}
+
+/** The policy of a retro right now: its current entry's reveal and its attribution. */
+export function policyOf(retro: Doc<"retros">): ProjectionPolicy {
+  return { cardsVisible: currentStageOf(retro).cardsVisible, attribution: retro.attribution };
+}
+
+/**
+ * Who is reading: a person — by id, and by the hashes of the edit keys they
+ * present (ADR-0012) — or nobody in particular (the identity-free board).
+ */
+export type Reader = { userId: Id<"users">; editKeyHashes?: ReadonlySet<string> } | null;
 
 function silhouetteOf(card: Doc<"retroCards">): Silhouette {
   return {
@@ -281,35 +303,44 @@ function silhouetteOf(card: Doc<"retroCards">): Silhouette {
   };
 }
 
-function fullCardOf(card: Doc<"retroCards">): FullCard {
+function fullCardOf(card: Doc<"retroCards">, attribution: Attribution): FullCard {
   return {
     ...silhouetteOf(card),
     text: card.text,
-    ...(card.authorId !== undefined ? { authorId: card.authorId } : {}),
+    ...(attribution === "named" && card.authorId !== undefined ? { authorId: card.authorId } : {}),
     createdAt: card.createdAt,
     updatedAt: card.updatedAt,
     committedAt: card.committedAt,
   };
 }
 
+/** Own means the author in a named retro and a presented key in an anonymous one (ADR-0012). */
+function isOwn(policy: ProjectionPolicy, reader: Reader, card: Doc<"retroCards">): boolean {
+  if (reader === null) return false;
+  if (policy.attribution === "named") {
+    return card.authorId !== undefined && card.authorId === reader.userId;
+  }
+  return card.editKeyHash !== undefined && reader.editKeyHashes?.has(card.editKeyHash) === true;
+}
+
 /**
  * The one projection (ADR-0015): when the entry hides cards and the card is
  * not the reader's own, a silhouette; otherwise the card without its edit
- * key hash. Pure. The entry is always the shared pointer's (the caller
- * reads it from the retros row, never from a client argument); the reader
- * is `null` for the identity-free board, so its bytes are the same for
- * every viewer, and a person for `retro.mine` and the exports.
+ * key hash, and without its author in an anonymous retro. Pure. The policy
+ * is always the shared pointer's (the caller reads it from the retros row,
+ * never from a client argument); the reader is `null` for the
+ * identity-free board, so its bytes are the same for every viewer, and a
+ * person for `retro.mine` and the exports.
  */
 export function projectCard(
-  entry: Pick<StageEntry, "cardsVisible">,
+  policy: ProjectionPolicy,
   reader: Reader,
   card: Doc<"retroCards">
 ): ProjectedCard {
-  const own = reader !== null && card.authorId !== undefined && card.authorId === reader.userId;
-  if (entry.cardsVisible === "hidden" && !own) {
+  if (policy.cardsVisible === "hidden" && !isOwn(policy, reader, card)) {
     return silhouetteOf(card);
   }
-  return fullCardOf(card);
+  return fullCardOf(card, policy.attribution);
 }
 
 /** How many cards and clusters one board read carries; a retro never approaches it. */
@@ -335,7 +366,7 @@ export interface BoardRead {
  */
 export async function board(ctx: QueryCtx, roomId: Id<"rooms">): Promise<BoardRead> {
   const retro = await requireRetro(ctx, roomId);
-  const entry = currentStageOf(retro);
+  const policy = policyOf(retro);
   const [clusters, rows] = await Promise.all([
     ctx.db
       .query("retroClusters")
@@ -355,35 +386,152 @@ export async function board(ctx: QueryCtx, roomId: Id<"rooms">): Promise<BoardRe
   return {
     retro,
     clusters,
-    cards: rows.map((row) => projectCard(entry, null, row)),
+    cards: rows.map((row) => projectCard(policy, null, row)),
     writers: [...writers],
   };
 }
 
+/** How many presented keys one `mine` read hashes; a browser never holds more cards than a board. */
+const MAX_PRESENTED_KEYS = MAX_BOARD_ROWS;
+
 /**
  * `retro.mine` (spec §9): the viewer's own cards, by `by_room_author` in a
- * named retro, through the one projection with the viewer as reader — so
- * "own means full" is decided in `projectCard`, not here. The anonymous
- * half (presented edit keys) joins with ADR-0012's edit-key ticket; until
- * then an anonymous retro has no "mine".
+ * named retro and by the presented edit keys — hashed and matched against
+ * the room's rows — in an anonymous one, through the one projection with
+ * the viewer as reader, so "own means full" is decided in `projectCard`,
+ * not here. Keys are the capability: whoever presents one reads its card.
  */
 export async function mine(
   ctx: QueryCtx,
   roomId: Id<"rooms">,
-  userId: Id<"users">
+  userId: Id<"users">,
+  editKeys: readonly string[] = []
 ): Promise<FullCard[]> {
   const retro = await requireRetro(ctx, roomId);
-  const entry = currentStageOf(retro);
+  const policy = policyOf(retro);
+  const { reader, rows } =
+    policy.attribution === "named"
+      ? await mineByAuthor(ctx, roomId, userId)
+      : await mineByKeys(ctx, roomId, userId, editKeys);
+  return rows.map((row) => {
+    const card = projectCard(policy, reader, row);
+    // Every row here is the reader's own, so the projection can only answer in full.
+    if (!("text" in card)) throw new Error("retro.mine: own card projected as a silhouette");
+    return card;
+  });
+}
+
+async function mineByAuthor(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  userId: Id<"users">
+): Promise<{ reader: Reader; rows: Doc<"retroCards">[] }> {
   const rows = await ctx.db
     .query("retroCards")
     .withIndex("by_room_author", (q) => q.eq("roomId", roomId).eq("authorId", userId))
     .take(MAX_BOARD_ROWS);
-  return rows.map((row) => {
-    const card = projectCard(entry, { userId }, row);
-    // The index is by author, so the projection can only answer in full.
-    if (!("text" in card)) throw new Error("retro.mine: own card projected as a silhouette");
-    return card;
+  return { reader: { userId }, rows };
+}
+
+/**
+ * The anonymous half: no index can answer "whose key is this", so the
+ * room's cards are read whole (bounded) and matched against the hashes of
+ * the presented keys. No keys, no read.
+ */
+async function mineByKeys(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  userId: Id<"users">,
+  editKeys: readonly string[]
+): Promise<{ reader: Reader; rows: Doc<"retroCards">[] }> {
+  const editKeyHashes = await hashEditKeys(editKeys.slice(0, MAX_PRESENTED_KEYS));
+  const reader: Reader = { userId, editKeyHashes };
+  if (editKeyHashes.size === 0) return { reader, rows: [] };
+  const all = await ctx.db
+    .query("retroCards")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .take(MAX_BOARD_ROWS);
+  return {
+    reader,
+    rows: all.filter((row) => row.editKeyHash !== undefined && editKeyHashes.has(row.editKeyHash)),
+  };
+}
+
+// --- The ratchet (ADR-0012, spec §4.3) ---
+
+/** How many cards one strip step touches; the rest continues by schedule (spec §4.3). */
+export const STRIP_BATCH_SIZE = 500;
+
+export interface StripStep {
+  done: boolean;
+  /** The creation time the next step starts after; meaningful only when not done. */
+  after?: number;
+}
+
+/**
+ * One bounded step of the ratchet's strip: the room's next batch of cards
+ * in creation order, each author removed. Progress is by `_creationTime`
+ * on `by_room`, resumed inclusively so rows sharing the boundary instant
+ * are never skipped — re-reading an already stripped row is a no-op.
+ * Never touches `editKeyHash`, never touches a voter, and never bumps the
+ * activity clock — the pressing mutation did that once (spec §14).
+ */
+export async function stripCardAuthorsChunk(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">,
+  after?: number,
+  batchSize: number = STRIP_BATCH_SIZE
+): Promise<StripStep> {
+  const rows = await ctx.db
+    .query("retroCards")
+    .withIndex("by_room", (q) =>
+      after === undefined ? q.eq("roomId", roomId) : q.eq("roomId", roomId).gte("_creationTime", after)
+    )
+    .take(batchSize);
+  for (const row of rows) {
+    if (row.authorId !== undefined) {
+      await ctx.db.patch(row._id, { authorId: undefined });
+    }
+  }
+  if (rows.length < batchSize) {
+    return { done: true };
+  }
+  return { done: false, after: rows[rows.length - 1]._creationTime };
+}
+
+/** Schedules the next strip step when one remains: the room-cascade continuation shape. */
+export async function continueStrip(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">,
+  step: StripStep
+): Promise<void> {
+  if (step.done) return;
+  await ctx.scheduler.runAfter(0, internal.maintenance.stripCardAuthorsChunk, {
+    roomId,
+    after: step.after,
   });
+}
+
+/**
+ * `ratchet` (ADR-0012): the guard has decided the actor is the owner. Flips
+ * the retro to `anonymous` and strips the first batch of authors in the
+ * same mutation, so no read after this commit shows a named card — the
+ * projection reads the flag, and the rest of the strip continues by
+ * schedule in the room-cascade shape. Irreversible; a second press is a
+ * no-op. Allowed on a retro at rest. Calls the activity chokepoint once;
+ * the continuation never does.
+ */
+export async function ratchet(ctx: MutationCtx, room: Doc<"rooms">): Promise<void> {
+  if (room.roomType !== "retro") {
+    throw refusal("missing", NOT_A_RETRO);
+  }
+  const retro = await requireRetro(ctx, room._id);
+  if (retro.attribution === "anonymous") {
+    return;
+  }
+  await ctx.db.patch(retro._id, { attribution: "anonymous" });
+  await continueStrip(ctx, room._id, await stripCardAuthorsChunk(ctx, room._id));
+  await updateRoomActivity(ctx, room);
 }
 
 // --- Stages (ADR-0010, spec §7) ---

--- a/convex/model/retroCards.ts
+++ b/convex/model/retroCards.ts
@@ -5,8 +5,8 @@ import { resolveRoomAction } from "./auth";
 import { updateRoomActivity } from "./rooms";
 import { requireRetro } from "./retro";
 import { refusal } from "./refusal";
+import { editKeyOpens, hashEditKey, mintEditKey } from "./editKeys";
 import {
-  ANONYMOUS_CARDS_NOT_YET,
   CARD_NOT_FOUND,
   CARD_TEXT_REQUIRED,
   CARD_TEXT_TOO_LONG,
@@ -14,11 +14,16 @@ import {
 } from "../retroCopy";
 
 /**
- * Cards (spec §8.1, ADR-0012 named half, ADR-0022): writing, own-card
- * rights, the one move batch, and the text edit and delete. Every act here
- * is a person's and correct in every stage; the shared pointer never
- * forbids one (ADR-0010). Every rule-based refusal is a `ConvexError` with
- * one of the four codes (spec §4.5).
+ * Cards (spec §8.1, ADR-0012, ADR-0022): writing, own-card rights, the one
+ * move batch, and the text edit and delete. Every act here is a person's
+ * and correct in every stage; the shared pointer never forbids one
+ * (ADR-0010). Every rule-based refusal is a `ConvexError` with one of the
+ * four codes (spec §4.5).
+ *
+ * Attribution is decided at write time and never revisited: a named card
+ * stores its author; an anonymous card stores only the SHA-256 hash of an
+ * edit key the server minted and returned once. "Mine" is then the key in
+ * the writer's browser, not a link in the row (ADR-0012).
  */
 
 export const MAX_CARD_TEXT = 2000;
@@ -70,13 +75,21 @@ async function requireCard(
   return card;
 }
 
+/** What a create returns: the row, and in an anonymous retro the key, once. */
+export interface CreateCardResult {
+  cardId: Id<"retroCards">;
+  /** Present only for a freshly written anonymous card; a retry never carries it again. */
+  editKey?: string;
+}
+
 /**
  * Write a card (spec §8.1). The client mints `clientId`, so a retried
- * create finds its row and inserts nothing. In a named retro the caller
- * becomes the author; the anonymous half (edit keys, ADR-0012) is not
- * built yet, so an anonymous retro refuses the write rather than store an
- * author it promised not to. `committedAt = createdAt = Date.now()` inside
- * the mutation (spec §23.6).
+ * create finds its row and inserts nothing — and, in an anonymous retro,
+ * returns no key a second time: the plaintext is never stored, so it can
+ * only ever be handed out once. In a named retro the caller becomes the
+ * author; in an anonymous one the row gets the hash of a minted key and the
+ * caller gets the key. `committedAt = createdAt = Date.now()` inside the
+ * mutation (spec §23.6).
  */
 export async function createCard(
   ctx: MutationCtx,
@@ -88,19 +101,17 @@ export async function createCard(
     promptId: string;
     position: Position;
   }
-): Promise<Id<"retroCards">> {
+): Promise<CreateCardResult> {
   const retro = await requireRetro(ctx, args.room._id);
   if (!retro.format.prompts.some((p) => p.id === args.promptId)) {
     throw refusal("missing", PROMPT_NOT_FOUND);
   }
   const text = validateCardText(args.text);
-  if (retro.attribution !== "named") {
-    throw refusal("forbidden", ANONYMOUS_CARDS_NOT_YET);
-  }
   const existing = await getCardByClientId(ctx, args.room._id, args.clientId);
   if (existing) {
-    return existing._id;
+    return { cardId: existing._id };
   }
+  const editKey = retro.attribution === "anonymous" ? mintEditKey() : undefined;
   const now = Date.now();
   const cardId = await ctx.db.insert("retroCards", {
     roomId: args.room._id,
@@ -108,31 +119,44 @@ export async function createCard(
     text,
     promptId: args.promptId,
     position: args.position,
-    authorId: args.actor.user._id,
+    // Exactly one of the two (ADR-0012).
+    ...(editKey === undefined
+      ? { authorId: args.actor.user._id }
+      : { editKeyHash: await hashEditKey(editKey) }),
     createdAt: now,
     updatedAt: now,
     committedAt: now,
   });
   await updateRoomActivity(ctx, args.room);
-  return cardId;
+  return editKey === undefined ? { cardId } : { cardId, editKey };
 }
 
 /**
  * Own-card rights (spec §8.1): the author may edit, move and delete their
- * card; anyone else needs `cardManagement`. The decision is the guard's own
- * (`resolveRoomAction`), read back rather than thrown because whether the
- * category applies depends on the card, and a denial must be a `forbidden`
- * refusal the client can tell from a failure. One check per act: a batch
- * resolves the category once and tests authorship per card.
+ * card, proven by `authorId` in a named retro and by presenting the edit
+ * key in an anonymous one; anyone else needs `cardManagement`, which is
+ * also the only way to touch a card the ratchet stripped (neither author
+ * nor key). The decision is the guard's own (`resolveRoomAction`), read
+ * back rather than thrown because whether the category applies depends on
+ * the card, and a denial must be a `forbidden` refusal the client can tell
+ * from a failure. One check per act: a batch resolves the category once and
+ * tests ownership per card, so a batch mixing owned and unowned cards is
+ * refused whole for anyone without the category.
  */
 function cardRights(
   ctx: QueryCtx,
   room: Doc<"rooms">,
   actor: CardActor
-): (card: Doc<"retroCards">) => Promise<void> {
+): (card: Doc<"retroCards">, editKey?: string) => Promise<void> {
   let decision: Promise<ResolvedDecision> | undefined;
-  return async (card) => {
+  return async (card, editKey) => {
+    // Between the ratchet's first batch and its last, a row may still carry
+    // its author; the author keeps their own-card right for that beat. No
+    // read shows the name meanwhile (the projection reads the flag).
     if (card.authorId !== undefined && card.authorId === actor.user._id) {
+      return;
+    }
+    if (await editKeyOpens(card, editKey)) {
       return;
     }
     decision ??= resolveRoomAction(ctx, actor.user, actor.membership, room, {
@@ -149,10 +173,10 @@ function cardRights(
 /** Edit a card's text; the author is untouched and no editor is recorded (ADR-0012). */
 export async function updateCardText(
   ctx: MutationCtx,
-  args: { room: Doc<"rooms">; actor: CardActor; clientId: string; text: string }
+  args: { room: Doc<"rooms">; actor: CardActor; clientId: string; text: string; editKey?: string }
 ): Promise<void> {
   const card = await requireCard(ctx, args.room._id, args.clientId);
-  await cardRights(ctx, args.room, args.actor)(card);
+  await cardRights(ctx, args.room, args.actor)(card, args.editKey);
   await ctx.db.patch(card._id, { text: validateCardText(args.text), updatedAt: Date.now() });
   await updateRoomActivity(ctx, args.room);
 }
@@ -160,6 +184,8 @@ export async function updateCardText(
 export interface CardMove {
   clientId: string;
   position: Position;
+  /** The card's edit key, for an anonymous card the mover wrote (ADR-0012). */
+  editKey?: string;
 }
 
 /**
@@ -175,8 +201,8 @@ export async function moveCards(
     args.moves.map((move) => requireCard(ctx, args.room._id, move.clientId))
   );
   const mayTouch = cardRights(ctx, args.room, args.actor);
-  for (const card of cards) {
-    await mayTouch(card);
+  for (const [i, card] of cards.entries()) {
+    await mayTouch(card, args.moves[i].editKey);
   }
   const now = Date.now();
   await Promise.all(
@@ -190,10 +216,10 @@ export async function moveCards(
 /** Delete a card: own, or under `cardManagement`. */
 export async function deleteCard(
   ctx: MutationCtx,
-  args: { room: Doc<"rooms">; actor: CardActor; clientId: string }
+  args: { room: Doc<"rooms">; actor: CardActor; clientId: string; editKey?: string }
 ): Promise<void> {
   const card = await requireCard(ctx, args.room._id, args.clientId);
-  await cardRights(ctx, args.room, args.actor)(card);
+  await cardRights(ctx, args.room, args.actor)(card, args.editKey);
   await ctx.db.delete(card._id);
   await updateRoomActivity(ctx, args.room);
 }

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -59,12 +59,16 @@ export const board = query({
   },
 });
 
-/** The viewer's own cards in full, whatever the shared pointer hides (spec §9). */
+/**
+ * The viewer's own cards in full, whatever the shared pointer hides (spec
+ * §9): by author in a named retro, by the presented edit keys in an
+ * anonymous one (ADR-0012).
+ */
 export const mine = query({
-  args: { roomId: v.id("rooms") },
+  args: { roomId: v.id("rooms"), editKeys: v.optional(v.array(v.string())) },
   handler: async (ctx, args) => {
     const { user } = await requireRoomReader(ctx, args.roomId);
-    return await Retro.mine(ctx, args.roomId, user._id);
+    return await Retro.mine(ctx, args.roomId, user._id, args.editKeys);
   },
 });
 
@@ -234,6 +238,19 @@ export const claim = mutation({
   },
 });
 
+/**
+ * The owner-only ratchet (ADR-0012, spec §4.3): named to anonymous, once,
+ * forever; every author stripped, the first batch here and the rest by
+ * schedule.
+ */
+export const ratchet = mutation({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { room } = await requireCan(ctx, args.roomId, { kind: "relationship", verb: "ratchet" });
+    await Retro.ratchet(ctx, room);
+  },
+});
+
 /** Owner-level hard delete through the room cascade (ADR-0019). */
 export const remove = mutation({
   args: { roomId: v.id("rooms") },
@@ -290,6 +307,8 @@ const positionValidator = v.object({ x: v.number(), y: v.number() });
 /**
  * Write a card. Attendance is the only guard: writing is never in the
  * config (spec §4.2). The client mints `clientId`; a retry returns the row.
+ * Returns `{ cardId, editKey? }`: in an anonymous retro the key rides back
+ * once, and the client keeps it (ADR-0012).
  */
 export const createCard = mutation({
   args: {
@@ -305,31 +324,34 @@ export const createCard = mutation({
   },
 });
 
-/** Edit a card's text: own, or under `cardManagement`; the model decides per card. */
+/** Edit a card's text: own (by author or edit key), or under `cardManagement`; the model decides per card. */
 export const updateCard = mutation({
-  args: { roomId: v.id("rooms"), clientId: v.string(), text: v.string() },
+  args: { roomId: v.id("rooms"), clientId: v.string(), text: v.string(), editKey: v.optional(v.string()) },
   handler: async (ctx, args) => {
     const { roomId, ...rest } = args;
     await RetroCards.updateCardText(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
   },
 });
 
-/** The one move mutation: a batch of `{ clientId, position }` (ADR-0022). */
+/** The one move mutation: a batch of `{ clientId, position, editKey? }` (ADR-0022, ADR-0012). */
 export const moveCards = mutation({
   args: {
     roomId: v.id("rooms"),
-    moves: v.array(v.object({ clientId: v.string(), position: positionValidator })),
+    moves: v.array(
+      v.object({ clientId: v.string(), position: positionValidator, editKey: v.optional(v.string()) })
+    ),
   },
   handler: async (ctx, args) => {
     await RetroCards.moveCards(ctx, { ...(await requireCardActor(ctx, args.roomId)), moves: args.moves });
   },
 });
 
-/** Delete a card: own, or under `cardManagement`. */
+/** Delete a card: own (by author or edit key), or under `cardManagement`. */
 export const deleteCard = mutation({
-  args: { roomId: v.id("rooms"), clientId: v.string() },
+  args: { roomId: v.id("rooms"), clientId: v.string(), editKey: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    await RetroCards.deleteCard(ctx, { ...(await requireCardActor(ctx, args.roomId)), clientId: args.clientId });
+    const { roomId, ...rest } = args;
+    await RetroCards.deleteCard(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
   },
 });
 

--- a/convex/retroAttribution.test.ts
+++ b/convex/retroAttribution.test.ts
@@ -1,0 +1,425 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "./schema";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { hashEditKey } from "./model/editKeys";
+import * as Retro from "./model/retro";
+import * as Rooms from "./model/rooms";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+
+// Anonymous attribution (ADR-0012, spec §8.1, §8.2, §4.3, §9, §14): an
+// anonymous card stores no author, only the hash of an edit key returned
+// once; "mine" is the presented keys; the ratchet flips a named retro to
+// anonymous in its first batch and strips every author across batches,
+// once, irreversibly, by the owner alone.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string) => seedNamedUser(t, authUserId, authUserId);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+async function cardsOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function userId(t: T, authUserId: string): Promise<Id<"users">> {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("users")
+      .withIndex("by_auth_user", (q) => q.eq("authUserId", authUserId))
+      .unique()
+  ))!._id;
+}
+
+/** An owner and a participant in a fresh teamless retro, anonymous when asked. */
+async function seedRetro(t: T, attribution: "named" | "anonymous" = "anonymous") {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, {
+    name: "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+  });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  let retro = await retroRow(t, roomId);
+  if (attribution === "anonymous") {
+    await t.run((ctx) => ctx.db.patch(retro._id, { attribution }));
+    retro = await retroRow(t, roomId);
+  }
+  return { roomId, stages: retro.stages, promptId: retro.format.prompts[0].id };
+}
+
+const POS = { x: 10, y: 20 };
+
+async function write(t: T, who: string, roomId: Id<"rooms">, promptId: string, clientId: string, text = "hello") {
+  return as(t, who).mutation(api.retro.createCard, { roomId, clientId, text, promptId, position: POS });
+}
+
+/** The refusal's code, or undefined for a plain error. */
+async function codeOf(p: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await p;
+    return "resolved";
+  } catch (error) {
+    return error instanceof ConvexError ? (error.data as { code: string }).code : undefined;
+  }
+}
+
+/** Drains `runAfter(0)` continuations (the room-cascade shape) on real timers. */
+async function drainScheduled(t: T): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+    await t.finishInProgressScheduledFunctions();
+    const jobs = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    if (!jobs.some((j) => j.state.kind === "pending")) return;
+  }
+  throw new Error("scheduled functions did not drain");
+}
+
+async function pendingStrips(t: T) {
+  const jobs = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+  return jobs.filter((j) => j.name.includes("stripCardAuthorsChunk") && j.state.kind === "pending");
+}
+
+describe("an anonymous card (ADR-0012, spec §8.1)", () => {
+  it("stores only the key's hash, never an author, and returns the plaintext once", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+
+    const result = await write(t, "guest", roomId, promptId, "c1", "  candid  ");
+
+    expect(typeof result.editKey).toBe("string");
+    expect(result.editKey!.length).toBeGreaterThanOrEqual(32);
+    const [card] = await cardsOf(t, roomId);
+    expect(card._id).toBe(result.cardId);
+    expect(card.text).toBe("candid");
+    expect(card.authorId).toBeUndefined();
+    expect(card.editKeyHash).toBe(await hashEditKey(result.editKey!));
+    expect(card.editKeyHash).not.toBe(result.editKey);
+    // The plaintext is nowhere in the row.
+    expect(JSON.stringify(card)).not.toContain(result.editKey);
+  });
+
+  it("a named card has exactly the author; an anonymous one exactly the hash; keys differ per card", async () => {
+    const t = convexTest(schema, modules);
+    const named = await seedRetro(t, "named");
+    const namedResult = await write(t, "guest", named.roomId, named.promptId, "n1");
+    expect(namedResult.editKey).toBeUndefined();
+    const [namedCard] = await cardsOf(t, named.roomId);
+    expect(namedCard.authorId).toBe(await userId(t, "guest"));
+    expect(namedCard.editKeyHash).toBeUndefined();
+
+    const retro = await retroRow(t, named.roomId);
+    await t.run((ctx) => ctx.db.patch(retro._id, { attribution: "anonymous" }));
+    const a = await write(t, "guest", named.roomId, named.promptId, "a1");
+    const b = await write(t, "guest", named.roomId, named.promptId, "a2");
+    expect(a.editKey).not.toBe(b.editKey);
+    for (const card of (await cardsOf(t, named.roomId)).filter((c) => c.clientId !== "n1")) {
+      expect(card.authorId).toBeUndefined();
+      expect(typeof card.editKeyHash).toBe("string");
+    }
+  });
+
+  it("a retried create returns the row without a second key", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    const first = await write(t, "guest", roomId, promptId, "c1", "one");
+    const again = await write(t, "guest", roomId, promptId, "c1", "two");
+    expect(again.cardId).toBe(first.cardId);
+    expect(again.editKey).toBeUndefined();
+    expect(await cardsOf(t, roomId)).toHaveLength(1);
+  });
+});
+
+describe("the board and mine in an anonymous retro (spec §9)", () => {
+  it("the board carries no author for anyone, names no writer, and mine is the presented keys", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, promptId } = await seedRetro(t);
+    const { editKey } = await write(t, "guest", roomId, promptId, "g1", "guest's");
+    await write(t, "owner", roomId, promptId, "o1", "owner's");
+
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+    const board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(board.writers).toEqual([]);
+    for (const card of board.cards) {
+      expect("authorId" in card).toBe(false);
+      expect("editKeyHash" in card).toBe(false);
+      expect("text" in card).toBe(true);
+    }
+    expect(await as(t, "owner").query(api.retro.board, { roomId })).toEqual(board);
+
+    const mine = await as(t, "guest").query(api.retro.mine, { roomId, editKeys: [editKey!] });
+    expect(mine.map((c) => c.clientId)).toEqual(["g1"]);
+    expect(mine[0].text).toBe("guest's");
+    expect("authorId" in mine[0]).toBe(false);
+    expect("editKeyHash" in mine[0]).toBe(false);
+
+    expect(await as(t, "guest").query(api.retro.mine, { roomId })).toEqual([]);
+    expect(await as(t, "guest").query(api.retro.mine, { roomId, editKeys: ["wrong"] })).toEqual([]);
+    // Keys are the capability: whoever presents one reads the card as theirs.
+    expect((await as(t, "owner").query(api.retro.mine, { roomId, editKeys: [editKey!] })).map((c) => c.clientId)).toEqual(["g1"]);
+  });
+
+  it("the ADR-0015 projection cases hold in anonymous mode", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, promptId } = await seedRetro(t);
+    const { editKey } = await write(t, "guest", roomId, promptId, "g1", "guest's");
+    await write(t, "owner", roomId, promptId, "o1", "owner's");
+    const byClient = (cards: { clientId: string }[], clientId: string) =>
+      cards.find((c) => c.clientId === clientId)! as Record<string, unknown>;
+    const boardFor = (who: string) => as(t, who).query(api.retro.board, { roomId });
+
+    // Hidden collect: silhouettes for everyone, the owner (facilitator) included.
+    for (const who of ["guest", "owner"]) {
+      const board = await boardFor(who);
+      for (const card of board.cards) {
+        expect(Object.keys(card).sort()).toEqual(["_id", "clientId", "position", "promptId"]);
+      }
+    }
+    // Own text comes through the key alone.
+    const mine = await as(t, "guest").query(api.retro.mine, { roomId, editKeys: [editKey!] });
+    expect(mine[0].text).toBe("guest's");
+
+    // The in-place toggle reveals without an advance, and hides again.
+    await as(t, "owner").mutation(api.retro.setCardsVisible, { roomId, stageId: stages[0].id, value: "visible" });
+    expect(byClient((await boardFor("guest")).cards, "o1").text).toBe("owner's");
+    await as(t, "owner").mutation(api.retro.setCardsVisible, { roomId, stageId: stages[0].id, value: "hidden" });
+    expect("text" in byClient((await boardFor("guest")).cards, "o1")).toBe(false);
+
+    // Advance reveals every card, with no author; rewind hides again.
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+    let board = await boardFor("guest");
+    expect(byClient(board.cards, "o1")).toMatchObject({ text: "owner's" });
+    expect("authorId" in byClient(board.cards, "o1")).toBe(false);
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[0].id });
+    board = await boardFor("guest");
+    expect("text" in byClient(board.cards, "o1")).toBe(false);
+
+    // A second collect entry later in the list hides again.
+    const second = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "collect", index: 2 });
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+    expect("text" in byClient((await boardFor("guest")).cards, "o1")).toBe(true);
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: second });
+    expect("text" in byClient((await boardFor("guest")).cards, "o1")).toBe(false);
+  });
+});
+
+describe("own-card rights by edit key (spec §8.1, §4.2)", () => {
+  it("the key edits, moves and deletes; a wrong or missing key is `forbidden` for a participant", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    const { editKey } = await write(t, "guest", roomId, promptId, "g1", "mine");
+
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "x" }))
+    ).toBe("forbidden");
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "x", editKey: "wrong" }))
+    ).toBe("forbidden");
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "g1", editKey: "wrong" }))
+    ).toBe("forbidden");
+    expect(
+      await codeOf(
+        as(t, "guest").mutation(api.retro.moveCards, {
+          roomId,
+          moves: [{ clientId: "g1", position: { x: 1, y: 1 }, editKey: "wrong" }],
+        })
+      )
+    ).toBe("forbidden");
+    let [card] = await cardsOf(t, roomId);
+    expect(card).toMatchObject({ text: "mine", position: POS });
+
+    await as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "edited", editKey });
+    await as(t, "guest").mutation(api.retro.moveCards, {
+      roomId,
+      moves: [{ clientId: "g1", position: { x: 5, y: 6 }, editKey }],
+    });
+    [card] = await cardsOf(t, roomId);
+    expect(card).toMatchObject({ text: "edited", position: { x: 5, y: 6 } });
+    expect(card.authorId).toBeUndefined();
+    expect(card.editKeyHash).toBe(await hashEditKey(editKey!));
+
+    await as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "g1", editKey });
+    expect(await cardsOf(t, roomId)).toHaveLength(0);
+  });
+
+  it("a batch mixing an owned and an unowned card is refused whole; a cardManagement holder needs no key", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, promptId } = await seedRetro(t);
+    const { editKey } = await write(t, "guest", roomId, promptId, "g1", "guest's");
+    await write(t, "owner", roomId, promptId, "o1", "owner's");
+
+    expect(
+      await codeOf(
+        as(t, "guest").mutation(api.retro.moveCards, {
+          roomId,
+          moves: [
+            { clientId: "g1", position: { x: 1, y: 1 }, editKey },
+            { clientId: "o1", position: { x: 2, y: 2 } },
+          ],
+        })
+      )
+    ).toBe("forbidden");
+    for (const card of await cardsOf(t, roomId)) expect(card.position).toEqual(POS);
+
+    await as(t, "owner").mutation(api.retro.updateCard, { roomId, clientId: "g1", text: "tidied" });
+    await as(t, "owner").mutation(api.retro.moveCards, {
+      roomId,
+      moves: [
+        { clientId: "g1", position: { x: 1, y: 1 } },
+        { clientId: "o1", position: { x: 2, y: 2 } },
+      ],
+    });
+    const cards = await cardsOf(t, roomId);
+    expect(cards.find((c) => c.clientId === "g1")).toMatchObject({ text: "tidied", position: { x: 1, y: 1 } });
+    await as(t, "owner").mutation(api.retro.deleteCard, { roomId, clientId: "g1" });
+    expect((await cardsOf(t, roomId)).map((c) => c.clientId)).toEqual(["o1"]);
+  });
+});
+
+describe("the ratchet (ADR-0012, spec §4.3)", () => {
+  /** A named retro whose cards were written by both members. */
+  async function seedNamedWithCards(t: T, count: number) {
+    const seeded = await seedRetro(t, "named");
+    const guestId = await userId(t, "guest");
+    const ownerId = await userId(t, "owner");
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      for (let i = 0; i < count; i++) {
+        await ctx.db.insert("retroCards", {
+          roomId: seeded.roomId,
+          clientId: `c${i}`,
+          text: `card ${i}`,
+          promptId: seeded.promptId,
+          position: POS,
+          authorId: i % 2 === 0 ? guestId : ownerId,
+          createdAt: now,
+          updatedAt: now,
+          committedAt: now,
+        });
+      }
+    });
+    return { ...seeded, guestId, ownerId };
+  }
+
+  it("flips the flag in the first batch, strips every card across batches, and a second ratchet is a no-op", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, guestId } = await seedNamedWithCards(t, 1200);
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: stages[1].id });
+
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId });
+
+    // Before the continuation runs: the flag is flipped, no read shows an
+    // author, and the rest of the strip is scheduled.
+    expect((await retroRow(t, roomId)).attribution).toBe("anonymous");
+    const rows = await cardsOf(t, roomId);
+    expect(rows.filter((c) => c.authorId !== undefined).length).toBe(1200 - Retro.STRIP_BATCH_SIZE);
+    const board = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(board.writers).toEqual([]);
+    for (const card of board.cards) expect("authorId" in card).toBe(false);
+    expect(await as(t, "guest").query(api.retro.mine, { roomId })).toEqual([]);
+    expect(await pendingStrips(t)).toHaveLength(1);
+
+    await drainScheduled(t);
+    const stripped = await cardsOf(t, roomId);
+    expect(stripped).toHaveLength(1200);
+    for (const card of stripped) {
+      expect(card.authorId).toBeUndefined();
+      expect(card.editKeyHash).toBeUndefined();
+    }
+
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId });
+    expect(await pendingStrips(t)).toHaveLength(0);
+    expect((await retroRow(t, roomId)).attribution).toBe("anonymous");
+    // A stripped card is touchable only under cardManagement.
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.updateCard, { roomId, clientId: "c0", text: "x" }))
+    ).toBe("forbidden");
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.deleteCard, { roomId, clientId: "c0" }))
+    ).toBe("forbidden");
+    await as(t, "owner").mutation(api.retro.updateCard, { roomId, clientId: "c0", text: "tidied" });
+    expect((await cardsOf(t, roomId)).find((c) => c.clientId === "c0")!.text).toBe("tidied");
+    void guestId;
+  });
+
+  it("a small retro is stripped inside the pressing mutation with nothing scheduled", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedNamedWithCards(t, 3);
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId });
+    expect(await pendingStrips(t)).toHaveLength(0);
+    for (const card of await cardsOf(t, roomId)) expect(card.authorId).toBeUndefined();
+    // New cards are keyed from here on.
+    const retro = await retroRow(t, roomId);
+    const { editKey } = await write(t, "guest", roomId, retro.format.prompts[0].id, "new");
+    expect(typeof editKey).toBe("string");
+  });
+
+  it("the strip chunk makes progress by creation time, resumes inclusively, and reports done on a short batch", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedNamedWithCards(t, 5);
+    const authored = async () => (await cardsOf(t, roomId)).filter((c) => c.authorId !== undefined).length;
+    let step = await t.run((ctx) => Retro.stripCardAuthorsChunk(ctx, roomId, undefined, 2));
+    expect(step.done).toBe(false);
+    expect(await authored()).toBe(3);
+    // Each further step resumes at the boundary instant (never past it), so
+    // a step strips at least one more row until the short batch ends it.
+    for (let steps = 1; !step.done; steps++) {
+      const before = await authored();
+      step = await t.run((ctx) => Retro.stripCardAuthorsChunk(ctx, roomId, step.after, 2));
+      if (!step.done) expect(await authored()).toBeLessThan(before);
+      expect(steps).toBeLessThan(10);
+    }
+    expect(await authored()).toBe(0);
+  });
+
+  it("a participant cannot ratchet, and a poker room has no ratchet", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedNamedWithCards(t, 2);
+    await expect(as(t, "guest").mutation(api.retro.ratchet, { roomId })).rejects.toThrow("Only the owner");
+    expect((await retroRow(t, roomId)).attribution).toBe("named");
+    for (const card of await cardsOf(t, roomId)) expect(card.authorId).toBeDefined();
+
+    const pokerId = await as(t, "owner").mutation(api.rooms.create, { name: "P" });
+    await as(t, "owner").mutation(api.users.join, { roomId: pokerId, name: "O", authUserId: "owner" });
+    expect(await codeOf(as(t, "owner").mutation(api.retro.ratchet, { roomId: pokerId }))).toBe("missing");
+  });
+
+  it("the pressing mutation bumps the activity clock once; the continuation never does (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedNamedWithCards(t, 1200);
+    const stale = Date.now() - Rooms.RETRO_ACTIVITY_GRANULARITY_MS - 60_000;
+    await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId });
+    const bumped = (await t.run((ctx) => ctx.db.get(roomId)))!.lastActivityAt;
+    expect(bumped).toBeGreaterThan(stale);
+
+    // Re-stale the clock, then run the continuation directly: it strips and leaves the clock alone.
+    await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+    const [job] = await pendingStrips(t);
+    await t.mutation(internal.maintenance.stripCardAuthorsChunk, job.args[0] as { roomId: Id<"rooms">; after?: number });
+    expect((await t.run((ctx) => ctx.db.get(roomId)))!.lastActivityAt).toBe(stale);
+    await drainScheduled(t);
+    expect((await t.run((ctx) => ctx.db.get(roomId)))!.lastActivityAt).toBe(stale);
+    expect((await cardsOf(t, roomId)).every((c) => c.authorId === undefined)).toBe(true);
+  });
+});

--- a/convex/retroCards.test.ts
+++ b/convex/retroCards.test.ts
@@ -13,6 +13,7 @@ import * as Users from "./model/users";
 // ADR-0022): writing, own-card rights, `cardManagement` on another's card,
 // `clientId` dedupe, the silhouette projection by the shared pointer, and
 // the four refusal codes on their paths. No stage ever forbids a card act.
+// The anonymous half (edit keys, the ratchet) is retroAttribution.test.ts.
 
 const modules = import.meta.glob("./**/*.*s");
 
@@ -80,8 +81,9 @@ describe("retro.createCard", () => {
     const t = convexTest(schema, modules);
     const { roomId, promptId } = await seedRetro(t);
 
-    const cardId = await write(t, "guest", roomId, promptId, "c1", "  keep the demo  ");
+    const { cardId, editKey } = await write(t, "guest", roomId, promptId, "c1", "  keep the demo  ");
 
+    expect(editKey).toBeUndefined();
     const [card] = await cardsOf(t, roomId);
     expect(card._id).toBe(cardId);
     expect(card).toMatchObject({
@@ -103,7 +105,7 @@ describe("retro.createCard", () => {
     const first = await write(t, "guest", roomId, promptId, "c1", "one");
     const again = await write(t, "guest", roomId, promptId, "c1", "changed");
 
-    expect(again).toBe(first);
+    expect(again).toEqual(first);
     const cards = await cardsOf(t, roomId);
     expect(cards).toHaveLength(1);
     expect(cards[0].text).toBe("one");
@@ -326,16 +328,7 @@ describe("a stage never forbids a card act (ADR-0010)", () => {
   });
 });
 
-describe("attribution (ADR-0012, named half)", () => {
-  it("an anonymous retro refuses a card with `forbidden` until the edit-key half ships", async () => {
-    const t = convexTest(schema, modules);
-    const { roomId, promptId } = await seedRetro(t);
-    const retro = await retroRow(t, roomId);
-    await t.run((ctx) => ctx.db.patch(retro._id, { attribution: "anonymous" }));
-    expect(await codeOf(write(t, "guest", roomId, promptId, "c1"))).toBe("forbidden");
-    expect(await cardsOf(t, roomId)).toHaveLength(0);
-  });
-
+describe("attribution (ADR-0012, named half; the anonymous half is retroAttribution.test.ts)", () => {
   it("linking an anonymous account to an existing permanent one re-points authorId", async () => {
     const t = convexTest(schema, modules);
     const { roomId, promptId } = await seedRetro(t);

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -240,6 +240,17 @@ export const DELETING_BUTTON = "Deleting…";
 export const DELETE_FAILED = "Failed to delete this retro";
 export const RETRO_DELETED = "Retro deleted";
 
+// --- The ratchet (spec §4.3, §19; ADR-0012) ---
+
+export const RATCHET_MENU_ITEM = "Make anonymous…";
+export const RATCHET_TITLE = "Make this retro anonymous?";
+export const RATCHET_DESCRIPTION =
+  "Every author is removed permanently and this cannot be undone.";
+export const RATCHET_BUTTON = "Make anonymous";
+export const RATCHETING_BUTTON = "Removing authors…";
+export const RATCHET_FAILED = "Failed to make this retro anonymous";
+export const RETRO_ANONYMOUS = "This retro is now anonymous";
+
 
 // --- Cards (spec §8.1, §19; ADR-0012, ADR-0015, ADR-0022) ---
 
@@ -247,14 +258,17 @@ export const RETRO_DELETED = "Retro deleted";
 export const CARD_NOT_FOUND = "That card is no longer on the board";
 export const CARD_TEXT_REQUIRED = "A card needs some text";
 export const CARD_TEXT_TOO_LONG = "A card holds at most 2000 characters";
-/** `createCard` in an anonymous retro before the edit-key half of ADR-0012 ships. */
-export const ANONYMOUS_CARDS_NOT_YET = "Anonymous retros cannot take cards yet";
-
 /** Composer, named (ADR-0012). */
 export const postedAs = (name: string) => `Posted as ${name}. Your name stays with this card.`;
+/** Composer, anonymous (ADR-0012): the claim the storage supports, no more. */
+export const COMPOSER_ANONYMOUS =
+  "Anonymous. Your name is not saved with this card, not even for the facilitator. Edit or delete it from this device.";
 /** Composer, hidden, named (ADR-0015); stacks under the attribution line. */
 export const COMPOSER_HIDDEN_NAMED =
   "Only you can read this for now. Others can see you've added a card, not what it says. Everyone reads it once cards are revealed.";
+/** Composer, hidden, anonymous (ADR-0015). */
+export const COMPOSER_HIDDEN_ANONYMOUS =
+  "Only you can read this for now. Everyone reads it once cards are revealed.";
 /** Composer, visible, either attribution. */
 export const COMPOSER_VISIBLE = "Everyone in the retro can read this now.";
 

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -620,6 +620,15 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     }
   });
 
+  it("ratchet bumps (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stale } = await seedTeamRetro(t, false);
+
+    await as(t, "auth-member").mutation(api.retro.ratchet, { roomId });
+
+    await expectBumped(t, roomId, stale);
+  });
+
   it("claim bumps", async () => {
     const t = convexTest(schema, modules);
     const { roomId, memberId, stale } = await seedTeamRetro(t, true);

--- a/docs/spec/retro.md
+++ b/docs/spec/retro.md
@@ -311,7 +311,7 @@ Own-card rights (edit text, move, delete) are proven by `authorId` in a named re
 
 ### 8.3 Reveal (ADR-0015)
 
-The projection is one pure function `projectCard(entry, reader, card)` in `convex/model/retro.ts`, applied in every read function and export: when the **shared pointer's** entry has `cardsVisible: "hidden"` and the card is not the reader's own, return `{ _id, clientId, position, promptId, clusterId, late? }` only, in both attribution modes. The read function takes the stage from the `retros` row, never from a client argument. Rewinding into a hidden entry hides every card again; a second `collect` entry hides again. No role peeks. The in-place toggle `setCardsVisible({ stageId: currentStageId, value })` is `stageFlow`. Tallies use the same mechanism with `tallyVisible`; a voter always sees their own dots.
+The projection is one pure function `projectCard(policy, reader, card)` in `convex/model/retro.ts` — `policy` being the shared pointer's `cardsVisible` and the retro's `attribution`, so a row still carrying an author between the ratchet's first batch and its last is never read as named, applied in every read function and export: when the **shared pointer's** entry has `cardsVisible: "hidden"` and the card is not the reader's own, return `{ _id, clientId, position, promptId, clusterId, late? }` only, in both attribution modes. The read function takes the stage from the `retros` row, never from a client argument. Rewinding into a hidden entry hides every card again; a second `collect` entry hides again. No role peeks. The in-place toggle `setCardsVisible({ stageId: currentStageId, value })` is `stageFlow`. Tallies use the same mechanism with `tallyVisible`; a voter always sees their own dots.
 
 ## 9. Board reads (ADR-0016)
 

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -12,6 +12,7 @@ import { RetroBoard, type BoardViewer } from "@/components/retro/retro-board";
 import { mergeCards, type BoardCard } from "@/components/retro/cards";
 import { readinessOf } from "@/components/retro/readiness";
 import { useCardActions } from "@/components/retro/use-card-actions";
+import { useEditKeys, type EditKeyStore } from "@/components/retro/use-edit-keys";
 import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
 import type { RetroTeam } from "@/components/retro/retro-header";
@@ -64,12 +65,21 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const isTeamMember = team !== undefined && (myTeams ?? []).some((t) => t._id === team._id);
   const canRead = isMember || isTeamMember;
   // The board read takes the reader guard; never subscribe before it passes.
-  // `mine` is the attendee's own text (spec §9); a Team reader has none.
+  // `mine` is the attendee's own text (spec §9); a Team reader has none. It
+  // always carries the keys this browser holds for the room (ADR-0012): an
+  // anonymous retro is answered by them, a named one ignores them, and
+  // neither read waits for the other.
   const board = useQuery(api.retro.board, canRead ? { roomId } : "skip");
-  const mine = useQuery(api.retro.mine, isMember ? { roomId } : "skip");
+  const editKeys = useEditKeys(roomId);
+  const mineArgs = useMemo(() => ({ roomId, editKeys: editKeys.keys }), [roomId, editKeys.keys]);
+  const mine = useQuery(api.retro.mine, isMember ? mineArgs : "skip");
+  // A re-keyed subscription answers a beat later; hold the last answer so
+  // the viewer's own cards never flash to silhouettes in between.
+  const [settledMine, setSettledMine] = useState(mine);
+  if (mine !== undefined && mine !== settledMine) setSettledMine(mine);
   const cards = useMemo<BoardCard[]>(
-    () => (board ? mergeCards(board.cards, mine, membership?._id) : []),
-    [board, mine, membership?._id]
+    () => (board ? mergeCards(board.cards, mine ?? settledMine, membership?._id) : []),
+    [board, mine, settledMine, membership?._id]
   );
   // A Team reader never heartbeats, so their roster reads everyone offline.
   const offlineUsers = useMemo<UserWithPresence[]>(
@@ -136,6 +146,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
       team={team}
       userId={membership!._id}
       myTeams={(myTeams ?? []) as MyTeam[]}
+      editKeys={editKeys}
     />
   );
 }
@@ -148,6 +159,7 @@ interface AttendeeBoardProps {
   team?: RetroTeam;
   userId: Id<"users">;
   myTeams: MyTeam[];
+  editKeys: EditKeyStore;
 }
 
 /**
@@ -157,7 +169,7 @@ interface AttendeeBoardProps {
  * wiring. Its own component so the presence hook — which has no skip —
  * mounts only once a membership exists; a Team reader never heartbeats.
  */
-function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams }: AttendeeBoardProps) {
+function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, editKeys }: AttendeeBoardProps) {
   const { retro } = board;
   const users = useRoomPresence(roomId, userId, roomData.users);
   const setRetroPresence = useSingleFlightMutation(
@@ -168,7 +180,11 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams }
   const setCardsVisible = useMutation(api.retro.setCardsVisible);
   const setTimebox = useMutation(api.retro.setTimebox);
   const { stageFlow, cardManagement, retroSettings } = useRetroPermissions(roomData, userId);
-  const cardActions = useCardActions(roomId, userId);
+  const writer = useMemo(
+    () => ({ userId, anonymous: retro.attribution === "anonymous", editKeys }),
+    [userId, retro.attribution, editKeys]
+  );
+  const cardActions = useCardActions(roomId, writer);
   const currentStageId = currentStageOf(retro).id;
   // The payload is written whole, so an editing write carries readiness
   // too: the viewer's last toggle for this entry, else what their presence
@@ -241,6 +257,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams }
           role={role}
           isOwnerAbsent={roomData.isOwnerAbsent}
           myTeams={myTeams}
+          attribution={retro.attribution}
           settings={{
             name: roomData.room.name,
             joinPolicy: roomData.room.joinPolicy ?? "anyone",

--- a/src/components/retro/card-composer.test.tsx
+++ b/src/components/retro/card-composer.test.tsx
@@ -20,10 +20,12 @@ describe("CardComposer", () => {
     const onSubmit = vi.fn().mockResolvedValue(true);
     const onOpenChange = vi.fn();
     render(
-      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" hidden onSubmit={onSubmit} />
+      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" attribution="named" hidden onSubmit={onSubmit} />
     );
     expect(screen.getByText("Posted as Sam. Your name stays with this card.")).toBeTruthy();
-    expect(screen.getByTestId("reveal-copy").textContent).toContain("Only you can read this for now");
+    expect(screen.getByTestId("reveal-copy").textContent).toBe(
+      "Only you can read this for now. Others can see you've added a card, not what it says. Everyone reads it once cards are revealed."
+    );
     expect(screen.getByTestId("prompt-hint").textContent).toBe("Something worth keeping.");
 
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "p2" } });
@@ -40,7 +42,7 @@ describe("CardComposer", () => {
     const onSubmit = vi.fn().mockResolvedValue(false);
     const onOpenChange = vi.fn();
     render(
-      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" hidden={false} onSubmit={onSubmit} />
+      <CardComposer open onOpenChange={onOpenChange} prompts={prompts} viewerName="Sam" attribution="named" hidden={false} onSubmit={onSubmit} />
     );
     expect(screen.getByTestId("reveal-copy").textContent).toBe("Everyone in the retro can read this now.");
     expect((screen.getByRole("button", { name: "Post card" }) as HTMLButtonElement).disabled).toBe(true);
@@ -51,5 +53,23 @@ describe("CardComposer", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onOpenChange).not.toHaveBeenCalled();
     expect((screen.getByLabelText("Your card") as HTMLTextAreaElement).value).toBe("draft");
+  });
+
+  it("in an anonymous retro reads the anonymous line with the anonymous hidden line stacked, and never the name", () => {
+    render(
+      <CardComposer open onOpenChange={vi.fn()} prompts={prompts} viewerName="Sam" attribution="anonymous" hidden onSubmit={vi.fn()} />
+    );
+    expect(screen.getByTestId("attribution-copy").textContent).toBe(
+      "Anonymous. Your name is not saved with this card, not even for the facilitator. Edit or delete it from this device."
+    );
+    expect(screen.getByTestId("reveal-copy").textContent).toBe(
+      "Only you can read this for now. Everyone reads it once cards are revealed."
+    );
+    expect(screen.queryByText(/Sam/)).toBeNull();
+    cleanup();
+    render(
+      <CardComposer open onOpenChange={vi.fn()} prompts={prompts} viewerName="Sam" attribution="anonymous" hidden={false} onSubmit={vi.fn()} />
+    );
+    expect(screen.getByTestId("reveal-copy").textContent).toBe("Everyone in the retro can read this now.");
   });
 });

--- a/src/components/retro/card-composer.tsx
+++ b/src/components/retro/card-composer.tsx
@@ -14,7 +14,10 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { FormatPrompt } from "@/convex/model/retroFormats";
 import { MAX_CARD_TEXT } from "@/convex/model/retroCards";
+import type { Attribution } from "@/convex/model/retro";
 import {
+  COMPOSER_ANONYMOUS,
+  COMPOSER_HIDDEN_ANONYMOUS,
   COMPOSER_HIDDEN_NAMED,
   COMPOSER_PROMPT_LABEL,
   COMPOSER_SUBMIT,
@@ -31,6 +34,8 @@ interface CardComposerProps {
   prompts: readonly FormatPrompt[];
   /** The viewer's display name for the attribution line (ADR-0012, named). */
   viewerName: string;
+  /** The retro's attribution; the write-time copy says what the storage supports (ADR-0012). */
+  attribution: Attribution;
   /** Whether the shared pointer's entry hides cards right now (ADR-0015). */
   hidden: boolean;
   /** Resolves to whether the card was written; the dialog closes on success. */
@@ -40,10 +45,11 @@ interface CardComposerProps {
 /**
  * The composer (spec §8.1, §19): pick a prompt and read its hint — the one
  * place a hint shows, never on a card or a zone (§6.2) — write, and post.
- * Above the button, the write-time copy: who the card is posted as, and
- * who can read it now.
+ * Above the button, the write-time copy: who the card is posted as (or
+ * that nobody is), and who can read it now; the two lines stack.
  */
-export function CardComposer({ open, onOpenChange, prompts, viewerName, hidden, onSubmit }: CardComposerProps) {
+export function CardComposer({ open, onOpenChange, prompts, viewerName, attribution, hidden, onSubmit }: CardComposerProps) {
+  const anonymous = attribution === "anonymous";
   const ordered = [...prompts].sort((a, b) => a.order - b.order);
   const [promptId, setPromptId] = useState(ordered[0]?.id ?? "");
   const [text, setText] = useState("");
@@ -67,7 +73,9 @@ export function CardComposer({ open, onOpenChange, prompts, viewerName, hidden, 
       <DialogContent data-testid="card-composer">
         <DialogHeader>
           <DialogTitle>{COMPOSER_TITLE}</DialogTitle>
-          <DialogDescription>{postedAs(viewerName)}</DialogDescription>
+          <DialogDescription data-testid="attribution-copy" data-attribution={attribution}>
+            {anonymous ? COMPOSER_ANONYMOUS : postedAs(viewerName)}
+          </DialogDescription>
         </DialogHeader>
         <form
           className="grid gap-4"
@@ -115,7 +123,7 @@ export function CardComposer({ open, onOpenChange, prompts, viewerName, hidden, 
             />
           </div>
           <p data-testid="reveal-copy" data-hidden={String(hidden)} className="text-xs text-muted-foreground">
-            {hidden ? COMPOSER_HIDDEN_NAMED : COMPOSER_VISIBLE}
+            {hidden ? (anonymous ? COMPOSER_HIDDEN_ANONYMOUS : COMPOSER_HIDDEN_NAMED) : COMPOSER_VISIBLE}
           </p>
           <DialogFooter>
             <Button type="submit" disabled={!text.trim() || posting}>

--- a/src/components/retro/edit-keys.test.ts
+++ b/src/components/retro/edit-keys.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The edit-key store (ADR-0012, spec §8.1): keys are kept per room, read
+ * back defensively, and a storage that throws never breaks the board.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  readEditKeys,
+  storageKeyFor,
+  withEditKey,
+  withoutEditKey,
+  writeEditKeys,
+  type KeyStorage,
+} from "./edit-keys";
+
+function memoryStorage(): KeyStorage & { data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem: (k) => data.get(k) ?? null,
+    setItem: (k, v) => void data.set(k, v),
+    removeItem: (k) => void data.delete(k),
+  };
+}
+
+describe("edit keys", () => {
+  it("round-trips per room and removes the entry when the last key goes", () => {
+    const storage = memoryStorage();
+    writeEditKeys(storage, "room-1", { a: "key-a", b: "key-b" });
+    writeEditKeys(storage, "room-2", { c: "key-c" });
+    expect(readEditKeys(storage, "room-1")).toEqual({ a: "key-a", b: "key-b" });
+    expect(readEditKeys(storage, "room-2")).toEqual({ c: "key-c" });
+    expect(readEditKeys(storage, "room-3")).toEqual({});
+
+    writeEditKeys(storage, "room-2", {});
+    expect(storage.data.has(storageKeyFor("room-2"))).toBe(false);
+  });
+
+  it("ignores garbage and non-string values, and tolerates a storage that throws or is absent", () => {
+    const storage = memoryStorage();
+    storage.setItem(storageKeyFor("r"), "{not json");
+    expect(readEditKeys(storage, "r")).toEqual({});
+    storage.setItem(storageKeyFor("r"), JSON.stringify({ a: 1, b: "", c: "ok" }));
+    expect(readEditKeys(storage, "r")).toEqual({ c: "ok" });
+    storage.setItem(storageKeyFor("r"), JSON.stringify(["x"]));
+    expect(readEditKeys(storage, "r")).toEqual({});
+
+    const throwing: KeyStorage = {
+      getItem: () => { throw new Error("blocked"); },
+      setItem: () => { throw new Error("quota"); },
+      removeItem: () => { throw new Error("blocked"); },
+    };
+    expect(readEditKeys(throwing, "r")).toEqual({});
+    expect(() => writeEditKeys(throwing, "r", { a: "k" })).not.toThrow();
+    expect(readEditKeys(undefined, "r")).toEqual({});
+    expect(() => writeEditKeys(undefined, "r", { a: "k" })).not.toThrow();
+  });
+
+  it("remember and forget are pure and keep identity when nothing changes", () => {
+    const keys = { a: "key-a" };
+    expect(withEditKey(keys, "a", "key-a")).toBe(keys);
+    expect(withEditKey(keys, "b", "key-b")).toEqual({ a: "key-a", b: "key-b" });
+    expect(withoutEditKey(keys, "zz")).toBe(keys);
+    expect(withoutEditKey(keys, "a")).toEqual({});
+  });
+});

--- a/src/components/retro/edit-keys.ts
+++ b/src/components/retro/edit-keys.ts
@@ -1,0 +1,59 @@
+/**
+ * The edit-key store (ADR-0012): the keys an anonymous retro handed this
+ * browser, one per card it wrote, kept in `localStorage` under the room id
+ * (spec §8.1). Pure functions over a `Storage`, so the hook is thin and the
+ * store is testable without a DOM. Every access is guarded: storage may be
+ * absent, full or blocked, and the board must still render — then "mine"
+ * is simply empty for this device.
+ */
+
+export type EditKeys = Readonly<Record<string, string>>;
+
+/** A minimal storage: what `localStorage` offers, and what a test fakes. */
+export type KeyStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export const EDIT_KEYS_PREFIX = "retro-edit-keys:";
+
+export const storageKeyFor = (roomId: string) => `${EDIT_KEYS_PREFIX}${roomId}`;
+
+/** The room's keys by `clientId`; empty when there are none or storage is unreadable. */
+export function readEditKeys(storage: KeyStorage | undefined, roomId: string): EditKeys {
+  try {
+    const raw = storage?.getItem(storageKeyFor(roomId));
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    const keys: Record<string, string> = {};
+    for (const [clientId, key] of Object.entries(parsed)) {
+      if (typeof key === "string" && key) keys[clientId] = key;
+    }
+    return keys;
+  } catch {
+    return {};
+  }
+}
+
+/** Writes the room's keys whole; a failure (quota, private mode) is swallowed. */
+export function writeEditKeys(storage: KeyStorage | undefined, roomId: string, keys: EditKeys): void {
+  try {
+    if (Object.keys(keys).length === 0) {
+      storage?.removeItem(storageKeyFor(roomId));
+    } else {
+      storage?.setItem(storageKeyFor(roomId), JSON.stringify(keys));
+    }
+  } catch {
+    // Nothing to do: the key stays in memory for this page's life.
+  }
+}
+
+/** The room's keys with one remembered. */
+export function withEditKey(keys: EditKeys, clientId: string, editKey: string): EditKeys {
+  return keys[clientId] === editKey ? keys : { ...keys, [clientId]: editKey };
+}
+
+/** The room's keys with one forgotten. */
+export function withoutEditKey(keys: EditKeys, clientId: string): EditKeys {
+  if (!(clientId in keys)) return keys;
+  const { [clientId]: _dropped, ...rest } = keys;
+  return rest;
+}

--- a/src/components/retro/optimistic.test.ts
+++ b/src/components/retro/optimistic.test.ts
@@ -89,6 +89,15 @@ describe("applyCreate", () => {
     applyCreate(store, { roomId, clientId: "c1", text: "hi", promptId: "p1", position: { x: 3, y: 4 } }, { userId: me, now: 9 });
     expect(writes).toEqual([]);
   });
+
+  it("in an anonymous retro carries no author and names no writer (ADR-0012)", () => {
+    const { store, value } = fakeStore({ [BOARD]: board("visible"), [MINE]: [] });
+    applyCreate(store, { roomId, clientId: "c1", text: "hi", promptId: "p1", position: { x: 3, y: 4 } }, { userId: me, anonymous: true, now: 9 });
+    expect("authorId" in value<BoardRead>(BOARD).cards[0]).toBe(false);
+    expect(value<BoardRead>(BOARD).writers).toEqual([]);
+    expect("authorId" in value<FullCard[]>(MINE)[0]).toBe(false);
+    expect(value<FullCard[]>(MINE)[0].text).toBe("hi");
+  });
 });
 
 describe("applyMove", () => {

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -24,18 +24,20 @@ export interface CreateCardArgs {
 
 export interface MoveCardsArgs {
   roomId: Id<"rooms">;
-  moves: { clientId: string; position: { x: number; y: number } }[];
+  moves: { clientId: string; position: { x: number; y: number }; editKey?: string }[];
 }
 
 export interface UpdateCardArgs {
   roomId: Id<"rooms">;
   clientId: string;
   text: string;
+  editKey?: string;
 }
 
 export interface DeleteCardArgs {
   roomId: Id<"rooms">;
   clientId: string;
+  editKey?: string;
 }
 
 function patchBoard(store: OptimisticLocalStore, patch: (board: BoardRead) => BoardRead): void {
@@ -52,11 +54,15 @@ function patchMine(store: OptimisticLocalStore, patch: (mine: FullCard[]) => Ful
   }
 }
 
-/** A create: the row as the server will write it, with a placeholder id until the result lands. */
+/**
+ * A create: the row as the server will write it, with a placeholder id
+ * until the result lands. In an anonymous retro the card carries no author
+ * and the writer set stays empty, as the server's read will (ADR-0012).
+ */
 export function applyCreate(
   store: OptimisticLocalStore,
   args: CreateCardArgs,
-  viewer: { userId: Id<"users">; now?: number }
+  viewer: { userId: Id<"users">; anonymous?: boolean; now?: number }
 ): void {
   const now = viewer.now ?? Date.now();
   const full: FullCard = {
@@ -65,7 +71,7 @@ export function applyCreate(
     position: args.position,
     promptId: args.promptId,
     text: args.text,
-    authorId: viewer.userId,
+    ...(viewer.anonymous ? {} : { authorId: viewer.userId }),
     createdAt: now,
     updatedAt: now,
     committedAt: now,
@@ -76,9 +82,10 @@ export function applyCreate(
     const card: ProjectedCard = hidden
       ? { _id: full._id, clientId: full.clientId, position: full.position, promptId: full.promptId }
       : full;
-    const writers = board.writers.includes(viewer.userId)
-      ? board.writers
-      : [...board.writers, viewer.userId];
+    const writers =
+      viewer.anonymous || board.writers.includes(viewer.userId)
+        ? board.writers
+        : [...board.writers, viewer.userId];
     return { ...board, cards: [...board.cards, card], writers };
   });
   patchMine(store, (mine) =>

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -277,6 +277,7 @@ export function RetroBoard({
           onOpenChange={setComposing}
           prompts={retro.format.prompts}
           viewerName={viewer.name}
+          attribution={retro.attribution}
           hidden={currentStage.cardsVisible === "hidden"}
           onSubmit={onSubmitCard}
         />

--- a/src/components/retro/retro-menu.test.tsx
+++ b/src/components/retro/retro-menu.test.tsx
@@ -139,6 +139,40 @@ describe("RetroMenu — delete", () => {
   });
 });
 
+describe("RetroMenu — the ratchet (ADR-0012)", () => {
+  it("the owner of a named retro confirms with the register copy and ratchets", async () => {
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} attribution="named" />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Make anonymous…" }));
+    const dialog = within(screen.getByRole("alertdialog"));
+    expect(dialog.getByText("Make this retro anonymous?")).toBeTruthy();
+    expect(dialog.getByText("Every author is removed permanently and this cannot be undone.")).toBeTruthy();
+
+    fireEvent.click(dialog.getByRole("button", { name: "Make anonymous" }));
+    await waitFor(() => expect(calledWith("retro:ratchet")).toEqual([{ roomId }]));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toasts.at(-1)).toEqual({ kind: "success", message: "This retro is now anonymous" });
+  });
+
+  it("is absent once the retro is anonymous, and disabled for a non-owner with the owner-only copy", () => {
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} attribution="anonymous" />);
+    expect(screen.queryByRole("menuitem", { name: "Make anonymous…" })).toBeNull();
+    cleanup();
+    render(<RetroMenu roomId={roomId} role="facilitator" isOwnerAbsent={false} myTeams={[]} attribution="named" />);
+    const item = screen.getByRole("menuitem", { name: "Make anonymous…" }) as HTMLButtonElement;
+    expect(item.disabled).toBe(true);
+    expect(item.title).toBe("Only the owner can do this.");
+  });
+
+  it("a refused ratchet keeps the confirmation open with the server's copy", async () => {
+    mocks.fail["retro:ratchet"] = "Room owner has left.";
+    render(<RetroMenu roomId={roomId} role="owner" isOwnerAbsent={false} myTeams={[]} attribution="named" />);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Make anonymous…" }));
+    fireEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Make anonymous" }));
+    await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: "Room owner has left." }));
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+});
+
 describe("RetroMenu — claim", () => {
   it("a team admin who is not the owner can claim; the server's refusal surfaces", async () => {
     mocks.fail["retro:claim"] = "The owner is still here — ask them to transfer ownership.";

--- a/src/components/retro/retro-menu.tsx
+++ b/src/components/retro/retro-menu.tsx
@@ -30,6 +30,13 @@ import {
   DELETE_MENU_ITEM,
   DELETE_TITLE,
   DELETING_BUTTON,
+  RATCHET_BUTTON,
+  RATCHET_DESCRIPTION,
+  RATCHET_FAILED,
+  RATCHET_MENU_ITEM,
+  RATCHET_TITLE,
+  RATCHETING_BUTTON,
+  RETRO_ANONYMOUS,
   RETRO_DELETED,
   SETTINGS_MENU_ITEM,
   TEAM_LABEL,
@@ -63,6 +70,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/lib/toast";
+import type { Attribution } from "@/convex/model/retro";
 import type { RetroTeam } from "./retro-header";
 import { RetroSettingsDialog } from "./retro-settings-dialog";
 
@@ -82,6 +90,8 @@ interface RetroMenuProps {
   isOwnerAbsent: boolean;
   /** The viewer's Teams; empty for an anonymous account. */
   myTeams: MyTeam[];
+  /** The retro's attribution (ADR-0012); the ratchet item shows while it is `named`, absent hides it. */
+  attribution?: Attribution;
   /** What the settings dialog edits (spec §6.4); absent hides the item. */
   settings?: {
     name: string;
@@ -93,22 +103,26 @@ interface RetroMenuProps {
 
 /**
  * The board header's menu (spec §4.3, §5, §15.2): the owner's *Delete
- * retro* behind the counted confirmation; *Claim ownership* for a team
- * admin who is not the owner (the server decides `owner-present`); *Keep
- * with a team…* for the owner of a teamless retro who has a Team to give it
- * to; *Retro settings…* opens the settings dialog (spec §6.4), where a
- * denied viewer reads the denial rather than finding the door gone. Every
- * item is a mutation on room-owned state, so the menu renders only for an
- * attendee.
+ * retro* behind the counted confirmation; the owner's *Make anonymous…*
+ * behind the irreversibility confirmation, gone once pressed (ADR-0012);
+ * *Claim ownership* for a team admin who is not the owner (the server
+ * decides `owner-present`); *Keep with a team…* for the owner of a
+ * teamless retro who has a Team to give it to; *Retro settings…* opens the
+ * settings dialog (spec §6.4), where a denied viewer reads the denial
+ * rather than finding the door gone. Every item is a mutation on
+ * room-owned state, so the menu renders only for an attendee.
  */
-export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings }: RetroMenuProps) {
+export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, attribution, settings }: RetroMenuProps) {
   const router = useRouter();
   const remove = useMutation(api.retro.remove);
+  const ratchet = useMutation(api.retro.ratchet);
   const claim = useMutation(api.retro.claim);
   const adopt = useMutation(api.retro.adoptIntoTeam);
 
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmRatchet, setConfirmRatchet] = useState(false);
+  const [isRatcheting, setIsRatcheting] = useState(false);
   const [adoptOpen, setAdoptOpen] = useState(false);
   const [adoptTeamId, setAdoptTeamId] = useState<string>("");
   const [isAdopting, setIsAdopting] = useState(false);
@@ -121,6 +135,10 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings
   // category levels, so the retro defaults stand in for the room's.
   const deleteDecision = resolve(
     { kind: "relationship", verb: "delete" },
+    { actorRole: role, permissions: DEFAULT_RETRO_PERMISSIONS, ownerAbsent: isOwnerAbsent, ownerInTeam: false }
+  );
+  const ratchetDecision = resolve(
+    { kind: "relationship", verb: "ratchet" },
     { actorRole: role, permissions: DEFAULT_RETRO_PERMISSIONS, ownerAbsent: isOwnerAbsent, ownerInTeam: false }
   );
   const myTeamRole = team ? myTeams.find((t) => t._id === team._id)?.role : undefined;
@@ -139,6 +157,19 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings
     } catch (error) {
       toast.error(error instanceof Error ? error.message : DELETE_FAILED);
       setIsDeleting(false);
+    }
+  };
+
+  const handleRatchet = async () => {
+    setIsRatcheting(true);
+    try {
+      await ratchet({ roomId });
+      setConfirmRatchet(false);
+      toast.success(RETRO_ANONYMOUS);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : RATCHET_FAILED);
+    } finally {
+      setIsRatcheting(false);
     }
   };
 
@@ -182,6 +213,15 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings
             <DropdownMenuItem onClick={() => setAdoptOpen(true)}>{ADOPT_MENU_ITEM}</DropdownMenuItem>
           )}
           {canClaim && <DropdownMenuItem onClick={handleClaim}>{CLAIM_MENU_ITEM}</DropdownMenuItem>}
+          {attribution === "named" && (
+            <DropdownMenuItem
+              disabled={!ratchetDecision.allowed}
+              title={ratchetDecision.allowed ? undefined : ratchetDecision.message}
+              onClick={() => setConfirmRatchet(true)}
+            >
+              {RATCHET_MENU_ITEM}
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             variant="destructive"
             disabled={!deleteDecision.allowed}
@@ -209,6 +249,21 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, settings
               disabled={isDeleting || counts === undefined}
             >
               {isDeleting ? DELETING_BUTTON : DELETE_BUTTON}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmRatchet} onOpenChange={(open) => !isRatcheting && setConfirmRatchet(open)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{RATCHET_TITLE}</AlertDialogTitle>
+            <AlertDialogDescription>{RATCHET_DESCRIPTION}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRatcheting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleRatchet} disabled={isRatcheting}>
+              {isRatcheting ? RATCHETING_BUTTON : RATCHET_BUTTON}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/retro/use-card-actions.test.tsx
+++ b/src/components/retro/use-card-actions.test.tsx
@@ -42,6 +42,19 @@ const roomId = "room1" as Id<"rooms">;
 const userId = "user1" as Id<"users">;
 const card = { clientId: "c-1", text: "hi", promptId: "p1", position: { x: 1, y: 2 } };
 
+/** An in-memory edit-key store with the hook's shape. */
+function fakeKeys(initial: Record<string, string> = {}) {
+  const keys = { ...initial };
+  return {
+    keys: Object.values(keys),
+    keyOf: (clientId: string) => keys[clientId],
+    remember: vi.fn((clientId: string, editKey: string) => void (keys[clientId] = editKey)),
+    forget: vi.fn((clientId: string) => void delete keys[clientId]),
+    held: keys,
+  };
+}
+const named = () => ({ userId, anonymous: false, editKeys: fakeKeys() });
+
 beforeEach(() => {
   vi.useFakeTimers();
   mocks.calls.length = 0;
@@ -53,24 +66,77 @@ afterEach(() => vi.useRealTimers());
 describe("useCardActions.create", () => {
   it("retries a transient failure with the same clientId and resolves true", async () => {
     mocks.outcomes.push(() => Promise.reject(new Error("network")), () => Promise.resolve("id-1"));
-    const { result } = renderHook(() => useCardActions(roomId, userId));
+    const writer = named();
+    const { result } = renderHook(() => useCardActions(roomId, writer));
     const outcome = result.current.create(card);
     await vi.advanceTimersByTimeAsync(400);
     expect(await outcome).toBe(true);
     expect(mocks.calls.map((c) => c.fn)).toEqual(["retro.createCard", "retro.createCard"]);
     expect(mocks.calls.map((c) => (c.args as { clientId: string }).clientId)).toEqual(["c-1", "c-1"]);
     expect(mocks.toast.error).not.toHaveBeenCalled();
+    expect(writer.editKeys.remember).not.toHaveBeenCalled();
   });
 
   it("does not retry a refusal, toasts its reason and resolves false", async () => {
     mocks.outcomes.push(() =>
       Promise.reject(new ConvexError({ code: "forbidden", message: "Not in a named retro" }))
     );
-    const { result } = renderHook(() => useCardActions(roomId, userId));
+    const { result } = renderHook(() => useCardActions(roomId, named()));
     const outcome = result.current.create(card);
     await vi.advanceTimersByTimeAsync(2000);
     expect(await outcome).toBe(false);
     expect(mocks.calls).toHaveLength(1);
     expect(mocks.toast.error).toHaveBeenCalledWith("Not in a named retro");
+  });
+});
+
+describe("useCardActions in an anonymous retro (ADR-0012)", () => {
+  it("remembers the key a create returns, once, and presents it on edit, move and delete", async () => {
+    mocks.outcomes.push(() => Promise.resolve({ cardId: "id-1", editKey: "key-1" }));
+    const writer = { userId, anonymous: true, editKeys: fakeKeys({ "c-0": "key-0" }) };
+    const { result } = renderHook(() => useCardActions(roomId, writer));
+
+    expect(await result.current.create(card)).toBe(true);
+    expect(writer.editKeys.remember).toHaveBeenCalledWith("c-1", "key-1");
+
+    mocks.outcomes.push(() => Promise.resolve(), () => Promise.resolve(), () => Promise.resolve());
+    await result.current.editText("c-1", "edited");
+    result.current.move([
+      { clientId: "c-0", position: { x: 1, y: 1 } },
+      { clientId: "c-1", position: { x: 2, y: 2 } },
+      { clientId: "other", position: { x: 3, y: 3 } },
+    ]);
+    result.current.remove("c-0");
+    await vi.advanceTimersByTimeAsync(10);
+
+    const argsOf = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c) => c.args);
+    expect(argsOf("retro.updateCard")).toEqual([{ roomId, clientId: "c-1", text: "edited", editKey: "key-1" }]);
+    expect(argsOf("retro.moveCards")).toEqual([
+      {
+        roomId,
+        moves: [
+          { clientId: "c-0", position: { x: 1, y: 1 }, editKey: "key-0" },
+          { clientId: "c-1", position: { x: 2, y: 2 }, editKey: "key-1" },
+          { clientId: "other", position: { x: 3, y: 3 } },
+        ],
+      },
+    ]);
+    expect(argsOf("retro.deleteCard")).toEqual([{ roomId, clientId: "c-0", editKey: "key-0" }]);
+    expect(writer.editKeys.forget).toHaveBeenCalledWith("c-0");
+  });
+
+  it("a create that returns no key remembers nothing, and a failed delete keeps the key", async () => {
+    mocks.outcomes.push(
+      () => Promise.resolve({ cardId: "id-1" }),
+      () => Promise.reject(new ConvexError({ code: "forbidden", message: "Not yours" }))
+    );
+    const writer = { userId, anonymous: true, editKeys: fakeKeys({ "c-1": "key-1" }) };
+    const { result } = renderHook(() => useCardActions(roomId, writer));
+    expect(await result.current.create(card)).toBe(true);
+    expect(writer.editKeys.remember).not.toHaveBeenCalled();
+    result.current.remove("c-1");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(writer.editKeys.forget).not.toHaveBeenCalled();
+    expect(mocks.toast.error).toHaveBeenCalledWith("Not yours");
   });
 });

--- a/src/components/retro/use-card-actions.ts
+++ b/src/components/retro/use-card-actions.ts
@@ -10,6 +10,7 @@ import { toast } from "@/lib/toast";
 import { CARD_ACT_FAILED } from "@/convex/retroCopy";
 import { applyCreate, applyDelete, applyMove, applyTextEdit, type MoveCardsArgs } from "./optimistic";
 import type { Move } from "./use-hand";
+import type { EditKeyStore } from "./use-edit-keys";
 
 export interface CardActions {
   /** Resolves to whether the card was written; the same `clientId` rides every retry. */
@@ -29,13 +30,23 @@ function surface(error: unknown, fallback: string): void {
 /** The batch key: the sorted id set (ADR-0022). */
 const moveKey = (args: MoveCardsArgs) => args.moves.map((m) => m.clientId).sort().join("\n");
 
+/** Who is writing: their id, and in an anonymous retro the keys this browser holds (ADR-0012). */
+export interface CardWriter {
+  userId: Id<"users">;
+  anonymous: boolean;
+  editKeys: EditKeyStore;
+}
+
 /**
  * The card writes (ADR-0022, spec §10.6 to §10.8): each mutation carries its
  * optimistic function, moves and text edits are keyed single-flight, and a
  * failure is retried with backoff while a refusal drops the value at once
- * and toasts its reason.
+ * and toasts its reason. In an anonymous retro a create's returned key is
+ * remembered, and every edit, move and delete of a keyed card presents it
+ * (ADR-0012); a named retro never sends one.
  */
-export function useCardActions(roomId: Id<"rooms">, userId: Id<"users">): CardActions {
+export function useCardActions(roomId: Id<"rooms">, writer: CardWriter): CardActions {
+  const { userId, anonymous, editKeys } = writer;
   const createCard = useMutation(api.retro.createCard);
   const moveCards = useMutation(api.retro.moveCards);
   const updateCard = useMutation(api.retro.updateCard);
@@ -43,8 +54,8 @@ export function useCardActions(roomId: Id<"rooms">, userId: Id<"users">): CardAc
 
   const optimisticCreate = useMemo(
     () =>
-      createCard.withOptimisticUpdate((store, args) => applyCreate(store, args, { userId })),
-    [createCard, userId]
+      createCard.withOptimisticUpdate((store, args) => applyCreate(store, args, { userId, anonymous })),
+    [createCard, userId, anonymous]
   );
   const optimisticMove = useMemo(() => moveCards.withOptimisticUpdate(applyMove), [moveCards]);
   const optimisticUpdate = useMemo(() => updateCard.withOptimisticUpdate(applyTextEdit), [updateCard]);
@@ -53,32 +64,44 @@ export function useCardActions(roomId: Id<"rooms">, userId: Id<"users">): CardAc
   const moveInFlight = useSingleFlightMutation(optimisticMove, moveKey);
   const updateInFlight = useSingleFlightMutation(optimisticUpdate, (args) => args.clientId);
 
+  /** The `editKey` argument for a card: the key this browser holds, in an anonymous retro only. */
+  const editKeyArg = useCallback(
+    (clientId: string): { editKey?: string } => {
+      const editKey = anonymous ? editKeys.keyOf(clientId) : undefined;
+      return editKey === undefined ? {} : { editKey };
+    },
+    [anonymous, editKeys]
+  );
+
   const create = useCallback<CardActions["create"]>(
     async (args) => {
       try {
-        await retryWrite(() => optimisticCreate({ roomId, ...args }));
+        const result = await retryWrite(() => optimisticCreate({ roomId, ...args }));
+        // The key comes back exactly once (ADR-0012); keep it before the
+        // result lands, so `mine` presents it on its next read.
+        if (result?.editKey) editKeys.remember(args.clientId, result.editKey);
         return true;
       } catch (error) {
         surface(error, CARD_ACT_FAILED);
         return false;
       }
     },
-    [optimisticCreate, roomId]
+    [optimisticCreate, roomId, editKeys]
   );
 
   const move = useCallback<CardActions["move"]>(
     (moves) => {
-      void retryWrite(() => moveInFlight({ roomId, moves })).catch((error) =>
-        surface(error, CARD_ACT_FAILED)
-      );
+      void retryWrite(() =>
+        moveInFlight({ roomId, moves: moves.map((m) => ({ ...m, ...editKeyArg(m.clientId) })) })
+      ).catch((error) => surface(error, CARD_ACT_FAILED));
     },
-    [moveInFlight, roomId]
+    [moveInFlight, roomId, editKeyArg]
   );
 
   const editText = useCallback<CardActions["editText"]>(
     async (clientId, text) => {
       try {
-        await updateInFlight({ roomId, clientId, text });
+        await updateInFlight({ roomId, clientId, text, ...editKeyArg(clientId) });
       } catch (error) {
         // A refusal is final and says why; a failure waits for the next
         // keystroke or blur (the draft hook retries), so it is not toasted.
@@ -87,16 +110,16 @@ export function useCardActions(roomId: Id<"rooms">, userId: Id<"users">): CardAc
         throw error;
       }
     },
-    [updateInFlight, roomId]
+    [updateInFlight, roomId, editKeyArg]
   );
 
   const remove = useCallback<CardActions["remove"]>(
     (clientId) => {
-      void retryWrite(() => optimisticDelete({ roomId, clientId })).catch((error) =>
-        surface(error, CARD_ACT_FAILED)
-      );
+      void retryWrite(() => optimisticDelete({ roomId, clientId, ...editKeyArg(clientId) }))
+        .then(() => editKeys.forget(clientId))
+        .catch((error) => surface(error, CARD_ACT_FAILED));
     },
-    [optimisticDelete, roomId]
+    [optimisticDelete, roomId, editKeyArg, editKeys]
   );
 
   return useMemo(() => ({ create, move, editText, remove }), [create, move, editText, remove]);

--- a/src/components/retro/use-edit-keys.test.tsx
+++ b/src/components/retro/use-edit-keys.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * The edit-key hook (ADR-0012, spec §8.1): the client stores and presents
+ * keys per room — a key remembered survives a remount, a different room
+ * presents none of them, and a forgotten key is gone from storage.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useEditKeys } from "./use-edit-keys";
+import { storageKeyFor } from "./edit-keys";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("useEditKeys", () => {
+  it("remembers a key under the room, presents it, and reads it back after a remount", () => {
+    const { result, unmount } = renderHook(() => useEditKeys("room-1"));
+    expect(result.current.keys).toEqual([]);
+    act(() => result.current.remember("c1", "key-1"));
+    act(() => result.current.remember("c2", "key-2"));
+    expect(result.current.keys).toEqual(["key-1", "key-2"]);
+    expect(result.current.keyOf("c1")).toBe("key-1");
+    expect(result.current.keyOf("zz")).toBeUndefined();
+    expect(JSON.parse(localStorage.getItem(storageKeyFor("room-1"))!)).toEqual({ c1: "key-1", c2: "key-2" });
+    unmount();
+
+    const again = renderHook(() => useEditKeys("room-1"));
+    expect(again.result.current.keys).toEqual(["key-1", "key-2"]);
+    expect(again.result.current.keyOf("c2")).toBe("key-2");
+  });
+
+  it("keys are per room: another room presents none, and a room change re-reads", () => {
+    localStorage.setItem(storageKeyFor("room-1"), JSON.stringify({ c1: "key-1" }));
+    const { result, rerender } = renderHook(({ roomId }) => useEditKeys(roomId), {
+      initialProps: { roomId: "room-2" },
+    });
+    expect(result.current.keys).toEqual([]);
+    rerender({ roomId: "room-1" });
+    expect(result.current.keys).toEqual(["key-1"]);
+  });
+
+  it("forget drops the key from state and storage; the presented list is stable while unchanged", () => {
+    const { result, rerender } = renderHook(() => useEditKeys("room-1"));
+    act(() => result.current.remember("c1", "key-1"));
+    const list = result.current.keys;
+    rerender();
+    expect(result.current.keys).toBe(list);
+    act(() => result.current.forget("c1"));
+    expect(result.current.keys).toEqual([]);
+    expect(localStorage.getItem(storageKeyFor("room-1"))).toBeNull();
+  });
+});

--- a/src/components/retro/use-edit-keys.ts
+++ b/src/components/retro/use-edit-keys.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { readEditKeys, withEditKey, withoutEditKey, writeEditKeys, type EditKeys } from "./edit-keys";
+
+/** What the board holds of its edit keys: the set to present, and the remember/forget pair. */
+export interface EditKeyStore {
+  /** Every key this browser holds for the room, for `retro.mine` (spec §9). Stable while unchanged. */
+  keys: string[];
+  /** The key for one card, to ride its edit, move or delete (ADR-0012). */
+  keyOf: (clientId: string) => string | undefined;
+  /** Keep the key a create returned; the store writes through to storage. */
+  remember: (clientId: string, editKey: string) => void;
+  /** Drop a deleted card's key. */
+  forget: (clientId: string) => void;
+}
+
+function storageOf(): Storage | undefined {
+  try {
+    return typeof window === "undefined" ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The edit keys of one room (ADR-0012, spec §8.1): read from `localStorage`
+ * once per room, held in state, and written through whenever they change.
+ * Keyed by room, so a browser that wrote in two retros presents each its
+ * own. Renders fine with no storage at all — then the keys live for the
+ * page.
+ */
+export function useEditKeys(roomId: string): EditKeyStore {
+  const [byRoom, setByRoom] = useState<{ roomId: string; keys: EditKeys }>(() => ({
+    roomId,
+    keys: readEditKeys(storageOf(), roomId),
+  }));
+  // A room change re-reads; state adjusted during render, no effect.
+  if (byRoom.roomId !== roomId) {
+    setByRoom({ roomId, keys: readEditKeys(storageOf(), roomId) });
+  }
+  const keys = byRoom.roomId === roomId ? byRoom.keys : readEditKeys(storageOf(), roomId);
+
+  // The write-through: storage follows state, so the updaters stay pure.
+  // Writing back what was just read is a no-op by value.
+  useEffect(() => {
+    writeEditKeys(storageOf(), byRoom.roomId, byRoom.keys);
+  }, [byRoom]);
+
+  const update = useCallback(
+    (change: (keys: EditKeys) => EditKeys) => {
+      setByRoom((current) => {
+        // A change addressed to a room the store has already left is dropped.
+        if (current.roomId !== roomId) return current;
+        const next = change(current.keys);
+        return next === current.keys ? current : { roomId, keys: next };
+      });
+    },
+    [roomId]
+  );
+
+  const remember = useCallback<EditKeyStore["remember"]>(
+    (clientId, editKey) => update((current) => withEditKey(current, clientId, editKey)),
+    [update]
+  );
+  const forget = useCallback<EditKeyStore["forget"]>(
+    (clientId) => update((current) => withoutEditKey(current, clientId)),
+    [update]
+  );
+  const keyOf = useCallback<EditKeyStore["keyOf"]>((clientId) => keys[clientId], [keys]);
+  const list = useMemo(() => Object.values(keys), [keys]);
+
+  return useMemo(() => ({ keys: list, keyOf, remember, forget }), [list, keyOf, remember, forget]);
+}


### PR DESCRIPTION
Closes #292. Part of the retro map #253.

## What

**Backend**
- `convex/model/editKeys.ts` (new): mint a 128-bit key, SHA-256 it, match presented keys. `createCard` in an anonymous retro stores only the hash and returns `{ cardId, editKey }` once; a retried create returns the row with no key (the plaintext is never stored, so it can only be handed out once). A named retro stores `authorId` — exactly one of the two per row (ADR-0012).
- Own-card rights (`cardRights`): `authorId` in a named retro, a presented key in an anonymous one; `updateCard`, `deleteCard` and each `moveCards` item take an optional `editKey`. A card with neither (ratchet-stripped) is touchable only under `cardManagement`; a batch mixing owned and unowned cards is refused whole with `forbidden`.
- `projectCard` now takes a policy (the shared pointer's `cardsVisible` plus the retro's `attribution`) so a row still carrying an author between the ratchet's first batch and its last is never read as named. `retro.mine({ roomId, editKeys? })` answers by author or by presented keys (bounded `by_room` read, hashes matched in JS — no hash index exists in the spec's schema). `board.writers` stays empty under anonymous, so the roster's count from #291 takes over.
- `retro.ratchet` (owner-only verb, `requireCan`): flips the flag and strips the first 500 authors in the pressing mutation, then continues through `maintenance.stripCardAuthorsChunk` (self-scheduling, resumed inclusively by `_creationTime`). Bumps the activity chokepoint once; the continuation never does. Second press is a no-op; a poker room refuses with `missing`.

**Client**
- `edit-keys.ts` + `use-edit-keys.ts` (new): keys per room in `localStorage`, read defensively, written through from an effect. `useCardActions` remembers a create's key, presents it on edit/move/delete, forgets it on delete.
- `retro.mine` always carries the browser's keys and re-keys as they change; the last answer is held so own cards never flash to silhouettes in the gap.
- Composer reads the §19 anonymous line with the anonymous hidden line stacked. Header menu gains **Make anonymous…** (owner-only, disabled with the owner copy otherwise) behind "Make this retro anonymous? Every author is removed permanently and this cannot be undone." Gone once the retro is anonymous.
- `docs/spec/retro.md` §8.3: `projectCard` signature updated to the policy form.

## Verification

- convex-test (`retroAttribution.test.ts`, 12 cases): exactly one of `authorId` / `editKeyHash`; plaintext returned once and never in the row; wrong or missing key is `forbidden`; mixed batch refused whole and a `cardManagement` holder needs no key; ADR-0015 projection cases in anonymous mode; a 1200-card ratchet flips the flag before the continuation and strips everything after draining the scheduler; second ratchet schedules nothing; participant refused; stripped card touchable only under `cardManagement`; pressing mutation bumps the clock, continuation leaves it stale. `roomActivity.test.ts` gains the ratchet bump.
- jsdom/node: key store round-trips per room and tolerates a throwing storage; hook survives a remount and a room change; actions attach keys and forget on delete; optimistic create carries no author under anonymous; composer copy; menu ratchet flow, absence once anonymous, disabled for non-owners.
- By hand against the dev deployment (proves `crypto.subtle.digest` in the real runtime): named card → ratchet → chip gone, card a silhouette to its keyless writer; anonymous card posted, key in `localStorage`, still editable after a reload.
- Full suite 876 passed; `ts:check` and lint clean.

## Notes for review

- Anonymous `mine` re-runs on any card write in the room (bounded to 2000 rows). Named mode keeps `by_room_author`.
- Mid-ratchet an author keeps own-card rights on a not-yet-stripped row for a beat; no read shows the name in that window (commented in `cardRights`).
- A create whose first attempt committed but whose response was lost would return no key on the retry; Convex's client does not re-send a confirmed mutation, so this needs a server-side error after commit to occur.
- Votes (#294) will add the assertion that the ratchet never strips a voter.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd
