### PR TITLE
feat(retro): clusters — form, membership, rename, merge, dissolve, tidy and the label chip (#293)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -42,6 +42,7 @@ import type * as model_permissions from "../model/permissions.js";
 import type * as model_refusal from "../model/refusal.js";
 import type * as model_retro from "../model/retro.js";
 import type * as model_retroCards from "../model/retroCards.js";
+import type * as model_retroClusters from "../model/retroClusters.js";
 import type * as model_retroFormats from "../model/retroFormats.js";
 import type * as model_roles from "../model/roles.js";
 import type * as model_roomAggregate from "../model/roomAggregate.js";
@@ -110,6 +111,7 @@ declare const fullApi: ApiFromModules<{
   "model/refusal": typeof model_refusal;
   "model/retro": typeof model_retro;
   "model/retroCards": typeof model_retroCards;
+  "model/retroClusters": typeof model_retroClusters;
   "model/retroFormats": typeof model_retroFormats;
   "model/roles": typeof model_roles;
   "model/roomAggregate": typeof model_roomAggregate;

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -344,7 +344,7 @@ export function projectCard(
 }
 
 /** How many cards and clusters one board read carries; a retro never approaches it. */
-const MAX_BOARD_ROWS = 2000;
+export const MAX_BOARD_ROWS = 2000;
 
 export interface BoardRead {
   retro: Doc<"retros">;

--- a/convex/model/retroClusters.ts
+++ b/convex/model/retroClusters.ts
@@ -1,0 +1,202 @@
+import { MutationCtx, QueryCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import { resolveRoomAction } from "./auth";
+import { updateRoomActivity } from "./rooms";
+import { refusal } from "./refusal";
+import { getCardByClientId, type CardActor } from "./retroCards";
+import {
+  CARD_NOT_FOUND,
+  CLUSTER_NAME_REQUIRED,
+  CLUSTER_NAME_TOO_LONG,
+  CLUSTER_NOT_FOUND,
+  CLUSTER_SELECTION_REQUIRED,
+  MERGE_INTO_SELF,
+  nextGroupName,
+} from "../retroCopy";
+
+/**
+ * Clusters (spec §10.3, ADR-0011, ADR-0016): a cluster is an identity, not
+ * a location. The row is a name and nothing else — no position, no member
+ * list, no count — and membership is the `clusterId` on each card. Forming
+ * one and changing membership is open to every attendee (spec §4.2 keeps
+ * it out of the config); rename, merge and dissolve are `cardManagement`.
+ * No member ever moves here: tidy is the client computing positions and
+ * calling the one move batch. Every act is correct in every stage
+ * (ADR-0010) and bumps the activity chokepoint (spec §14).
+ *
+ * Dots and action sources arrive with #294 and #296: merge re-points dots,
+ * dissolve deletes them behind the confirmation and nulls an action's
+ * source. A cluster emptied by a membership change is removed as a dissolve
+ * of nothing; those tickets treat it as one.
+ */
+
+export const MAX_CLUSTER_NAME = 80;
+
+async function requireCluster(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  clusterId: Id<"retroClusters">
+): Promise<Doc<"retroClusters">> {
+  const cluster = await ctx.db.get(clusterId);
+  if (!cluster || cluster.roomId !== roomId) {
+    throw refusal("missing", CLUSTER_NOT_FOUND);
+  }
+  return cluster;
+}
+
+/** The room's cards named by the selection, each a `missing` refusal when gone. */
+async function requireCards(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  clientIds: readonly string[]
+): Promise<Doc<"retroCards">[]> {
+  if (clientIds.length === 0) {
+    throw refusal("forbidden", CLUSTER_SELECTION_REQUIRED);
+  }
+  const unique = [...new Set(clientIds)];
+  return Promise.all(
+    unique.map(async (clientId) => {
+      const card = await getCardByClientId(ctx, roomId, clientId);
+      if (!card) throw refusal("missing", CARD_NOT_FOUND);
+      return card;
+    })
+  );
+}
+
+async function membersOf(ctx: QueryCtx, clusterId: Id<"retroClusters">): Promise<Doc<"retroCards">[]> {
+  return ctx.db
+    .query("retroCards")
+    .withIndex("by_cluster", (q) => q.eq("clusterId", clusterId))
+    .collect();
+}
+
+/** The `cardManagement` decision as a `forbidden` refusal the client can tell from a failure. */
+async function requireCardManagement(ctx: QueryCtx, room: Doc<"rooms">, actor: CardActor): Promise<void> {
+  const { decision } = await resolveRoomAction(ctx, actor.user, actor.membership, room, {
+    kind: "category",
+    category: "cardManagement",
+  });
+  if (!decision.allowed) {
+    throw refusal("forbidden", decision.message);
+  }
+}
+
+function validateClusterName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) throw refusal("forbidden", CLUSTER_NAME_REQUIRED);
+  if (trimmed.length > MAX_CLUSTER_NAME) throw refusal("forbidden", CLUSTER_NAME_TOO_LONG);
+  return trimmed;
+}
+
+/** The default name at formation, by the rule the copy register keeps. */
+async function defaultName(ctx: QueryCtx, roomId: Id<"rooms">): Promise<string> {
+  return nextGroupName(
+    await ctx.db
+      .query("retroClusters")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+/**
+ * Point cards at a cluster (or at none), then drop any cluster the change
+ * emptied. Positions are untouched.
+ */
+async function repoint(
+  ctx: MutationCtx,
+  cards: readonly Doc<"retroCards">[],
+  clusterId: Id<"retroClusters"> | undefined
+): Promise<void> {
+  const vacated = new Set<Id<"retroClusters">>();
+  for (const card of cards) {
+    if (card.clusterId !== undefined && card.clusterId !== clusterId) vacated.add(card.clusterId);
+  }
+  await Promise.all(
+    cards.map((card) =>
+      ctx.db.patch(card._id, clusterId === undefined ? { clusterId: undefined } : { clusterId })
+    )
+  );
+  for (const id of vacated) {
+    if ((await membersOf(ctx, id)).length === 0) await ctx.db.delete(id);
+  }
+}
+
+/**
+ * Form a cluster from a selection (everyone): the row named "Group {n}",
+ * every selected card pointed at it. A card already in another cluster is
+ * re-pointed; members never move.
+ */
+export async function formCluster(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clientIds: string[] }
+): Promise<Id<"retroClusters">> {
+  const cards = await requireCards(ctx, args.room._id, args.clientIds);
+  const clusterId = await ctx.db.insert("retroClusters", {
+    roomId: args.room._id,
+    name: await defaultName(ctx, args.room._id),
+    createdAt: Date.now(),
+  });
+  await repoint(ctx, cards, clusterId);
+  await updateRoomActivity(ctx, args.room);
+  return clusterId;
+}
+
+/** Add cards to a cluster (everyone). */
+export async function addToCluster(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clusterId: Id<"retroClusters">; clientIds: string[] }
+): Promise<void> {
+  const cluster = await requireCluster(ctx, args.room._id, args.clusterId);
+  const cards = await requireCards(ctx, args.room._id, args.clientIds);
+  await repoint(ctx, cards, cluster._id);
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Take cards out of whatever cluster they are in (everyone); a cluster left empty is removed. */
+export async function removeFromCluster(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clientIds: string[] }
+): Promise<void> {
+  const cards = await requireCards(ctx, args.room._id, args.clientIds);
+  await repoint(ctx, cards, undefined);
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Rename a cluster (`cardManagement`). */
+export async function renameCluster(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clusterId: Id<"retroClusters">; name: string }
+): Promise<void> {
+  const cluster = await requireCluster(ctx, args.room._id, args.clusterId);
+  await requireCardManagement(ctx, args.room, args.actor);
+  await ctx.db.patch(cluster._id, { name: validateClusterName(args.name) });
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Merge one cluster into another (`cardManagement`): members re-pointed, the empty row deleted. */
+export async function mergeClusters(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; from: Id<"retroClusters">; into: Id<"retroClusters"> }
+): Promise<void> {
+  if (args.from === args.into) throw refusal("forbidden", MERGE_INTO_SELF);
+  const from = await requireCluster(ctx, args.room._id, args.from);
+  const into = await requireCluster(ctx, args.room._id, args.into);
+  await requireCardManagement(ctx, args.room, args.actor);
+  const members = await membersOf(ctx, from._id);
+  await Promise.all(members.map((card) => ctx.db.patch(card._id, { clusterId: into._id })));
+  await ctx.db.delete(from._id);
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Dissolve a cluster (`cardManagement`): every member's `clusterId` nulled, the row deleted. */
+export async function dissolveCluster(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; clusterId: Id<"retroClusters"> }
+): Promise<void> {
+  const cluster = await requireCluster(ctx, args.room._id, args.clusterId);
+  await requireCardManagement(ctx, args.room, args.actor);
+  const members = await membersOf(ctx, cluster._id);
+  await Promise.all(members.map((card) => ctx.db.patch(card._id, { clusterId: undefined })));
+  await ctx.db.delete(cluster._id);
+  await updateRoomActivity(ctx, args.room);
+}

--- a/convex/model/retroClusters.ts
+++ b/convex/model/retroClusters.ts
@@ -4,6 +4,7 @@ import { resolveRoomAction } from "./auth";
 import { updateRoomActivity } from "./rooms";
 import { refusal } from "./refusal";
 import { getCardByClientId, type CardActor } from "./retroCards";
+import { MAX_BOARD_ROWS } from "./retro";
 import {
   CARD_NOT_FOUND,
   CLUSTER_NAME_REQUIRED,
@@ -67,7 +68,7 @@ async function membersOf(ctx: QueryCtx, clusterId: Id<"retroClusters">): Promise
   return ctx.db
     .query("retroCards")
     .withIndex("by_cluster", (q) => q.eq("clusterId", clusterId))
-    .collect();
+    .take(MAX_BOARD_ROWS);
 }
 
 /** The `cardManagement` decision as a `forbidden` refusal the client can tell from a failure. */
@@ -94,31 +95,27 @@ async function defaultName(ctx: QueryCtx, roomId: Id<"rooms">): Promise<string> 
     await ctx.db
       .query("retroClusters")
       .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect()
+      .take(MAX_BOARD_ROWS)
   );
 }
 
 /**
- * Point cards at a cluster (or at none), then drop any cluster the change
- * emptied. Positions are untouched.
+ * Point cards at a cluster (or at none). Positions are untouched, and a
+ * cluster the change leaves empty keeps its row: deleting one is dissolve,
+ * which is `cardManagement` (spec §4.2), while membership is open to
+ * everyone. Only merge removes a row (spec §10.3). An empty cluster draws
+ * no chip and is deleted with the room.
  */
 async function repoint(
   ctx: MutationCtx,
   cards: readonly Doc<"retroCards">[],
   clusterId: Id<"retroClusters"> | undefined
 ): Promise<void> {
-  const vacated = new Set<Id<"retroClusters">>();
-  for (const card of cards) {
-    if (card.clusterId !== undefined && card.clusterId !== clusterId) vacated.add(card.clusterId);
-  }
   await Promise.all(
     cards.map((card) =>
       ctx.db.patch(card._id, clusterId === undefined ? { clusterId: undefined } : { clusterId })
     )
   );
-  for (const id of vacated) {
-    if ((await membersOf(ctx, id)).length === 0) await ctx.db.delete(id);
-  }
 }
 
 /**
@@ -152,7 +149,7 @@ export async function addToCluster(
   await updateRoomActivity(ctx, args.room);
 }
 
-/** Take cards out of whatever cluster they are in (everyone); a cluster left empty is removed. */
+/** Take cards out of whatever cluster they are in (everyone); a cluster left empty keeps its row. */
 export async function removeFromCluster(
   ctx: MutationCtx,
   args: { room: Doc<"rooms">; actor: CardActor; clientIds: string[] }

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import * as Retro from "./model/retro";
 import * as RetroCards from "./model/retroCards";
+import * as RetroClusters from "./model/retroClusters";
 import {
   joinPolicyValidator,
   retroFormatValidator,
@@ -355,9 +356,69 @@ export const deleteCard = mutation({
   },
 });
 
+// --- Clusters (spec §10.3, ADR-0011) ---
+
 /**
- * A card act's actor: the attendance guard (which does not load the room)
- * and the room row the model needs.
+ * Form a cluster from a selection: attendance is the only guard (forming
+ * is never in the config, spec §4.2). Returns the new row's id; members
+ * never move.
+ */
+export const formCluster = mutation({
+  args: { roomId: v.id("rooms"), clientIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    return await RetroClusters.formCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Add cards to a cluster (everyone). */
+export const addToCluster = mutation({
+  args: { roomId: v.id("rooms"), clusterId: v.id("retroClusters"), clientIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroClusters.addToCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Take cards out of their cluster (everyone); a cluster left empty is removed. */
+export const removeFromCluster = mutation({
+  args: { roomId: v.id("rooms"), clientIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroClusters.removeFromCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Rename a cluster: `cardManagement`, decided in the model as a `forbidden` refusal. */
+export const renameCluster = mutation({
+  args: { roomId: v.id("rooms"), clusterId: v.id("retroClusters"), name: v.string() },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroClusters.renameCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Merge `from` into `into` (`cardManagement`): members re-pointed, the empty row deleted. */
+export const mergeClusters = mutation({
+  args: { roomId: v.id("rooms"), from: v.id("retroClusters"), into: v.id("retroClusters") },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroClusters.mergeClusters(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Dissolve a cluster (`cardManagement`): every member's `clusterId` nulled, the row deleted. */
+export const dissolveCluster = mutation({
+  args: { roomId: v.id("rooms"), clusterId: v.id("retroClusters") },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroClusters.dissolveCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/**
+ * A card or cluster act's actor: the attendance guard (which does not load
+ * the room) and the room row the model needs.
  */
 async function requireCardActor(ctx: QueryCtx, roomId: Id<"rooms">) {
   const { user, membership } = await requireRoomMember(ctx, roomId);

--- a/convex/retroClusters.test.ts
+++ b/convex/retroClusters.test.ts
@@ -1,0 +1,270 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+
+// Clusters (spec §10.3, ADR-0011, ADR-0016): a cluster is an identity, not a
+// location. Forming one and changing membership is open to every attendee;
+// rename, merge and dissolve are `cardManagement`. The row stores a name
+// and nothing else — no position, member list or count — and no member
+// ever moves. Every act is correct in every stage (ADR-0010).
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string) => seedNamedUser(t, authUserId, authUserId);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+async function cardsOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function clustersOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroClusters")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+const POS = { x: 10, y: 20 };
+
+/** An owner and a participant in a fresh teamless (named) retro, with three cards. */
+async function seedRetro(t: T) {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, {
+    name: "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+  });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  const retro = await retroRow(t, roomId);
+  const promptId = retro.format.prompts[0].id;
+  const write = (who: string, clientId: string, position = POS) =>
+    as(t, who).mutation(api.retro.createCard, { roomId, clientId, text: clientId, promptId, position });
+  await write("owner", "o1", { x: 0, y: 0 });
+  await write("owner", "o2", { x: 300, y: 0 });
+  await write("guest", "g1", { x: 0, y: 300 });
+  return { roomId, stages: retro.stages, promptId };
+}
+
+/** The refusal's code, or undefined for a plain error. */
+async function codeOf(p: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await p;
+    return "resolved";
+  } catch (error) {
+    return error instanceof ConvexError ? (error.data as { code: string }).code : undefined;
+  }
+}
+
+describe("retro.formCluster (spec §10.3)", () => {
+  it("a participant groups another person's cards: the row is named Group {n}, members point at it, nobody moves", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const before = await cardsOf(t, roomId);
+
+    const clusterId = await as(t, "guest").mutation(api.retro.formCluster, {
+      roomId,
+      clientIds: ["o1", "o2"],
+    });
+
+    const clusters = await clustersOf(t, roomId);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]._id).toBe(clusterId);
+    expect(clusters[0].name).toBe("Group 1");
+    // The row is a name and nothing else (ADR-0016).
+    expect(Object.keys(clusters[0]).sort()).toEqual(["_creationTime", "_id", "createdAt", "name", "roomId"]);
+    const after = await cardsOf(t, roomId);
+    for (const card of after) {
+      const was = before.find((c) => c.clientId === card.clientId)!;
+      expect(card.position).toEqual(was.position);
+      expect(card.clusterId).toBe(["o1", "o2"].includes(card.clientId) ? clusterId : undefined);
+    }
+  });
+
+  it("names count past the highest Group {n} the room carries, so a merged-away number is never reused", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const me = as(t, "owner");
+    const first = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    const second = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o2"] });
+    await me.mutation(api.retro.mergeClusters, { roomId, from: first, into: second });
+    const third = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["g1"] });
+    const clusters = await clustersOf(t, roomId);
+    expect(clusters.map((c) => c.name).sort()).toEqual(["Group 2", "Group 3"]);
+    expect(clusters.find((c) => c._id === third)!.name).toBe("Group 3");
+  });
+
+  it("refuses an empty selection with `forbidden`, an unknown card with `missing`, and a non-member with a guard error", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    await seedUser(t, "stranger");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.formCluster, { roomId, clientIds: [] }))).toBe("forbidden");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.formCluster, { roomId, clientIds: ["o1", "nope"] }))).toBe("missing");
+    await expect(
+      as(t, "stranger").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] })
+    ).rejects.toThrow("Not a member");
+    expect(await clustersOf(t, roomId)).toHaveLength(0);
+  });
+
+  it("a card already in a cluster is re-pointed, and a cluster emptied that way is removed", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const me = as(t, "owner");
+    const first = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    const second = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o1", "o2"] });
+    const clusters = await clustersOf(t, roomId);
+    expect(clusters.map((c) => c._id)).toEqual([second]);
+    expect(clusters[0]._id).not.toBe(first);
+    const cards = await cardsOf(t, roomId);
+    expect(cards.find((c) => c.clientId === "o1")!.clusterId).toBe(second);
+  });
+});
+
+describe("membership (spec §10.3): open to everyone", () => {
+  it("addToCluster and removeFromCluster set and null clusterId without moving anyone; the last removal deletes the row", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const clusterId = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+
+    await as(t, "guest").mutation(api.retro.addToCluster, { roomId, clusterId, clientIds: ["g1", "o2"] });
+    let cards = await cardsOf(t, roomId);
+    expect(cards.every((c) => c.clusterId === clusterId)).toBe(true);
+    expect(cards.find((c) => c.clientId === "g1")!.position).toEqual({ x: 0, y: 300 });
+
+    await as(t, "guest").mutation(api.retro.removeFromCluster, { roomId, clientIds: ["o1", "o2"] });
+    cards = await cardsOf(t, roomId);
+    expect(cards.find((c) => c.clientId === "o1")!.clusterId).toBeUndefined();
+    expect(cards.find((c) => c.clientId === "g1")!.clusterId).toBe(clusterId);
+    expect(await clustersOf(t, roomId)).toHaveLength(1);
+
+    await as(t, "guest").mutation(api.retro.removeFromCluster, { roomId, clientIds: ["g1"] });
+    expect(await clustersOf(t, roomId)).toHaveLength(0);
+    expect((await cardsOf(t, roomId)).every((c) => c.clusterId === undefined)).toBe(true);
+  });
+
+  it("addToCluster refuses an unknown cluster or card with `missing`", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const clusterId = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    await as(t, "owner").mutation(api.retro.dissolveCluster, { roomId, clusterId });
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.addToCluster, { roomId, clusterId, clientIds: ["g1"] }))
+    ).toBe("missing");
+    const again = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.addToCluster, { roomId, clusterId: again, clientIds: ["nope"] }))
+    ).toBe("missing");
+  });
+});
+
+describe("rename, merge, dissolve: cardManagement (spec §4.2, §10.3)", () => {
+  it("a participant at defaults is refused each with `forbidden`; the owner does all three", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const owner = as(t, "owner");
+    const guest = as(t, "guest");
+    const a = await guest.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    const b = await guest.mutation(api.retro.formCluster, { roomId, clientIds: ["o2", "g1"] });
+
+    expect(await codeOf(guest.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "Demo" }))).toBe("forbidden");
+    expect(await codeOf(guest.mutation(api.retro.mergeClusters, { roomId, from: a, into: b }))).toBe("forbidden");
+    expect(await codeOf(guest.mutation(api.retro.dissolveCluster, { roomId, clusterId: a }))).toBe("forbidden");
+    expect(await clustersOf(t, roomId)).toHaveLength(2);
+
+    await owner.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "  Demo  " });
+    expect((await clustersOf(t, roomId)).find((c) => c._id === a)!.name).toBe("Demo");
+
+    const before = await cardsOf(t, roomId);
+    await owner.mutation(api.retro.mergeClusters, { roomId, from: a, into: b });
+    let clusters = await clustersOf(t, roomId);
+    expect(clusters.map((c) => c._id)).toEqual([b]);
+    let cards = await cardsOf(t, roomId);
+    expect(cards.every((c) => c.clusterId === b)).toBe(true);
+    for (const card of cards) {
+      expect(card.position).toEqual(before.find((c) => c.clientId === card.clientId)!.position);
+    }
+
+    await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: b });
+    clusters = await clustersOf(t, roomId);
+    expect(clusters).toHaveLength(0);
+    cards = await cardsOf(t, roomId);
+    expect(cards.every((c) => c.clusterId === undefined)).toBe(true);
+    for (const card of cards) {
+      expect(card.position).toEqual(before.find((c) => c.clientId === card.clientId)!.position);
+    }
+  });
+
+  it("rename refuses a blank or overlong name with `forbidden`; merge refuses a cluster into itself and an unknown cluster", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const owner = as(t, "owner");
+    const a = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    expect(await codeOf(owner.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "   " }))).toBe("forbidden");
+    expect(await codeOf(owner.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "x".repeat(81) }))).toBe("forbidden");
+    expect(await codeOf(owner.mutation(api.retro.mergeClusters, { roomId, from: a, into: a }))).toBe("forbidden");
+    const b = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o2"] });
+    await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: b });
+    expect(await codeOf(owner.mutation(api.retro.mergeClusters, { roomId, from: b, into: a }))).toBe("missing");
+    expect(await codeOf(owner.mutation(api.retro.mergeClusters, { roomId, from: a, into: b }))).toBe("missing");
+    expect(await codeOf(owner.mutation(api.retro.renameCluster, { roomId, clusterId: b, name: "x" }))).toBe("missing");
+    expect(await codeOf(owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: b }))).toBe("missing");
+  });
+});
+
+describe("no stage forbids a cluster act (ADR-0010)", () => {
+  it("form, add, remove, rename, merge and dissolve all resolve at collect and at close", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages } = await seedRetro(t);
+    const owner = as(t, "owner");
+    const run = async () => {
+      const a = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+      const b = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o2"] });
+      await owner.mutation(api.retro.addToCluster, { roomId, clusterId: a, clientIds: ["g1"] });
+      await owner.mutation(api.retro.removeFromCluster, { roomId, clientIds: ["g1"] });
+      await owner.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "A" });
+      await owner.mutation(api.retro.mergeClusters, { roomId, from: b, into: a });
+      await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: a });
+      expect(await clustersOf(t, roomId)).toHaveLength(0);
+    };
+    expect(stages[0].kind).toBe("collect");
+    await run();
+    await owner.mutation(api.retro.advance, { roomId, toStageId: stages[stages.length - 1].id });
+    expect((await retroRow(t, roomId)).stages.find((s) => s.id === stages[stages.length - 1].id)!.kind).toBe("close");
+    await run();
+  });
+});
+
+describe("the board carries clusters (spec §9)", () => {
+  it("retro.board lists the cluster row and the members' clusterId, identically for every viewer", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const clusterId = await as(t, "guest").mutation(api.retro.formCluster, { roomId, clientIds: ["o1", "g1"] });
+    const asOwner = await as(t, "owner").query(api.retro.board, { roomId });
+    const asGuest = await as(t, "guest").query(api.retro.board, { roomId });
+    expect(asOwner).toEqual(asGuest);
+    expect(asOwner.clusters.map((c) => ({ _id: c._id, name: c.name }))).toEqual([{ _id: clusterId, name: "Group 1" }]);
+    expect(asOwner.cards.find((c) => c.clientId === "o1")!.clusterId).toBe(clusterId);
+    expect(asOwner.cards.find((c) => c.clientId === "o2")!.clusterId).toBeUndefined();
+  });
+});

--- a/convex/retroClusters.test.ts
+++ b/convex/retroClusters.test.ts
@@ -127,22 +127,22 @@ describe("retro.formCluster (spec §10.3)", () => {
     expect(await clustersOf(t, roomId)).toHaveLength(0);
   });
 
-  it("a card already in a cluster is re-pointed, and a cluster emptied that way is removed", async () => {
+  it("a card already in a cluster is re-pointed; the cluster emptied that way keeps its row (only merge or dissolve removes one)", async () => {
     const t = convexTest(schema, modules);
     const { roomId } = await seedRetro(t);
     const me = as(t, "owner");
     const first = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
     const second = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["o1", "o2"] });
     const clusters = await clustersOf(t, roomId);
-    expect(clusters.map((c) => c._id)).toEqual([second]);
-    expect(clusters[0]._id).not.toBe(first);
+    expect(clusters.map((c) => c._id).sort()).toEqual([first, second].sort());
+    expect(second).not.toBe(first);
     const cards = await cardsOf(t, roomId);
     expect(cards.find((c) => c.clientId === "o1")!.clusterId).toBe(second);
   });
 });
 
 describe("membership (spec §10.3): open to everyone", () => {
-  it("addToCluster and removeFromCluster set and null clusterId without moving anyone; the last removal deletes the row", async () => {
+  it("addToCluster and removeFromCluster set and null clusterId without moving anyone; the last removal keeps the row, since deleting one is dissolve", async () => {
     const t = convexTest(schema, modules);
     const { roomId } = await seedRetro(t);
     const clusterId = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
@@ -159,7 +159,7 @@ describe("membership (spec §10.3): open to everyone", () => {
     expect(await clustersOf(t, roomId)).toHaveLength(1);
 
     await as(t, "guest").mutation(api.retro.removeFromCluster, { roomId, clientIds: ["g1"] });
-    expect(await clustersOf(t, roomId)).toHaveLength(0);
+    expect(await clustersOf(t, roomId)).toHaveLength(1);
     expect((await cardsOf(t, roomId)).every((c) => c.clusterId === undefined)).toBe(true);
   });
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -288,3 +288,48 @@ export const cardsCount = (n: number) => `${n} ${n === 1 ? "card" : "cards"}`;
 /** Missing user (spec §19). */
 export const FORMER_MEMBER = "Former member";
 export const CARD_ACT_FAILED = "That did not go through. Try again.";
+
+// --- Clusters (spec §10.3, §19; ADR-0011, ADR-0016) ---
+
+/** The default cluster name at formation. */
+export const groupName = (n: number) => `Group ${n}`;
+/**
+ * The next default name: one past the highest "Group {n}" the room carries
+ * and past the row count, so a number freed by a merge or dissolve is never
+ * handed out twice while its neighbours stand. Here rather than in the
+ * model because the optimistic form names its placeholder by the same rule.
+ */
+export function nextGroupName(clusters: readonly { name: string }[]): string {
+  let highest = 0;
+  for (const cluster of clusters) {
+    const match = /^Group (\d+)$/.exec(cluster.name);
+    if (match) highest = Math.max(highest, Number(match[1]));
+  }
+  return groupName(Math.max(highest, clusters.length) + 1);
+}
+/** A cluster act naming a row the room does not carry. */
+export const CLUSTER_NOT_FOUND = "That group is no longer on the board";
+export const CLUSTER_SELECTION_REQUIRED = "Select at least one card to group";
+export const CLUSTER_NAME_REQUIRED = "A group needs a name";
+export const CLUSTER_NAME_TOO_LONG = "A group name holds at most 80 characters";
+export const MERGE_INTO_SELF = "Pick a different group to merge into";
+/** Dissolve confirmation, only when the cluster has dots (spec §19; #294). */
+export const dissolveClusterConfirm = (votes: number) =>
+  `Dissolve this group? Its ${votes} ${votes === 1 ? "vote is" : "votes are"} removed.`;
+export const GROUP_SELECTION = "Group";
+export const groupCards = (n: number) => `Group ${n} ${n === 1 ? "card" : "cards"}`;
+export const ADD_TO_GROUP = "Add to group";
+export const REMOVE_FROM_GROUP = "Remove from group";
+export const CLEAR_SELECTION = "Clear selection";
+export const selectedCards = (n: number) => `${n} selected`;
+export const RENAME_GROUP = "Rename group";
+export const GROUP_NAME_LABEL = "Group name";
+export const RENAME_GROUP_SAVE = "Save";
+export const MERGE_GROUP = "Merge into…";
+export const MERGE_GROUP_TITLE = "Merge group";
+export const MERGE_GROUP_INTO_LABEL = "Into";
+export const MERGE_GROUP_BUTTON = "Merge";
+export const TIDY_GROUP = "Tidy";
+export const DISSOLVE_GROUP = "Dissolve group";
+export const GROUP_MENU = "Group actions";
+export const CLUSTER_ACT_FAILED = "That did not go through. Try again.";

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -620,6 +620,36 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     }
   });
 
+  it("every cluster mutation bumps (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t, false);
+    const retro = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const me = as(t, "auth-member");
+    const promptId = retro.format.prompts[0].id;
+    for (const clientId of ["c1", "c2", "c3"]) {
+      await me.mutation(api.retro.createCard, { roomId, clientId, text: clientId, promptId, position: { x: 0, y: 0 } });
+    }
+    let a: Id<"retroClusters">;
+    let b: Id<"retroClusters">;
+    const acts = [
+      async () => void (a = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["c1"] })),
+      async () => void (b = await me.mutation(api.retro.formCluster, { roomId, clientIds: ["c2"] })),
+      () => me.mutation(api.retro.addToCluster, { roomId, clusterId: a, clientIds: ["c3"] }),
+      () => me.mutation(api.retro.removeFromCluster, { roomId, clientIds: ["c3"] }),
+      () => me.mutation(api.retro.renameCluster, { roomId, clusterId: a, name: "A" }),
+      () => me.mutation(api.retro.mergeClusters, { roomId, from: b, into: a }),
+      () => me.mutation(api.retro.dissolveCluster, { roomId, clusterId: a }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+  });
+
   it("ratchet bumps (spec §14)", async () => {
     const t = convexTest(schema, modules);
     const { roomId, stale } = await seedTeamRetro(t, false);

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -12,6 +12,7 @@ import { RetroBoard, type BoardViewer } from "@/components/retro/retro-board";
 import { mergeCards, type BoardCard } from "@/components/retro/cards";
 import { readinessOf } from "@/components/retro/readiness";
 import { useCardActions } from "@/components/retro/use-card-actions";
+import { useClusterActions } from "@/components/retro/use-cluster-actions";
 import { useEditKeys, type EditKeyStore } from "@/components/retro/use-edit-keys";
 import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
@@ -117,6 +118,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
         name={room.name}
         retro={board.retro}
         cards={cards}
+        clusters={board.clusters}
         writers={board.writers}
         users={offlineUsers}
         team={team}
@@ -185,6 +187,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
     [userId, retro.attribution, editKeys]
   );
   const cardActions = useCardActions(roomId, writer);
+  const clusterActions = useClusterActions(roomId);
   const currentStageId = currentStageOf(retro).id;
   // The payload is written whole, so an editing write carries readiness
   // too: the viewer's last toggle for this entry, else what their presence
@@ -235,9 +238,10 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       onEditing: (clientId) => writePresence({ editing: clientId }),
       controls,
       cards: cardActions,
+      clusters: clusterActions,
       cardManagement,
     }),
-    [userId, me?.name, writePresence, controls, cardActions, cardManagement]
+    [userId, me?.name, writePresence, controls, cardActions, clusterActions, cardManagement]
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
@@ -246,6 +250,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       name={roomData.room.name}
       retro={retro}
       cards={cards}
+      clusters={board.clusters}
       writers={board.writers}
       users={users}
       team={team}

--- a/src/components/retro/card-node.tsx
+++ b/src/components/retro/card-node.tsx
@@ -40,8 +40,7 @@ export type CardNode = Node<CardNodeData, "card">;
  * A card on the board (ADR-0011 at the detail level, ADR-0015, spec §10.9):
  * text, tint and author chip, or a tint-only silhouette when the viewer has
  * no text for it. Its data attributes are the canvas contract the tests
- * read; `data-cluster-id` and `data-late` are placeholders until #293 and
- * #295.
+ * read; `data-late` is a placeholder until #295.
  */
 export const CardNodeView = memo(function CardNodeView({ data, selected }: NodeProps<CardNode>) {
   const { card, color, authorName, editingBy, editable } = data;

--- a/src/components/retro/cluster-node.test.tsx
+++ b/src/components/retro/cluster-node.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * The cluster chip (spec §10.3, ADR-0011): the name and count at the
+ * centroid, and the `cardManagement` menu — rename, merge, tidy, dissolve —
+ * disabled with the decision's copy for a participant at defaults, absent
+ * for a Team reader.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, within, act } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+import type { NodeProps } from "@xyflow/react";
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render: el, children }: { render: ReactElement; children?: ReactNode }) =>
+    cloneElement(el, undefined, children),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button role="menuitem" onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+}));
+vi.mock("@/components/ui/dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Dialog: ({ children, open }: { children?: ReactNode; open: boolean }) => (open ? <div role="dialog">{children}</div> : null),
+    DialogContent: pass,
+    DialogHeader: pass,
+    DialogFooter: pass,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+  };
+});
+
+import { ClusterNodeView, type ClusterNode } from "./cluster-node";
+
+afterEach(cleanup);
+
+const chip = { clusterId: "k1", name: "Group 1", position: { x: 100, y: 50 }, count: 3 };
+const others = [{ clusterId: "k2", name: "Group 2" }];
+const allowed = { allowed: true as const };
+const denied = { allowed: false as const, message: "Only facilitators can manage cards" };
+
+function renderChip(data: ClusterNode["data"]) {
+  const props = { id: data.chip.clusterId, data } as unknown as NodeProps<ClusterNode>;
+  return render(<ClusterNodeView {...props} />);
+}
+
+const actions = () => ({
+  rename: vi.fn().mockResolvedValue(true),
+  merge: vi.fn().mockResolvedValue(true),
+  dissolve: vi.fn().mockResolvedValue(true),
+  tidy: vi.fn(),
+});
+
+describe("ClusterNodeView", () => {
+  it("shows the name and count; a Team reader gets no menu", () => {
+    renderChip({ chip, others });
+    const root = document.querySelector("[data-cluster-chip='k1']")!;
+    expect(root.getAttribute("data-count")).toBe("3");
+    expect(screen.getByTestId("cluster-name").textContent).toBe("Group 1");
+    expect(screen.getByText("3 cards")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Group actions" })).toBeNull();
+  });
+
+  it("a participant at defaults sees the menu disabled with the decision's copy", () => {
+    renderChip({ chip, others, decision: denied, actions: actions() });
+    const trigger = screen.getByRole("button", { name: "Group actions" }) as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.title).toBe("Only facilitators can manage cards");
+  });
+
+  it("under cardManagement: rename saves the trimmed name, merge picks a target, tidy and dissolve fire", async () => {
+    const acts = actions();
+    renderChip({ chip, others, decision: allowed, actions: acts });
+    expect((screen.getByRole("button", { name: "Group actions" }) as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename group" }));
+    const rename = within(screen.getByRole("dialog"));
+    fireEvent.change(rename.getByLabelText("Group name"), { target: { value: "  Demo  " } });
+    await act(async () => {
+      fireEvent.click(rename.getByRole("button", { name: "Save" }));
+    });
+    expect(acts.rename).toHaveBeenCalledWith("k1", "Demo");
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Merge into…" }));
+    const merge = within(screen.getByRole("dialog"));
+    expect((merge.getByLabelText("Into") as HTMLSelectElement).value).toBe("k2");
+    await act(async () => {
+      fireEvent.click(merge.getByRole("button", { name: "Merge" }));
+    });
+    expect(acts.merge).toHaveBeenCalledWith("k1", "k2");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Tidy" }));
+    expect(acts.tidy).toHaveBeenCalledWith("k1");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Dissolve group" }));
+    expect(acts.dissolve).toHaveBeenCalledWith("k1");
+  });
+
+  it("merge is disabled when there is no other cluster", () => {
+    renderChip({ chip, others: [], decision: allowed, actions: actions() });
+    expect((screen.getByRole("menuitem", { name: "Merge into…" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/retro/cluster-node.tsx
+++ b/src/components/retro/cluster-node.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { memo, useState } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ResolvedDecision } from "@/convex/permissions";
+import { MAX_CLUSTER_NAME } from "@/convex/model/retroClusters";
+import {
+  DISSOLVE_GROUP,
+  GROUP_MENU,
+  GROUP_NAME_LABEL,
+  MERGE_GROUP,
+  MERGE_GROUP_BUTTON,
+  MERGE_GROUP_INTO_LABEL,
+  MERGE_GROUP_TITLE,
+  RENAME_GROUP,
+  RENAME_GROUP_SAVE,
+  TIDY_GROUP,
+  cardsCount,
+} from "@/convex/retroCopy";
+import type { ClusterChip } from "./clusters";
+
+/** The `cardManagement` acts on one cluster, as the board wires them. */
+export interface ClusterChipActions {
+  rename: (clusterId: string, name: string) => Promise<boolean>;
+  merge: (from: string, into: string) => Promise<boolean>;
+  dissolve: (clusterId: string) => Promise<boolean>;
+  /** Tidy: the board computes the positions and issues the one move batch. */
+  tidy: (clusterId: string) => void;
+}
+
+// A type alias: React Flow node data must satisfy Record<string, unknown>.
+export type ClusterNodeData = {
+  chip: ClusterChip;
+  /** The other clusters on the board, as merge targets. */
+  others: readonly { clusterId: string; name: string }[];
+  /** The `cardManagement` decision; absent for a Team reader, who gets the label alone. */
+  decision?: ResolvedDecision;
+  actions?: ClusterChipActions;
+};
+
+export type ClusterNode = Node<ClusterNodeData, "cluster">;
+
+/**
+ * A cluster's label chip (spec §10.3, ADR-0011): the name and member count,
+ * centred on the members' centroid at render time. The chip is the one
+ * place a cluster is acted on: rename, merge, tidy and dissolve sit in its
+ * menu under `cardManagement`, disabled with the decision's copy otherwise.
+ * It never moves its members; tidy is the explicit opt-in.
+ */
+export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps<ClusterNode>) {
+  const { chip, others, decision, actions } = data;
+  const [renaming, setRenaming] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const managed = decision !== undefined && actions !== undefined;
+  const allowed = managed && decision.allowed;
+  return (
+    <div
+      data-cluster-chip={chip.clusterId}
+      data-count={chip.count}
+      className="-translate-x-1/2 -translate-y-1/2"
+    >
+      <div
+        className={cn(
+          // React Flow drops pointer events on a node that is neither selectable
+          // nor draggable; the chip itself takes them back.
+          "nodrag nopan pointer-events-auto flex items-center gap-1 rounded-full border bg-white/95 py-1 pr-1 pl-3 text-xs font-semibold shadow-md",
+          "dark:bg-surface-2/95"
+        )}
+      >
+        <span data-testid="cluster-name" className="max-w-48 truncate">
+          {chip.name}
+        </span>
+        <span className="text-muted-foreground font-normal">{cardsCount(chip.count)}</span>
+        {managed && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={GROUP_MENU}
+                  disabled={!allowed}
+                  title={allowed ? undefined : decision.message}
+                />
+              }
+            >
+              <ChevronDown className="size-3.5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem onClick={() => setRenaming(true)}>{RENAME_GROUP}</DropdownMenuItem>
+              <DropdownMenuItem disabled={others.length === 0} onClick={() => setMerging(true)}>
+                {MERGE_GROUP}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => actions.tidy(chip.clusterId)}>{TIDY_GROUP}</DropdownMenuItem>
+              <DropdownMenuItem variant="destructive" onClick={() => void actions.dissolve(chip.clusterId)}>
+                {DISSOLVE_GROUP}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+      {managed && renaming && (
+        <RenameDialog
+          name={chip.name}
+          onClose={() => setRenaming(false)}
+          onSave={(name) => actions.rename(chip.clusterId, name)}
+        />
+      )}
+      {managed && merging && (
+        <MergeDialog
+          others={others}
+          onClose={() => setMerging(false)}
+          onMerge={(into) => actions.merge(chip.clusterId, into)}
+        />
+      )}
+    </div>
+  );
+});
+
+function RenameDialog({
+  name,
+  onClose,
+  onSave,
+}: {
+  name: string;
+  onClose: () => void;
+  onSave: (name: string) => Promise<boolean>;
+}) {
+  const [draft, setDraft] = useState(name);
+  const [saving, setSaving] = useState(false);
+  const save = async () => {
+    if (!draft.trim() || saving) return;
+    setSaving(true);
+    const ok = await onSave(draft.trim());
+    setSaving(false);
+    if (ok) onClose();
+  };
+  return (
+    <Dialog open onOpenChange={(open) => !open && !saving && onClose()}>
+      <DialogContent data-testid="rename-cluster" className="nodrag nowheel">
+        <DialogHeader>
+          <DialogTitle>{RENAME_GROUP}</DialogTitle>
+        </DialogHeader>
+        <form
+          className="grid gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void save();
+          }}
+        >
+          <div className="grid gap-1.5">
+            <Label htmlFor="cluster-name">{GROUP_NAME_LABEL}</Label>
+            <Input
+              id="cluster-name"
+              value={draft}
+              maxLength={MAX_CLUSTER_NAME}
+              autoFocus
+              onChange={(e) => setDraft(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={!draft.trim() || saving}>
+              {RENAME_GROUP_SAVE}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MergeDialog({
+  others,
+  onClose,
+  onMerge,
+}: {
+  others: readonly { clusterId: string; name: string }[];
+  onClose: () => void;
+  onMerge: (into: string) => Promise<boolean>;
+}) {
+  const [into, setInto] = useState(others[0]?.clusterId ?? "");
+  const [merging, setMerging] = useState(false);
+  const merge = async () => {
+    if (!into || merging) return;
+    setMerging(true);
+    const ok = await onMerge(into);
+    setMerging(false);
+    if (ok) onClose();
+  };
+  return (
+    <Dialog open onOpenChange={(open) => !open && !merging && onClose()}>
+      <DialogContent data-testid="merge-cluster" className="nodrag nowheel">
+        <DialogHeader>
+          <DialogTitle>{MERGE_GROUP_TITLE}</DialogTitle>
+        </DialogHeader>
+        <form
+          className="grid gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void merge();
+          }}
+        >
+          <div className="grid gap-1.5">
+            <Label htmlFor="merge-into">{MERGE_GROUP_INTO_LABEL}</Label>
+            <select
+              id="merge-into"
+              value={into}
+              onChange={(e) => setInto(e.target.value)}
+              className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+            >
+              {others.map((other) => (
+                <option key={other.clusterId} value={other.clusterId}>
+                  {other.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={!into || merging}>
+              {MERGE_GROUP_BUTTON}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/retro/clusters.test.ts
+++ b/src/components/retro/clusters.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Cluster geometry (spec §10.3, ADR-0011): the label chip sits at the
+ * members' centroid at render time and is never stored; tidy is the client
+ * laying members out around that centroid as one move batch.
+ */
+import { describe, it, expect } from "vitest";
+import { centroidOf, clusterChips, tidyPositions } from "./clusters";
+import { nextGroupName } from "@/convex/retroCopy";
+
+const size = { width: 200, height: 100 };
+const card = (clientId: string, x: number, y: number, clusterId?: string) => ({
+  clientId,
+  position: { x, y },
+  ...(clusterId ? { clusterId } : {}),
+});
+
+describe("centroidOf", () => {
+  it("is the mean of the points, and undefined for none", () => {
+    expect(centroidOf([])).toBeUndefined();
+    expect(centroidOf([{ x: 0, y: 0 }, { x: 10, y: 20 }])).toEqual({ x: 5, y: 10 });
+  });
+});
+
+describe("clusterChips", () => {
+  it("anchors each chip at the centroid of its members' centres and counts them; an empty cluster has no chip", () => {
+    const clusters = [
+      { _id: "k1", name: "Group 1" },
+      { _id: "k2", name: "Group 2" },
+    ];
+    const cards = [card("a", 0, 0, "k1"), card("b", 400, 200, "k1"), card("c", 900, 900)];
+    expect(clusterChips(clusters, cards, size)).toEqual([
+      { clusterId: "k1", name: "Group 1", position: { x: 300, y: 150 }, count: 2 },
+    ]);
+  });
+});
+
+describe("tidyPositions", () => {
+  it("lays members out in a near-square grid centred on their centroid, keeping their reading order", () => {
+    const members = [card("c", 500, 0), card("a", 0, 0), card("b", 250, 0), card("d", 0, 300)];
+    const moves = tidyPositions(members, size, 20);
+    // Four members → two columns, two rows; a 420 × 220 grid around the
+    // centroid of the members' centres, (287.5, 125).
+    expect(moves.map((m) => m.clientId)).toEqual(["a", "b", "c", "d"]);
+    expect(moves.map((m) => m.position)).toEqual([
+      { x: 77.5, y: 15 },
+      { x: 297.5, y: 15 },
+      { x: 77.5, y: 135 },
+      { x: 297.5, y: 135 },
+    ]);
+  });
+
+  it("a single member is left where it is", () => {
+    expect(tidyPositions([card("a", 40, 50)], size)).toEqual([{ clientId: "a", position: { x: 40, y: 50 } }]);
+  });
+});
+
+describe("nextGroupName", () => {
+  it("counts past the highest Group {n} and past the row count, whichever is larger", () => {
+    expect(nextGroupName([])).toBe("Group 1");
+    expect(nextGroupName([{ name: "Group 2" }])).toBe("Group 3");
+    expect(nextGroupName([{ name: "Demo" }, { name: "Group 1" }])).toBe("Group 3");
+  });
+});

--- a/src/components/retro/clusters.ts
+++ b/src/components/retro/clusters.ts
@@ -1,0 +1,102 @@
+/**
+ * Cluster geometry (spec §10.3, ADR-0011): a cluster is an identity, not a
+ * location, so nothing here is stored. The label chip is anchored at the
+ * members' centroid at render time; tidy is the client computing positions
+ * around that centroid and calling the one move batch. Pure, so the board
+ * derives its chip nodes by memo and a node test proves the layout.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Member {
+  clientId: string;
+  position: Point;
+  clusterId?: string;
+}
+
+export interface ClusterChip {
+  clusterId: string;
+  name: string;
+  /** The centroid of the members' centres, in canvas coordinates. */
+  position: Point;
+  count: number;
+}
+
+export function centroidOf(points: readonly Point[]): Point | undefined {
+  if (points.length === 0) return undefined;
+  let x = 0;
+  let y = 0;
+  for (const p of points) {
+    x += p.x;
+    y += p.y;
+  }
+  return { x: x / points.length, y: y / points.length };
+}
+
+const centreOf = (card: Member, size: Size): Point => ({
+  x: card.position.x + size.width / 2,
+  y: card.position.y + size.height / 2,
+});
+
+/** One chip per cluster that has members, at their centroid; an empty cluster has none. */
+export function clusterChips(
+  clusters: readonly { _id: string; name: string }[],
+  cards: readonly Member[],
+  size: Size
+): ClusterChip[] {
+  const centres = new Map<string, Point[]>();
+  for (const card of cards) {
+    if (card.clusterId === undefined) continue;
+    const list = centres.get(card.clusterId) ?? [];
+    list.push(centreOf(card, size));
+    centres.set(card.clusterId, list);
+  }
+  const chips: ClusterChip[] = [];
+  for (const cluster of clusters) {
+    const points = centres.get(cluster._id);
+    const position = points && centroidOf(points);
+    if (!position) continue;
+    chips.push({ clusterId: cluster._id, name: cluster.name, position, count: points!.length });
+  }
+  return chips;
+}
+
+/**
+ * Tidy: the members in reading order (top to bottom, left to right) laid
+ * out in a near-square grid whose centre is their current centroid, so the
+ * group gathers where it already sits. A lone member stays put.
+ */
+export function tidyPositions(
+  members: readonly Member[],
+  size: Size,
+  gap = 16
+): { clientId: string; position: Point }[] {
+  if (members.length <= 1) {
+    return members.map((m) => ({ clientId: m.clientId, position: m.position }));
+  }
+  const centroid = centroidOf(members.map((m) => centreOf(m, size)))!;
+  const ordered = [...members].sort(
+    (a, b) => a.position.y - b.position.y || a.position.x - b.position.x || a.clientId.localeCompare(b.clientId)
+  );
+  const columns = Math.ceil(Math.sqrt(ordered.length));
+  const rows = Math.ceil(ordered.length / columns);
+  const totalWidth = columns * size.width + (columns - 1) * gap;
+  const totalHeight = rows * size.height + (rows - 1) * gap;
+  const originX = centroid.x - totalWidth / 2;
+  const originY = centroid.y - totalHeight / 2;
+  return ordered.map((m, i) => ({
+    clientId: m.clientId,
+    position: {
+      x: originX + (i % columns) * (size.width + gap),
+      y: originY + Math.floor(i / columns) * (size.height + gap),
+    },
+  }));
+}

--- a/src/components/retro/optimistic.test.ts
+++ b/src/components/retro/optimistic.test.ts
@@ -165,7 +165,7 @@ describe("group and ungroup (spec §10.7): clusterId in board only", () => {
     expect(next.cards.map((c) => c.clusterId)).toEqual(["opt-1", "opt-1", undefined]);
   });
 
-  it("applyAddToCluster re-points the members and drops a cluster left empty; positions are untouched", () => {
+  it("applyAddToCluster re-points the members and keeps a cluster left empty; positions are untouched", () => {
     const { store, value } = fakeStore({
       [BOARD]: board(
         "visible",
@@ -177,10 +177,10 @@ describe("group and ungroup (spec §10.7): clusterId in board only", () => {
     const next = value<BoardRead>(BOARD);
     expect(next.cards.map((c) => c.clusterId)).toEqual(["k2", "k2"]);
     expect(next.cards.map((c) => c.position)).toEqual([{ x: 0, y: 0 }, { x: 0, y: 0 }]);
-    expect(next.clusters.map((k) => k._id)).toEqual(["k2"]);
+    expect(next.clusters.map((k) => k._id)).toEqual(["k1", "k2"]);
   });
 
-  it("applyUngroup nulls clusterId and drops a cluster left empty, touching mine never", () => {
+  it("applyUngroup nulls clusterId and keeps a cluster left empty, touching mine never", () => {
     const { store, writes, value } = fakeStore({
       [BOARD]: board(
         "visible",
@@ -194,6 +194,6 @@ describe("group and ungroup (spec §10.7): clusterId in board only", () => {
     const next = value<BoardRead>(BOARD);
     expect(next.cards.map((c) => c.clusterId)).toEqual([undefined, "k1", undefined]);
     expect(next.cards.map((c) => "clusterId" in c)).toEqual([false, true, false]);
-    expect(next.clusters.map((k) => k._id)).toEqual(["k1"]);
+    expect(next.clusters.map((k) => k._id)).toEqual(["k1", "k2"]);
   });
 });

--- a/src/components/retro/optimistic.test.ts
+++ b/src/components/retro/optimistic.test.ts
@@ -11,7 +11,7 @@ import { getFunctionName, type FunctionReference } from "convex/server";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { BoardRead, FullCard } from "@/convex/model/retro";
-import { applyCreate, applyDelete, applyMove, applyTextEdit } from "./optimistic";
+import { applyAddToCluster, applyCreate, applyDelete, applyFormCluster, applyMove, applyTextEdit, applyUngroup } from "./optimistic";
 
 const roomId = "room-1" as Id<"rooms">;
 const me = "u-me" as Id<"users">;
@@ -36,18 +36,27 @@ function fakeStore(initial: Record<string, unknown>) {
   return { store, writes, value: <T>(name: string) => values.get(name) as T };
 }
 
-function board(cardsVisible: "hidden" | "visible", cards: BoardRead["cards"] = []): BoardRead {
+function board(
+  cardsVisible: "hidden" | "visible",
+  cards: BoardRead["cards"] = [],
+  clusters: BoardRead["clusters"] = []
+): BoardRead {
   return {
     retro: {
       currentStageId: "s1",
       stages: [{ id: "s1", kind: "collect", cardsVisible, tallyVisible: "visible" }],
       attribution: "named",
     } as unknown as BoardRead["retro"],
-    clusters: [],
+    clusters,
     cards,
     writers: [],
   };
 }
+
+const cluster = (id: string, name: string): BoardRead["clusters"][number] =>
+  ({ _id: id as Id<"retroClusters">, _creationTime: 1, roomId, name, createdAt: 1 });
+const inCluster = (card: FullCard, clusterId: string): FullCard =>
+  ({ ...card, clusterId: clusterId as Id<"retroClusters"> });
 
 const full = (clientId: string, authorId: Id<"users">, text = clientId): FullCard => ({
   _id: `id-${clientId}` as Id<"retroCards">,
@@ -137,5 +146,54 @@ describe("applyDelete", () => {
     applyDelete(store, { roomId, clientId: "a" });
     expect(value<BoardRead>(BOARD).cards.map((c) => c.clientId)).toEqual(["b"]);
     expect(value<FullCard[]>(MINE)).toEqual([]);
+  });
+});
+
+describe("group and ungroup (spec §10.7): clusterId in board only", () => {
+  it("applyFormCluster inserts a placeholder row named by the same rule as the server and points the members at it", () => {
+    const { store, writes, value } = fakeStore({
+      [BOARD]: board("visible", [full("a", me), full("b", other), full("c", other)], [cluster("k1", "Group 1")]),
+      [MINE]: [full("a", me)],
+    });
+    applyFormCluster(store, { roomId, clientIds: ["a", "b"] }, "opt-1");
+    expect(writes).toEqual([BOARD]);
+    const next = value<BoardRead>(BOARD);
+    expect(next.clusters.map((k) => ({ _id: k._id, name: k.name }))).toEqual([
+      { _id: "k1", name: "Group 1" },
+      { _id: "opt-1", name: "Group 2" },
+    ]);
+    expect(next.cards.map((c) => c.clusterId)).toEqual(["opt-1", "opt-1", undefined]);
+  });
+
+  it("applyAddToCluster re-points the members and drops a cluster left empty; positions are untouched", () => {
+    const { store, value } = fakeStore({
+      [BOARD]: board(
+        "visible",
+        [inCluster(full("a", me), "k1"), inCluster(full("b", other), "k2")],
+        [cluster("k1", "Group 1"), cluster("k2", "Group 2")]
+      ),
+    });
+    applyAddToCluster(store, { roomId, clusterId: "k2" as Id<"retroClusters">, clientIds: ["a"] });
+    const next = value<BoardRead>(BOARD);
+    expect(next.cards.map((c) => c.clusterId)).toEqual(["k2", "k2"]);
+    expect(next.cards.map((c) => c.position)).toEqual([{ x: 0, y: 0 }, { x: 0, y: 0 }]);
+    expect(next.clusters.map((k) => k._id)).toEqual(["k2"]);
+  });
+
+  it("applyUngroup nulls clusterId and drops a cluster left empty, touching mine never", () => {
+    const { store, writes, value } = fakeStore({
+      [BOARD]: board(
+        "visible",
+        [inCluster(full("a", me), "k1"), inCluster(full("b", other), "k1"), inCluster(full("c", other), "k2")],
+        [cluster("k1", "Group 1"), cluster("k2", "Group 2")]
+      ),
+      [MINE]: [inCluster(full("a", me), "k1")],
+    });
+    applyUngroup(store, { roomId, clientIds: ["a", "c"] });
+    expect(writes).toEqual([BOARD]);
+    const next = value<BoardRead>(BOARD);
+    expect(next.cards.map((c) => c.clusterId)).toEqual([undefined, "k1", undefined]);
+    expect(next.cards.map((c) => "clusterId" in c)).toEqual([false, true, false]);
+    expect(next.clusters.map((k) => k._id)).toEqual(["k1"]);
   });
 });

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -3,6 +3,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { BoardRead, FullCard, ProjectedCard } from "@/convex/model/retro";
 import { currentStageOf } from "@/convex/model/retroFormats";
+import { nextGroupName } from "@/convex/retroCopy";
 
 /**
  * Optimistic functions (ADR-0022, spec §10.7): one synchronous pure
@@ -11,7 +12,8 @@ import { currentStageOf } from "@/convex/model/retroFormats";
  * matters. A move patches `retro.board` and `retro.mine`; a create inserts
  * into both (a silhouette or the full card by the current entry's reveal);
  * a text edit patches `retro.mine` and `retro.board` only where the board
- * already carries the text; a delete removes from both.
+ * already carries the text; a delete removes from both. Group and ungroup
+ * patch `clusterId` in `retro.board` only (spec §10.7); tidy is a move.
  */
 
 export interface CreateCardArgs {
@@ -122,4 +124,66 @@ export function applyDelete(store: OptimisticLocalStore, args: DeleteCardArgs): 
     cards: board.cards.filter((card) => card.clientId !== args.clientId),
   }));
   patchMine(store, (mine) => mine.filter((card) => card.clientId !== args.clientId));
+}
+
+export interface FormClusterArgs {
+  roomId: Id<"rooms">;
+  clientIds: string[];
+}
+
+export interface AddToClusterArgs {
+  roomId: Id<"rooms">;
+  clusterId: Id<"retroClusters">;
+  clientIds: string[];
+}
+
+export interface UngroupArgs {
+  roomId: Id<"rooms">;
+  clientIds: string[];
+}
+
+/**
+ * Point the named cards at a cluster (or none) and drop any cluster this
+ * change left empty — the server's own rule, no more: a row that was
+ * already empty is the server's to remove.
+ */
+function repointBoard(board: BoardRead, clientIds: readonly string[], clusterId: Id<"retroClusters"> | undefined): BoardRead {
+  const named = new Set(clientIds);
+  const vacated = new Set<Id<"retroClusters">>();
+  const cards = board.cards.map((card): ProjectedCard => {
+    if (!named.has(card.clientId)) return card;
+    if (card.clusterId !== undefined && card.clusterId !== clusterId) vacated.add(card.clusterId);
+    const { clusterId: _dropped, ...rest } = card;
+    return clusterId === undefined ? rest : { ...rest, clusterId };
+  });
+  if (vacated.size === 0) return { ...board, cards };
+  const populated = new Set(cards.map((card) => card.clusterId));
+  return { ...board, cards, clusters: board.clusters.filter((k) => !vacated.has(k._id) || populated.has(k._id)) };
+}
+
+/**
+ * A form: a placeholder row under the id the caller minted, named by the
+ * server's own rule, and the members pointed at it. The server's id
+ * replaces the placeholder when the result lands.
+ */
+export function applyFormCluster(store: OptimisticLocalStore, args: FormClusterArgs, placeholderId: string): void {
+  const clusterId = placeholderId as Id<"retroClusters">;
+  patchBoard(store, (board) => {
+    const row: BoardRead["clusters"][number] = {
+      _id: clusterId,
+      _creationTime: Date.now(),
+      roomId: args.roomId,
+      name: nextGroupName(board.clusters),
+      createdAt: Date.now(),
+    };
+    return repointBoard({ ...board, clusters: [...board.clusters, row] }, args.clientIds, clusterId);
+  });
+}
+
+export function applyAddToCluster(store: OptimisticLocalStore, args: AddToClusterArgs): void {
+  patchBoard(store, (board) => repointBoard(board, args.clientIds, args.clusterId));
+}
+
+export function applyUngroup(store: OptimisticLocalStore, args: UngroupArgs): void {
+  patchBoard(store, (board) => repointBoard(board, args.clientIds, undefined));
 }

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -147,18 +147,15 @@ export interface UngroupArgs {
  * change left empty — the server's own rule, no more: a row that was
  * already empty is the server's to remove.
  */
+/** Re-point the named cards; a cluster left empty keeps its row, as on the server. */
 function repointBoard(board: BoardRead, clientIds: readonly string[], clusterId: Id<"retroClusters"> | undefined): BoardRead {
   const named = new Set(clientIds);
-  const vacated = new Set<Id<"retroClusters">>();
   const cards = board.cards.map((card): ProjectedCard => {
     if (!named.has(card.clientId)) return card;
-    if (card.clusterId !== undefined && card.clusterId !== clusterId) vacated.add(card.clusterId);
     const { clusterId: _dropped, ...rest } = card;
     return clusterId === undefined ? rest : { ...rest, clusterId };
   });
-  if (vacated.size === 0) return { ...board, cards };
-  const populated = new Set(cards.map((card) => card.clusterId));
-  return { ...board, cards, clusters: board.clusters.filter((k) => !vacated.has(k._id) || populated.has(k._id)) };
+  return { ...board, cards };
 }
 
 /**

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react
 import { ReactFlow, ReactFlowProvider, type Node, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Plus, Users } from "lucide-react";
-import type { Doc } from "@/convex/_generated/dataModel";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
 import type { ResolvedDecision } from "@/convex/permissions";
 import type { UserWithPresence } from "@/hooks/useRoomPresence";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
@@ -18,8 +18,12 @@ import { StageNav, type StageControls } from "./stage-nav";
 import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
 import { CardNodeView, type CardNode } from "./card-node";
+import { ClusterNodeView, type ClusterNode, type ClusterChipActions } from "./cluster-node";
+import { SelectionBar } from "./selection-bar";
+import { clusterChips, tidyPositions } from "./clusters";
+import type { ClusterActions } from "./use-cluster-actions";
 import { CardComposer } from "./card-composer";
-import { placeNewCard, type BoardCard } from "./cards";
+import { CARD_MIN_HEIGHT, CARD_WIDTH, placeNewCard, type BoardCard } from "./cards";
 import { useHand } from "./use-hand";
 import { editingOf } from "./readiness";
 import type { CardActions } from "./use-card-actions";
@@ -34,7 +38,8 @@ export interface BoardViewer {
   onEditing: (clientId: string | undefined) => void;
   controls: StageControls;
   cards: CardActions;
-  /** Another person's card is touchable only under this decision (spec §4.2). */
+  clusters: ClusterActions;
+  /** Another person's card, and a cluster's rename, merge, tidy and dissolve, only under this decision (spec §4.2). */
   cardManagement: ResolvedDecision;
 }
 
@@ -44,6 +49,8 @@ interface RetroBoardProps {
   retro: Doc<"retros">;
   /** Every card after the board and mine merge (spec §9). */
   cards: readonly BoardCard[];
+  /** Every cluster row: a name and nothing else (ADR-0016). */
+  clusters: readonly Pick<Doc<"retroClusters">, "_id" | "name">[];
   /** Who has written, in a named retro (ADR-0012); empty under `anonymous`. */
   writers: readonly string[];
   /** The roster's members with presence merged on; a Team reader sees everyone offline. */
@@ -59,7 +66,13 @@ interface RetroBoardProps {
 }
 
 // Outside the component so React Flow sees one stable object.
-const nodeTypes: NodeTypes = { zone: PromptZoneNodeView, card: CardNodeView };
+const nodeTypes: NodeTypes = { zone: PromptZoneNodeView, card: CardNodeView, cluster: ClusterNodeView };
+
+/** React Flow elevates a selected node to 1000; a chip stays above its members either way. */
+const CHIP_Z_INDEX = 1001;
+
+/** The card size the chip centroid and tidy assume; never stored (spec §10.2). */
+const CARD_SIZE = { width: CARD_WIDTH, height: CARD_MIN_HEIGHT };
 
 const noMoves = () => {};
 
@@ -73,12 +86,19 @@ const noMoves = () => {};
  *
  * The root shows the shared stage (`data-stage`); the viewer's own view may
  * sit on another entry (`data-view-stage`) without moving anyone
- * (ADR-0010). `data-zoom-level` is fixed to `detail` until #293.
+ * (ADR-0010). `data-zoom-level` is fixed to `detail` until the zoom PR.
+ *
+ * Clusters are identities (spec §10.3): the chip at the members' centroid
+ * is derived here from the cluster rows and the cards' derived positions,
+ * so it follows a drag without a write. The selection bar turns a
+ * selection into a cluster; tidy computes the grid here and issues the
+ * one move batch.
  */
 export function RetroBoard({
   name,
   retro,
   cards,
+  clusters,
   writers,
   users,
   team,
@@ -163,7 +183,90 @@ export function RetroBoard({
     [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy]
   );
 
-  const nodes = useMemo<Node[]>(() => [...zoneNodes, ...cardNodes], [zoneNodes, cardNodes]);
+  const chips = useMemo(
+    () =>
+      clusterChips(
+        clusters,
+        cards.map((card) => ({
+          clientId: card.clientId,
+          position: hand.positions.get(card.clientId) ?? card.position,
+          ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
+        })),
+        CARD_SIZE
+      ),
+    [clusters, cards, hand.positions]
+  );
+
+  const clusterActions = viewer?.clusters;
+  const moveCards = viewer?.cards.move;
+  const chipActions = useMemo<ClusterChipActions | undefined>(() => {
+    if (!clusterActions || !moveCards) return undefined;
+    return {
+      rename: (clusterId, name) => clusterActions.rename(clusterId as Id<"retroClusters">, name),
+      merge: (from, into) => clusterActions.merge(from as Id<"retroClusters">, into as Id<"retroClusters">),
+      dissolve: (clusterId) => clusterActions.dissolve(clusterId as Id<"retroClusters">),
+      tidy: (clusterId) => {
+        const members = cards
+          .filter((card) => card.clusterId === clusterId)
+          .map((card) => ({ clientId: card.clientId, position: hand.positions.get(card.clientId) ?? card.position }));
+        moveCards(tidyPositions(members, CARD_SIZE));
+      },
+    };
+  }, [clusterActions, moveCards, cards, hand.positions]);
+
+  const clusterNodes = useMemo<ClusterNode[]>(
+    () =>
+      chips.map((chip) => ({
+        id: `cluster-${chip.clusterId}`,
+        type: "cluster",
+        position: chip.position,
+        draggable: false,
+        selectable: false,
+        focusable: false,
+        // Above a selected card, which React Flow elevates to 1000.
+        zIndex: CHIP_Z_INDEX,
+        data: {
+          chip,
+          others: chips.filter((other) => other.clusterId !== chip.clusterId),
+          ...(viewer && chipActions ? { decision: viewer.cardManagement, actions: chipActions } : {}),
+        },
+      })),
+    [chips, viewer, chipActions]
+  );
+
+  const nodes = useMemo<Node[]>(
+    () => [...zoneNodes, ...cardNodes, ...clusterNodes],
+    [zoneNodes, cardNodes, clusterNodes]
+  );
+
+  const selectedIds = useMemo(
+    () => cards.filter((card) => hand.selected.has(card.clientId)).map((card) => card.clientId),
+    [cards, hand.selected]
+  );
+  const selectedInCluster = useMemo(
+    () => cards.filter((card) => hand.selected.has(card.clientId) && card.clusterId !== undefined).length,
+    [cards, hand.selected]
+  );
+  const clusterTargets = useMemo(
+    () => clusters.map((cluster) => ({ clusterId: cluster._id as string, name: cluster.name })),
+    [clusters]
+  );
+  const clearSelection = hand.clearSelection;
+  const onGroup = useCallback(() => {
+    clusterActions?.form(selectedIds);
+    clearSelection();
+  }, [clusterActions, selectedIds, clearSelection]);
+  const onAddTo = useCallback(
+    (clusterId: string) => {
+      clusterActions?.addTo(clusterId as Id<"retroClusters">, selectedIds);
+      clearSelection();
+    },
+    [clusterActions, selectedIds, clearSelection]
+  );
+  const onRemove = useCallback(() => {
+    clusterActions?.removeFrom(selectedIds);
+    clearSelection();
+  }, [clusterActions, selectedIds, clearSelection]);
 
   const onSubmitCard = useCallback(
     async (promptId: string, text: string) => {
@@ -247,6 +350,18 @@ export function RetroBoard({
               <CanvasDotsBackground />
             </ReactFlow>
           </ReactFlowProvider>
+          {viewer && (
+            <SelectionBar
+              count={selectedIds.length}
+              inCluster={selectedInCluster}
+              clusters={clusterTargets}
+              onGroup={onGroup}
+              onAddTo={onAddTo}
+              onRemove={onRemove}
+              onClear={clearSelection}
+              className="absolute top-3 left-3 rounded-lg border bg-white/95 p-1.5 shadow-md dark:bg-surface-2/95"
+            />
+          )}
           {viewer && (
             <Button
               type="button"

--- a/src/components/retro/selection-bar.test.tsx
+++ b/src/components/retro/selection-bar.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * The selection bar (spec §10.3, §10.4): what a selection can become. Open
+ * to everyone; "Add to group" only when a cluster exists, "Remove from
+ * group" only when a selected card is in one, nothing at all for none.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render: el, children }: { render: ReactElement; children?: ReactNode }) =>
+    cloneElement(el, undefined, children),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button role="menuitem" onClick={onClick}>{children}</button>
+  ),
+}));
+
+import { SelectionBar } from "./selection-bar";
+
+afterEach(cleanup);
+
+const handlers = () => ({ onGroup: vi.fn(), onAddTo: vi.fn(), onRemove: vi.fn(), onClear: vi.fn() });
+
+describe("SelectionBar", () => {
+  it("renders nothing for an empty selection", () => {
+    render(<SelectionBar count={0} inCluster={0} clusters={[]} {...handlers()} />);
+    expect(screen.queryByTestId("selection-bar")).toBeNull();
+  });
+
+  it("offers Group for a plain selection with no clusters on the board, and clears", () => {
+    const h = handlers();
+    render(<SelectionBar count={2} inCluster={0} clusters={[]} {...h} />);
+    expect(screen.getByText("2 selected")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Group 2 cards" }));
+    expect(h.onGroup).toHaveBeenCalled();
+    expect(screen.queryByText("Add to group")).toBeNull();
+    expect(screen.queryByText("Remove from group")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+    expect(h.onClear).toHaveBeenCalled();
+  });
+
+  it("offers the clusters as Add-to targets and Remove when a selected card is grouped", () => {
+    const h = handlers();
+    render(
+      <SelectionBar
+        count={1}
+        inCluster={1}
+        clusters={[{ clusterId: "k1", name: "Group 1" }, { clusterId: "k2", name: "Demo" }]}
+        {...h}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Group 1 card" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Demo" }));
+    expect(h.onAddTo).toHaveBeenCalledWith("k2");
+    fireEvent.click(screen.getByRole("button", { name: "Remove from group" }));
+    expect(h.onRemove).toHaveBeenCalled();
+  });
+});

--- a/src/components/retro/selection-bar.tsx
+++ b/src/components/retro/selection-bar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ChevronDown, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ADD_TO_GROUP,
+  CLEAR_SELECTION,
+  REMOVE_FROM_GROUP,
+  groupCards,
+  selectedCards,
+} from "@/convex/retroCopy";
+import { cn } from "@/lib/utils";
+
+export interface SelectionBarProps {
+  /** How many cards are selected; the bar renders nothing for none. */
+  count: number;
+  /** How many of them already belong to a cluster. */
+  inCluster: number;
+  /** The clusters on the board, as "Add to group" targets. */
+  clusters: readonly { clusterId: string; name: string }[];
+  onGroup: () => void;
+  onAddTo: (clusterId: string) => void;
+  onRemove: () => void;
+  onClear: () => void;
+  className?: string;
+}
+
+/**
+ * What a selection can become (spec §10.3, §10.4): a new cluster, part of
+ * an existing one, or free again. Open to everyone — forming and changing
+ * membership are never in the config. On desktop it floats over the
+ * canvas; on a phone the same controls sit in the bottom sheet, fed by
+ * tap-select.
+ */
+export function SelectionBar({
+  count,
+  inCluster,
+  clusters,
+  onGroup,
+  onAddTo,
+  onRemove,
+  onClear,
+  className,
+}: SelectionBarProps) {
+  if (count === 0) return null;
+  return (
+    <div
+      data-testid="selection-bar"
+      data-count={count}
+      className={cn("flex flex-wrap items-center gap-2", className)}
+    >
+      <span className="text-xs text-muted-foreground">{selectedCards(count)}</span>
+      <Button type="button" size="sm" onClick={onGroup}>
+        {groupCards(count)}
+      </Button>
+      {clusters.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger render={<Button type="button" variant="outline" size="sm" />}>
+            {ADD_TO_GROUP}
+            <ChevronDown className="size-3.5" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {clusters.map((cluster) => (
+              <DropdownMenuItem key={cluster.clusterId} onClick={() => onAddTo(cluster.clusterId)}>
+                {cluster.name}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {inCluster > 0 && (
+        <Button type="button" variant="outline" size="sm" onClick={onRemove}>
+          {REMOVE_FROM_GROUP}
+        </Button>
+      )}
+      <Button type="button" variant="ghost" size="icon-sm" aria-label={CLEAR_SELECTION} onClick={onClear}>
+        <X className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/retro/use-cluster-actions.test.tsx
+++ b/src/components/retro/use-cluster-actions.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The cluster writes (spec §10.3, §10.7, §10.8): group and ungroup retry a
+ * transient failure and drop a refusal at once with its reason; rename,
+ * merge and dissolve resolve to whether they went through and toast a
+ * refusal's copy.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { ConvexError } from "convex/values";
+import type { Id } from "@/convex/_generated/dataModel";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as { fn: string; args: unknown }[],
+  outcomes: [] as (() => Promise<unknown>)[],
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/convex/_generated/api", () => ({
+  api: {
+    retro: {
+      formCluster: "retro.formCluster",
+      addToCluster: "retro.addToCluster",
+      removeFromCluster: "retro.removeFromCluster",
+      renameCluster: "retro.renameCluster",
+      mergeClusters: "retro.mergeClusters",
+      dissolveCluster: "retro.dissolveCluster",
+    },
+  },
+}));
+vi.mock("convex/react", () => ({
+  useMutation: (ref: string) => {
+    const fn = async (args: unknown) => {
+      mocks.calls.push({ fn: ref, args });
+      const next = mocks.outcomes.shift();
+      return next ? await next() : undefined;
+    };
+    return Object.assign(fn, { withOptimisticUpdate: () => fn });
+  },
+}));
+vi.mock("@/lib/toast", () => ({ toast: mocks.toast }));
+
+import { useClusterActions } from "./use-cluster-actions";
+
+const roomId = "room1" as Id<"rooms">;
+const k1 = "k1" as Id<"retroClusters">;
+const k2 = "k2" as Id<"retroClusters">;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.calls.length = 0;
+  mocks.outcomes.length = 0;
+  mocks.toast.error.mockClear();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("useClusterActions: group and ungroup", () => {
+  it("form retries a transient failure with the same selection and stays silent on success", async () => {
+    mocks.outcomes.push(() => Promise.reject(new Error("network")), () => Promise.resolve("k-new"));
+    const { result } = renderHook(() => useClusterActions(roomId));
+    result.current.form(["a", "b"]);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(mocks.calls.map((c) => c.fn)).toEqual(["retro.formCluster", "retro.formCluster"]);
+    expect(mocks.calls[1].args).toEqual({ roomId, clientIds: ["a", "b"] });
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+  });
+
+  it("addTo and removeFrom carry the ids; a refusal is not retried and toasts its reason", async () => {
+    mocks.outcomes.push(
+      () => Promise.resolve(),
+      () => Promise.reject(new ConvexError({ code: "missing", message: "That group is no longer on the board" }))
+    );
+    const { result } = renderHook(() => useClusterActions(roomId));
+    result.current.addTo(k1, ["a"]);
+    result.current.removeFrom(["b"]);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mocks.calls).toEqual([
+      { fn: "retro.addToCluster", args: { roomId, clusterId: k1, clientIds: ["a"] } },
+      { fn: "retro.removeFromCluster", args: { roomId, clientIds: ["b"] } },
+    ]);
+    expect(mocks.toast.error).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith("That group is no longer on the board");
+  });
+});
+
+describe("useClusterActions: cardManagement acts", () => {
+  it("rename, merge and dissolve resolve true on success and pass their arguments through", async () => {
+    mocks.outcomes.push(() => Promise.resolve(), () => Promise.resolve(), () => Promise.resolve());
+    const { result } = renderHook(() => useClusterActions(roomId));
+    expect(await result.current.rename(k1, "Demo")).toBe(true);
+    expect(await result.current.merge(k1, k2)).toBe(true);
+    expect(await result.current.dissolve(k2)).toBe(true);
+    expect(mocks.calls).toEqual([
+      { fn: "retro.renameCluster", args: { roomId, clusterId: k1, name: "Demo" } },
+      { fn: "retro.mergeClusters", args: { roomId, from: k1, into: k2 } },
+      { fn: "retro.dissolveCluster", args: { roomId, clusterId: k2 } },
+    ]);
+  });
+
+  it("a refused rename resolves false and toasts the refusal's copy", async () => {
+    mocks.outcomes.push(() =>
+      Promise.reject(new ConvexError({ code: "forbidden", message: "Only facilitators can do that" }))
+    );
+    const { result } = renderHook(() => useClusterActions(roomId));
+    expect(await result.current.rename(k1, "Demo")).toBe(false);
+    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith("Only facilitators can do that");
+  });
+});

--- a/src/components/retro/use-cluster-actions.ts
+++ b/src/components/retro/use-cluster-actions.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { refusalOf, retryWrite } from "@/lib/write-retry";
+import { toast } from "@/lib/toast";
+import { CLUSTER_ACT_FAILED } from "@/convex/retroCopy";
+import { applyAddToCluster, applyFormCluster, applyUngroup } from "./optimistic";
+
+export interface ClusterActions {
+  /** Form a cluster from a selection; fire and forget, the board settles by itself. */
+  form: (clientIds: string[]) => void;
+  addTo: (clusterId: Id<"retroClusters">, clientIds: string[]) => void;
+  removeFrom: (clientIds: string[]) => void;
+  /** The `cardManagement` acts resolve to whether they went through; a refusal toasts its reason. */
+  rename: (clusterId: Id<"retroClusters">, name: string) => Promise<boolean>;
+  merge: (from: Id<"retroClusters">, into: Id<"retroClusters">) => Promise<boolean>;
+  dissolve: (clusterId: Id<"retroClusters">) => Promise<boolean>;
+}
+
+/** The refusal's reason, or the fallback for a failure that outlived its retries. */
+function surface(error: unknown): void {
+  toast.error(refusalOf(error)?.message || CLUSTER_ACT_FAILED);
+}
+
+/** One non-optimistic act: whether it went through, a failure surfaced as its copy. */
+async function act(write: Promise<unknown>): Promise<boolean> {
+  try {
+    await write;
+    return true;
+  } catch (error) {
+    surface(error);
+    return false;
+  }
+}
+
+/**
+ * The cluster writes (spec §10.3, §10.7): group and ungroup are optimistic
+ * and retried on failure like a move; rename, merge and dissolve are not
+ * optimistic (the board settles on the server's answer) and surface a
+ * refusal as its copy. Tidy is not here: it is the one move batch, issued
+ * by the board through the card actions.
+ */
+export function useClusterActions(roomId: Id<"rooms">): ClusterActions {
+  const formCluster = useMutation(api.retro.formCluster);
+  const addToCluster = useMutation(api.retro.addToCluster);
+  const removeFromCluster = useMutation(api.retro.removeFromCluster);
+  const renameCluster = useMutation(api.retro.renameCluster);
+  const mergeClusters = useMutation(api.retro.mergeClusters);
+  const dissolveCluster = useMutation(api.retro.dissolveCluster);
+
+  const optimisticAdd = useMemo(() => addToCluster.withOptimisticUpdate(applyAddToCluster), [addToCluster]);
+  const optimisticRemove = useMemo(() => removeFromCluster.withOptimisticUpdate(applyUngroup), [removeFromCluster]);
+
+  const form = useCallback<ClusterActions["form"]>(
+    (clientIds) => {
+      // The placeholder id is minted once per gesture, so a retry re-points
+      // the same optimistic row rather than adding another.
+      const placeholderId = `optimistic-${crypto.randomUUID()}`;
+      const optimisticForm = formCluster.withOptimisticUpdate((store, args) =>
+        applyFormCluster(store, args, placeholderId)
+      );
+      void retryWrite(() => optimisticForm({ roomId, clientIds })).catch(surface);
+    },
+    [formCluster, roomId]
+  );
+
+  const addTo = useCallback<ClusterActions["addTo"]>(
+    (clusterId, clientIds) => {
+      void retryWrite(() => optimisticAdd({ roomId, clusterId, clientIds })).catch(surface);
+    },
+    [optimisticAdd, roomId]
+  );
+
+  const removeFrom = useCallback<ClusterActions["removeFrom"]>(
+    (clientIds) => {
+      void retryWrite(() => optimisticRemove({ roomId, clientIds })).catch(surface);
+    },
+    [optimisticRemove, roomId]
+  );
+
+  const rename = useCallback<ClusterActions["rename"]>(
+    (clusterId, name) => act(renameCluster({ roomId, clusterId, name })),
+    [renameCluster, roomId]
+  );
+
+  const merge = useCallback<ClusterActions["merge"]>(
+    (from, into) => act(mergeClusters({ roomId, from, into })),
+    [mergeClusters, roomId]
+  );
+
+  const dissolve = useCallback<ClusterActions["dissolve"]>(
+    (clusterId) => act(dissolveCluster({ roomId, clusterId })),
+    [dissolveCluster, roomId]
+  );
+
+  return useMemo(
+    () => ({ form, addTo, removeFrom, rename, merge, dissolve }),
+    [form, addTo, removeFrom, rename, merge, dissolve]
+  );
+}

--- a/src/components/retro/use-hand.ts
+++ b/src/components/retro/use-hand.ts
@@ -96,11 +96,14 @@ export function useHand({ cards, onDrop }: UseHandArgs) {
     [onDrop]
   );
 
+  /** Drop the selection: after a group or ungroup, or from the bar's clear. */
+  const clearSelection = useCallback(() => setSelected(new Set()), []);
+
   const positions = useMemo(() => {
     const map = new Map<string, Position>();
     for (const card of cards) map.set(card.clientId, overrides.get(card.clientId) ?? card.position);
     return map;
   }, [cards, overrides]);
 
-  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop };
+  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop, clearSelection };
 }


### PR DESCRIPTION
Part (a) of #293, spec §10.3, §10.9, §14, ADR-0011.

A cluster is an identity, not a location: the row holds a name only, cards carry `clusterId`, and the label chip sits at the members' centroid at render time. Forming a cluster and changing membership are open to everyone. Rename, merge, dissolve and tidy are `cardManagement`; the chip menu is disabled with the decision's copy for a participant at defaults. Tidy is the client computing a grid around the centroid and calling the one move batch. Every mutation is valid in every stage and bumps room activity.

An emptied cluster keeps its row (only merge or dissolve removes one), since deleting a row is dissolve and that is gated. An empty row draws no chip and is not offered as a target.

Tests: convex-test proves the invariants (no position, member list or count stored; merge and dissolve effects; each mutation at collect and close; the activity bump), plus jsdom for the chip, selection bar and actions hook, and node tests for the geometry.

Checked by hand in the browser: forming a group from another person's cards keeps positions and shows the chip; rename, add-to, tidy and dissolve work for the owner and the menu is disabled for a participant at defaults. The two-browser walk-through is in `tests/retro/MANUAL.md`.

Dots (#294), action sources (#296) and Playwright scenarios (#301) are out of scope.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd