### PR TITLE
feat(retro): semantic zoom, proximity hulls and the phone's chrome (#293)

### DIFF
--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -316,7 +316,6 @@ export const MERGE_INTO_SELF = "Pick a different group to merge into";
 /** Dissolve confirmation, only when the cluster has dots (spec §19; #294). */
 export const dissolveClusterConfirm = (votes: number) =>
   `Dissolve this group? Its ${votes} ${votes === 1 ? "vote is" : "votes are"} removed.`;
-export const GROUP_SELECTION = "Group";
 export const groupCards = (n: number) => `Group ${n} ${n === 1 ? "card" : "cards"}`;
 export const ADD_TO_GROUP = "Add to group";
 export const REMOVE_FROM_GROUP = "Remove from group";

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -333,3 +333,7 @@ export const TIDY_GROUP = "Tidy";
 export const DISSOLVE_GROUP = "Dissolve group";
 export const GROUP_MENU = "Group actions";
 export const CLUSTER_ACT_FAILED = "That did not go through. Try again.";
+
+// --- Mobile chrome (spec §10.4) ---
+
+export const BOARD_MENU = "Board menu";

--- a/src/components/retro/card-node.test.tsx
+++ b/src/components/retro/card-node.test.tsx
@@ -74,7 +74,7 @@ describe("CardNodeView", () => {
     expect(screen.getByTestId("editing-chip").textContent).toContain("Ben");
   });
 
-  it("at headline draws the clamped first line only, at shape a tinted block; a silhouette is a block at every level (spec §10.2)", () => {
+  it("at headline draws the clamped first line only, at shape a tinted block; a silhouette is a block below detail (spec §10.2)", () => {
     const long = { ...base, text: "first line of a long card that goes on\nsecond line" };
     const { unmount } = renderCard({ card: long, color: "green", authorName: "Ada", editable: true, level: "headline", onEditText: vi.fn() });
     let root = document.querySelector("[data-card-id='a']") as HTMLElement;

--- a/src/components/retro/card-node.test.tsx
+++ b/src/components/retro/card-node.test.tsx
@@ -73,4 +73,30 @@ describe("CardNodeView", () => {
     renderCard({ card: { ...base, own: false }, color: "green", authorName: "Ada", editingBy: "Ben", editable: false });
     expect(screen.getByTestId("editing-chip").textContent).toContain("Ben");
   });
+
+  it("at headline draws the clamped first line only, at shape a tinted block; a silhouette is a block at every level (spec §10.2)", () => {
+    const long = { ...base, text: "first line of a long card that goes on\nsecond line" };
+    const { unmount } = renderCard({ card: long, color: "green", authorName: "Ada", editable: true, level: "headline", onEditText: vi.fn() });
+    let root = document.querySelector("[data-card-id='a']") as HTMLElement;
+    expect(root.getAttribute("data-level")).toBe("headline");
+    expect(root.textContent).toBe("first line of a long card that goes on");
+    expect(screen.queryByTestId("author-chip")).toBeNull();
+    expect(screen.queryByLabelText("Card text")).toBeNull();
+    expect(root.style.height).toBe("56px");
+    unmount();
+
+    renderCard({ card: long, color: "green", authorName: "Ada", editable: true, level: "shape", onEditText: vi.fn() });
+    root = document.querySelector("[data-card-id='a']") as HTMLElement;
+    expect(root.getAttribute("data-level")).toBe("shape");
+    expect(root.textContent).toBe("");
+    expect(root.getAttribute("data-hidden")).toBe("false");
+    expect(root.style.height).toBe("96px");
+    cleanup();
+
+    renderCard({ card: { ...base, hidden: true, text: undefined, own: false }, color: "green", editable: false, level: "headline" });
+    root = document.querySelector("[data-card-id='a']") as HTMLElement;
+    expect(root.getAttribute("data-hidden")).toBe("true");
+    expect(root.getAttribute("aria-label")).toBe("Hidden card");
+    expect(root.textContent).toBe("");
+  });
 });

--- a/src/components/retro/card-node.tsx
+++ b/src/components/retro/card-node.tsx
@@ -14,8 +14,9 @@ import {
   UNSAVED_CHIP,
 } from "@/convex/retroCopy";
 import { tintClasses } from "./tints";
-import { CARD_WIDTH, type BoardCard } from "./cards";
+import type { BoardCard } from "./cards";
 import { useCardDraft } from "./use-card-draft";
+import { cardSizeAt, headlineOf, type ZoomLevel } from "./zoom";
 
 // A type alias: React Flow node data must satisfy Record<string, unknown>.
 export type CardNodeData = {
@@ -28,6 +29,10 @@ export type CardNodeData = {
   editingBy?: string;
   /** Own card, or another's under `cardManagement`. */
   editable: boolean;
+  /** The semantic zoom level (spec §10.2); detail when absent. */
+  level?: ZoomLevel;
+  /** In the tap-selection (spec §10.4), which the board keeps out of React Flow's own. */
+  tapSelected?: boolean;
   onEditText?: (clientId: string, text: string) => Promise<void>;
   onDelete?: (clientId: string) => void;
   /** The editing indicator: the card focused, or none. */
@@ -37,27 +42,63 @@ export type CardNodeData = {
 export type CardNode = Node<CardNodeData, "card">;
 
 /**
- * A card on the board (ADR-0011 at the detail level, ADR-0015, spec §10.9):
- * text, tint and author chip, or a tint-only silhouette when the viewer has
- * no text for it. Its data attributes are the canvas contract the tests
- * read; `data-late` is a placeholder until #295.
+ * A card on the board (ADR-0011, ADR-0015, spec §10.2, §10.9): at detail
+ * the text, tint and author chip; at headline the clamped first line and
+ * tint; at shape a tinted block. A silhouette — a card the viewer has no
+ * text for — is a tint-only block at every level. The size is a function
+ * of the level and never stored. Its data attributes are the canvas
+ * contract the tests read; `data-late` is a placeholder until #295.
  */
-export const CardNodeView = memo(function CardNodeView({ data, selected }: NodeProps<CardNode>) {
-  const { card, color, authorName, editingBy, editable } = data;
+export const CardNodeView = memo(function CardNodeView({ data, selected: flowSelected }: NodeProps<CardNode>) {
+  const { card, color, authorName, editingBy, editable, level = "detail" } = data;
+  const selected = flowSelected || data.tapSelected === true;
   const tint = tintClasses(color);
+  const size = cardSizeAt(level);
+  const attributes = {
+    "data-card-id": card.clientId,
+    "data-hidden": String(card.hidden),
+    "data-cluster-id": card.clusterId ?? "",
+    "data-late": "false",
+    "data-level": level,
+    "data-selected": String(selected),
+  };
+  if (level === "shape" || (card.hidden && level !== "detail")) {
+    return (
+      <div
+        {...attributes}
+        role="img"
+        aria-label={card.hidden ? HIDDEN_CARD_LABEL : headlineOf(card.text ?? "")}
+        className={cn("rounded-xl border shadow-sm", tint.zone, card.hidden && "opacity-60", selected && "ring-2 ring-ring")}
+        style={{ width: size.width, height: size.height }}
+      />
+    );
+  }
+  if (level === "headline") {
+    return (
+      <div
+        {...attributes}
+        className={cn(
+          "flex items-center rounded-xl border px-3 text-base font-medium shadow-sm",
+          tint.zone,
+          "bg-white/90 dark:bg-surface-2/90",
+          selected && "ring-2 ring-ring"
+        )}
+        style={{ width: size.width, height: size.height }}
+      >
+        <p className="truncate">{headlineOf(card.text ?? "")}</p>
+      </div>
+    );
+  }
   return (
     <div
-      data-card-id={card.clientId}
-      data-hidden={String(card.hidden)}
-      data-cluster-id={card.clusterId ?? ""}
-      data-late="false"
+      {...attributes}
       className={cn(
         "flex flex-col gap-2 rounded-xl border p-3 text-sm shadow-sm",
         tint.zone,
         "bg-white/90 dark:bg-surface-2/90",
         selected && "ring-2 ring-ring"
       )}
-      style={{ width: CARD_WIDTH }}
+      style={{ width: size.width }}
     >
       {card.hidden ? (
         <div

--- a/src/components/retro/cluster-node.test.tsx
+++ b/src/components/retro/cluster-node.test.tsx
@@ -7,7 +7,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, within, act } from "@testing-library/react";
 import { cloneElement, type ReactElement, type ReactNode } from "react";
-import type { NodeProps } from "@xyflow/react";
+import { useLayoutEffect } from "react";
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -38,9 +39,23 @@ const others = [{ clusterId: "k2", name: "Group 2" }];
 const allowed = { allowed: true as const };
 const denied = { allowed: false as const, message: "Only facilitators can manage cards" };
 
-function renderChip(data: ClusterNode["data"]) {
+/** The viewport zoom the node reads, set on the store the provider owns. */
+function AtZoom({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useLayoutEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [store, zoom]);
+  return null;
+}
+
+function renderChip(data: ClusterNode["data"], zoom = 1) {
   const props = { id: data.chip.clusterId, data } as unknown as NodeProps<ClusterNode>;
-  return render(<ClusterNodeView {...props} />);
+  return render(
+    <ReactFlowProvider>
+      <AtZoom zoom={zoom} />
+      <ClusterNodeView {...props} />
+    </ReactFlowProvider>
+  );
 }
 
 const actions = () => ({
@@ -98,5 +113,17 @@ describe("ClusterNodeView", () => {
   it("merge is disabled when there is no other cluster", () => {
     renderChip({ chip, others: [], decision: allowed, actions: actions() });
     expect((screen.getByRole("menuitem", { name: "Merge into…" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("at shape zoom the chip is scaled by the inverse zoom so it holds constant screen size (spec §10.2)", () => {
+    renderChip({ chip, others }, 0.25);
+    const root = document.querySelector("[data-cluster-chip='k1']") as HTMLElement;
+    expect(root.getAttribute("data-level")).toBe("shape");
+    expect(root.style.transform).toBe("translate(-50%, -50%) scale(4)");
+    cleanup();
+    renderChip({ chip, others }, 1);
+    const detail = document.querySelector("[data-cluster-chip='k1']") as HTMLElement;
+    expect(detail.getAttribute("data-level")).toBe("detail");
+    expect(detail.style.transform).toBe("translate(-50%, -50%) scale(1)");
   });
 });

--- a/src/components/retro/cluster-node.test.tsx
+++ b/src/components/retro/cluster-node.test.tsx
@@ -30,12 +30,14 @@ vi.mock("@/components/ui/dialog", () => {
   };
 });
 
-import { ClusterNodeView, type ClusterNode } from "./cluster-node";
+import { ClusterNodeView, type ClusterId, type ClusterNode } from "./cluster-node";
 
 afterEach(cleanup);
 
-const chip = { clusterId: "k1", name: "Group 1", position: { x: 100, y: 50 }, count: 3 };
-const others = [{ clusterId: "k2", name: "Group 2" }];
+const k1 = "k1" as ClusterId;
+const k2 = "k2" as ClusterId;
+const chip = { clusterId: k1, name: "Group 1", position: { x: 100, y: 50 }, count: 3 };
+const others = [{ clusterId: k2, name: "Group 2" }];
 const allowed = { allowed: true as const };
 const denied = { allowed: false as const, message: "Only facilitators can manage cards" };
 

--- a/src/components/retro/cluster-node.tsx
+++ b/src/components/retro/cluster-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useState } from "react";
-import type { Node, NodeProps } from "@xyflow/react";
+import { useStore, type Node, type NodeProps } from "@xyflow/react";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -36,6 +36,7 @@ import {
   cardsCount,
 } from "@/convex/retroCopy";
 import type { ClusterChip } from "./clusters";
+import { zoomLevelOf } from "./zoom";
 
 /** The `cardManagement` acts on one cluster, as the board wires them. */
 export interface ClusterChipActions {
@@ -58,24 +59,32 @@ export type ClusterNodeData = {
 
 export type ClusterNode = Node<ClusterNodeData, "cluster">;
 
+const selectZoom = (state: { transform: [number, number, number] }) => state.transform[2];
+
 /**
  * A cluster's label chip (spec §10.3, ADR-0011): the name and member count,
  * centred on the members' centroid at render time. The chip is the one
  * place a cluster is acted on: rename, merge, tidy and dissolve sit in its
  * menu under `cardManagement`, disabled with the decision's copy otherwise.
- * It never moves its members; tidy is the explicit opt-in.
+ * It never moves its members; tidy is the explicit opt-in. At the shape
+ * level the chip is held at constant screen size and becomes the board's
+ * content (spec §10.2).
  */
 export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps<ClusterNode>) {
   const { chip, others, decision, actions } = data;
+  const zoom = useStore(selectZoom);
+  const level = zoomLevelOf(zoom);
   const [renaming, setRenaming] = useState(false);
   const [merging, setMerging] = useState(false);
   const managed = decision !== undefined && actions !== undefined;
   const allowed = managed && decision.allowed;
+  const scale = level === "shape" ? 1 / zoom : 1;
   return (
     <div
       data-cluster-chip={chip.clusterId}
       data-count={chip.count}
-      className="-translate-x-1/2 -translate-y-1/2"
+      data-level={level}
+      style={{ transform: `translate(-50%, -50%) scale(${scale})` }}
     >
       <div
         className={cn(

--- a/src/components/retro/cluster-node.tsx
+++ b/src/components/retro/cluster-node.tsx
@@ -35,23 +35,32 @@ import {
   TIDY_GROUP,
   cardsCount,
 } from "@/convex/retroCopy";
+import type { Id } from "@/convex/_generated/dataModel";
 import type { ClusterChip } from "./clusters";
 import { zoomLevelOf } from "./zoom";
 
 /** The `cardManagement` acts on one cluster, as the board wires them. */
+export type ClusterId = Id<"retroClusters">;
+
 export interface ClusterChipActions {
-  rename: (clusterId: string, name: string) => Promise<boolean>;
-  merge: (from: string, into: string) => Promise<boolean>;
-  dissolve: (clusterId: string) => Promise<boolean>;
+  rename: (clusterId: ClusterId, name: string) => Promise<boolean>;
+  merge: (from: ClusterId, into: ClusterId) => Promise<boolean>;
+  dissolve: (clusterId: ClusterId) => Promise<boolean>;
   /** Tidy: the board computes the positions and issues the one move batch. */
-  tidy: (clusterId: string) => void;
+  tidy: (clusterId: ClusterId) => void;
+}
+
+/** A merge target: another cluster on the board. */
+export interface ClusterTarget {
+  clusterId: ClusterId;
+  name: string;
 }
 
 // A type alias: React Flow node data must satisfy Record<string, unknown>.
 export type ClusterNodeData = {
-  chip: ClusterChip;
+  chip: ClusterChip<ClusterId>;
   /** The other clusters on the board, as merge targets. */
-  others: readonly { clusterId: string; name: string }[];
+  others: readonly ClusterTarget[];
   /** The `cardManagement` decision; absent for a Team reader, who gets the label alone. */
   decision?: ResolvedDecision;
   actions?: ClusterChipActions;
@@ -201,11 +210,11 @@ function MergeDialog({
   onClose,
   onMerge,
 }: {
-  others: readonly { clusterId: string; name: string }[];
+  others: readonly ClusterTarget[];
   onClose: () => void;
-  onMerge: (into: string) => Promise<boolean>;
+  onMerge: (into: ClusterId) => Promise<boolean>;
 }) {
-  const [into, setInto] = useState(others[0]?.clusterId ?? "");
+  const [into, setInto] = useState<ClusterId | "">(others[0]?.clusterId ?? "");
   const [merging, setMerging] = useState(false);
   const merge = async () => {
     if (!into || merging) return;
@@ -232,7 +241,7 @@ function MergeDialog({
             <select
               id="merge-into"
               value={into}
-              onChange={(e) => setInto(e.target.value)}
+              onChange={(e) => setInto(e.target.value as ClusterId)}
               className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
             >
               {others.map((other) => (

--- a/src/components/retro/clusters.test.ts
+++ b/src/components/retro/clusters.test.ts
@@ -49,6 +49,21 @@ describe("tidyPositions", () => {
     ]);
   });
 
+  it("reads a measured height over the level's: the chip centres on the real box, and a tidy row is as tall as its tallest member", () => {
+    const tall = { ...card("a", 0, 0, "k1"), height: 300 };
+    const short = card("b", 400, 0, "k1");
+    // Centres (100, 150) and (500, 50) → centroid (300, 100), not (300, 50).
+    expect(clusterChips([{ _id: "k1", name: "Group 1" }], [tall, short], size)[0].position).toEqual({ x: 300, y: 100 });
+    const moves = tidyPositions([tall, short, card("c", 0, 600), card("d", 400, 600)], size, 20);
+    // Row one is 300 tall, row two 100: a 420 × 420 grid around the centroid of the centres, (300, 375).
+    expect(moves.map((m) => m.position)).toEqual([
+      { x: 90, y: 165 },
+      { x: 310, y: 165 },
+      { x: 90, y: 485 },
+      { x: 310, y: 485 },
+    ]);
+  });
+
   it("a single member is left where it is", () => {
     expect(tidyPositions([card("a", 40, 50)], size)).toEqual([{ clientId: "a", position: { x: 40, y: 50 } }]);
   });

--- a/src/components/retro/clusters.ts
+++ b/src/components/retro/clusters.ts
@@ -4,6 +4,8 @@
  * members' centroid at render time; tidy is the client computing positions
  * around that centroid and calling the one move batch. Pure, so the board
  * derives its chip nodes by memo and a node test proves the layout.
+ * Geometry reads a member's measured height when it has one, so a detail
+ * card taller than the minimum is not mistaken for the minimum.
  */
 
 export interface Point {
@@ -16,14 +18,16 @@ export interface Size {
   height: number;
 }
 
-export interface Member {
+export interface Member<K extends string = string> {
   clientId: string;
   position: Point;
-  clusterId?: string;
+  clusterId?: K;
+  /** The box React Flow measured, when it has; at detail the text sets it. */
+  height?: number;
 }
 
-export interface ClusterChip {
-  clusterId: string;
+export interface ClusterChip<K extends string = string> {
+  clusterId: K;
   name: string;
   /** The centroid of the members' centres, in canvas coordinates. */
   position: Point;
@@ -41,25 +45,28 @@ export function centroidOf(points: readonly Point[]): Point | undefined {
   return { x: x / points.length, y: y / points.length };
 }
 
+/** The card's height: what was measured, else the level's. */
+export const heightOf = (card: Member, size: Size): number => card.height ?? size.height;
+
 const centreOf = (card: Member, size: Size): Point => ({
   x: card.position.x + size.width / 2,
-  y: card.position.y + size.height / 2,
+  y: card.position.y + heightOf(card, size) / 2,
 });
 
 /** One chip per cluster that has members, at their centroid; an empty cluster has none. */
-export function clusterChips(
-  clusters: readonly { _id: string; name: string }[],
-  cards: readonly Member[],
+export function clusterChips<K extends string>(
+  clusters: readonly { _id: K; name: string }[],
+  cards: readonly Member<K>[],
   size: Size
-): ClusterChip[] {
-  const centres = new Map<string, Point[]>();
+): ClusterChip<K>[] {
+  const centres = new Map<K, Point[]>();
   for (const card of cards) {
     if (card.clusterId === undefined) continue;
     const list = centres.get(card.clusterId) ?? [];
     list.push(centreOf(card, size));
     centres.set(card.clusterId, list);
   }
-  const chips: ClusterChip[] = [];
+  const chips: ClusterChip<K>[] = [];
   for (const cluster of clusters) {
     const points = centres.get(cluster._id);
     const position = points && centroidOf(points);
@@ -88,15 +95,20 @@ export function tidyPositions(
   );
   const columns = Math.ceil(Math.sqrt(ordered.length));
   const rows = Math.ceil(ordered.length / columns);
+  // Each row is as tall as its tallest member, so detail cards never overlap.
+  const rowHeights = Array.from({ length: rows }, (_, r) =>
+    Math.max(...ordered.slice(r * columns, (r + 1) * columns).map((m) => heightOf(m, size)))
+  );
+  const rowTops = rowHeights.map((_, r) => rowHeights.slice(0, r).reduce((sum, h) => sum + h + gap, 0));
   const totalWidth = columns * size.width + (columns - 1) * gap;
-  const totalHeight = rows * size.height + (rows - 1) * gap;
+  const totalHeight = rowHeights.reduce((sum, h) => sum + h, 0) + (rows - 1) * gap;
   const originX = centroid.x - totalWidth / 2;
   const originY = centroid.y - totalHeight / 2;
   return ordered.map((m, i) => ({
     clientId: m.clientId,
     position: {
       x: originX + (i % columns) * (size.width + gap),
-      y: originY + Math.floor(i / columns) * (size.height + gap),
+      y: originY + rowTops[Math.floor(i / columns)],
     },
   }));
 }

--- a/src/components/retro/hull-node.tsx
+++ b/src/components/retro/hull-node.tsx
@@ -1,0 +1,26 @@
+import { memo } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
+import type { Hull } from "./hulls";
+
+// A type alias: React Flow node data must satisfy Record<string, unknown>.
+export type HullNodeData = { hull: Hull };
+export type HullNode = Node<HullNodeData, "hull">;
+
+/**
+ * A proximity hull (spec §10.3, ADR-0011): a dashed outline around cards
+ * that sit close together while the shared pointer is in `group`. Inert
+ * and identity-free: it is derived from positions on every render, so a
+ * member moving away dissolves it, and naming one — forming a cluster from
+ * its members — is what promotes it.
+ */
+export const HullNodeView = memo(function HullNodeView({ data }: NodeProps<HullNode>) {
+  const { hull } = data;
+  return (
+    <div
+      data-hull={hull.key}
+      data-members={hull.members.length}
+      className="rounded-3xl border-2 border-dashed border-ring/40 bg-ring/5"
+      style={{ width: hull.width, height: hull.height }}
+    />
+  );
+});

--- a/src/components/retro/hulls.test.ts
+++ b/src/components/retro/hulls.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Proximity hulls (spec §10.3, ADR-0011): drawn only in `group`, from
+ * near-connected ungrouped cards, with no identity beyond their members;
+ * a member moving away dissolves the hull.
+ */
+import { describe, it, expect } from "vitest";
+import { hullsFor, proximityHulls } from "./hulls";
+
+const size = { width: 200, height: 100 };
+const card = (clientId: string, x: number, y: number, clusterId?: string) => ({
+  clientId,
+  position: { x, y },
+  ...(clusterId ? { clusterId } : {}),
+});
+
+describe("proximityHulls", () => {
+  it("joins cards whose boxes come within the gap into one hull, padded around their bounds", () => {
+    const hulls = proximityHulls([card("a", 0, 0), card("b", 230, 10), card("c", 900, 900)], size, 40, 16);
+    expect(hulls).toEqual([
+      { key: "a+b", members: ["a", "b"], position: { x: -16, y: -16 }, width: 462, height: 142 },
+    ]);
+  });
+
+  it("chains through a middle card, and dissolves when a member moves away", () => {
+    const chain = [card("a", 0, 0), card("b", 220, 0), card("c", 440, 0)];
+    expect(proximityHulls(chain, size).map((h) => h.members)).toEqual([["a", "b", "c"]]);
+    const moved = [card("a", 0, 0), card("b", 220, 0), card("c", 800, 0)];
+    expect(proximityHulls(moved, size).map((h) => h.members)).toEqual([["a", "b"]]);
+  });
+
+  it("ignores cards that already belong to a cluster", () => {
+    expect(proximityHulls([card("a", 0, 0, "k1"), card("b", 210, 0)], size)).toEqual([]);
+    expect(proximityHulls([card("a", 0, 0, "k1"), card("b", 210, 0, "k1")], size)).toEqual([]);
+  });
+});
+
+describe("hullsFor", () => {
+  it("draws hulls only while the shared pointer is in group", () => {
+    const cards = [card("a", 0, 0), card("b", 210, 0)];
+    expect(hullsFor("group", cards, size)).toHaveLength(1);
+    for (const kind of ["collect", "review", "vote", "discuss", "close"] as const) {
+      expect(hullsFor(kind, cards, size)).toEqual([]);
+    }
+  });
+});

--- a/src/components/retro/hulls.test.ts
+++ b/src/components/retro/hulls.test.ts
@@ -21,6 +21,12 @@ describe("proximityHulls", () => {
     ]);
   });
 
+  it("a measured height reaches further than the level's box", () => {
+    const cards = [card("a", 0, 0), card("b", 0, 300)];
+    expect(proximityHulls(cards, size)).toEqual([]);
+    expect(proximityHulls([{ ...cards[0], height: 280 }, cards[1]], size).map((h) => h.height)).toEqual([432]);
+  });
+
   it("chains through a middle card, and dissolves when a member moves away", () => {
     const chain = [card("a", 0, 0), card("b", 220, 0), card("c", 440, 0)];
     expect(proximityHulls(chain, size).map((h) => h.members)).toEqual([["a", "b", "c"]]);

--- a/src/components/retro/hulls.ts
+++ b/src/components/retro/hulls.ts
@@ -1,5 +1,5 @@
 import type { StageKind } from "@/convex/model/retroFormats";
-import type { Member, Point, Size } from "./clusters";
+import { heightOf, type Member, type Point, type Size } from "./clusters";
 
 /**
  * Proximity hulls (spec §10.3, ADR-0011): the transient shape drawn around
@@ -49,7 +49,7 @@ export function proximityHulls(
       left: card.position.x,
       top: card.position.y,
       right: card.position.x + size.width,
-      bottom: card.position.y + size.height,
+      bottom: card.position.y + heightOf(card, size),
     }));
   // Union-find over pairs that come near.
   const parent = boxes.map((_, i) => i);

--- a/src/components/retro/hulls.ts
+++ b/src/components/retro/hulls.ts
@@ -1,0 +1,83 @@
+import type { StageKind } from "@/convex/model/retroFormats";
+import type { Member, Point, Size } from "./clusters";
+
+/**
+ * Proximity hulls (spec §10.3, ADR-0011): the transient shape drawn around
+ * cards that happen to sit close together. An affordance for forming a
+ * cluster, never a representation of one: a hull has no identity, is
+ * derived from positions on every render (so it dissolves when a member
+ * moves), ignores cards that already belong to a cluster, and is drawn only
+ * while the shared pointer is in a `group` entry.
+ */
+
+export interface Hull {
+  /** Derived from the sorted member ids; stable while the members stand, no identity beyond. */
+  key: string;
+  members: string[];
+  position: Point;
+  width: number;
+  height: number;
+}
+
+/** How near two card boxes must come, in canvas units, to share a hull. */
+export const HULL_GAP = 40;
+/** How far the hull is drawn outside its members' boxes. */
+export const HULL_PADDING = 16;
+
+interface Box {
+  clientId: string;
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+const near = (a: Box, b: Box, gap: number) =>
+  a.left - gap < b.right && b.left - gap < a.right && a.top - gap < b.bottom && b.top - gap < a.bottom;
+
+/** The hulls among the ungrouped cards: every near-connected component of two or more. */
+export function proximityHulls(
+  cards: readonly Member[],
+  size: Size,
+  gap = HULL_GAP,
+  padding = HULL_PADDING
+): Hull[] {
+  const boxes: Box[] = cards
+    .filter((card) => card.clusterId === undefined)
+    .map((card) => ({
+      clientId: card.clientId,
+      left: card.position.x,
+      top: card.position.y,
+      right: card.position.x + size.width,
+      bottom: card.position.y + size.height,
+    }));
+  // Union-find over pairs that come near.
+  const parent = boxes.map((_, i) => i);
+  const find = (i: number): number => (parent[i] === i ? i : (parent[i] = find(parent[i])));
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      if (near(boxes[i], boxes[j], gap)) parent[find(i)] = find(j);
+    }
+  }
+  const groups = new Map<number, Box[]>();
+  boxes.forEach((box, i) => {
+    const root = find(i);
+    groups.set(root, [...(groups.get(root) ?? []), box]);
+  });
+  const hulls: Hull[] = [];
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const left = Math.min(...group.map((b) => b.left)) - padding;
+    const top = Math.min(...group.map((b) => b.top)) - padding;
+    const right = Math.max(...group.map((b) => b.right)) + padding;
+    const bottom = Math.max(...group.map((b) => b.bottom)) + padding;
+    const members = group.map((b) => b.clientId).sort();
+    hulls.push({ key: members.join("+"), members, position: { x: left, y: top }, width: right - left, height: bottom - top });
+  }
+  return hulls.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/** The hulls the board draws: only in a `group` entry, none anywhere else. */
+export function hullsFor(stageKind: StageKind, cards: readonly Member[], size: Size): Hull[] {
+  return stageKind === "group" ? proximityHulls(cards, size) : [];
+}

--- a/src/components/retro/mobile-chrome.test.tsx
+++ b/src/components/retro/mobile-chrome.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * The phone's chrome (spec §10.4, ADR-0011): one stage pill, one bottom
+ * sheet, one card-creation button, and the tap-selection's Group controls
+ * in the same bar. Writing a card needs no spatial step: the button opens
+ * the composer, whose prompt picker is the only choice.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render: el, children }: { render: ReactElement; children?: ReactNode }) =>
+    cloneElement(el, undefined, children),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button role="menuitem" onClick={onClick}>{children}</button>
+  ),
+}));
+vi.mock("@/components/ui/sheet", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Sheet: ({ children, open }: { children?: ReactNode; open: boolean }) => (open ? <div role="dialog">{children}</div> : null),
+    SheetContent: ({ children, ...rest }: { children?: ReactNode; "data-testid"?: string }) => (
+      <div data-testid={rest["data-testid"]}>{children}</div>
+    ),
+    SheetHeader: pass,
+    SheetTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    SheetDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+  };
+});
+
+import { MobileChrome } from "./mobile-chrome";
+import { CardComposer } from "./card-composer";
+import { useState } from "react";
+
+afterEach(cleanup);
+
+const prompts = [
+  { id: "p1", label: "What went well?", color: "green", order: 0 },
+  { id: "p2", label: "Ideas", color: "blue", order: 1 },
+];
+
+describe("MobileChrome", () => {
+  it("renders the stage pill, the sheet on demand, and the card button", () => {
+    const onCompose = vi.fn();
+    render(
+      <MobileChrome name="Sprint 42" stageKind="collect" onCompose={onCompose}>
+        <p>sheet body</p>
+      </MobileChrome>
+    );
+    expect(screen.getByTestId("stage-pill").getAttribute("data-stage")).toBe("collect");
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Board menu" }));
+    expect(screen.getByTestId("board-sheet").textContent).toContain("sheet body");
+    expect(screen.getByRole("heading", { name: "Sprint 42" })).toBeTruthy();
+    expect(screen.getByText("Not kept by a team. This retro disappears after 5 quiet days.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Add card" }));
+    expect(onCompose).toHaveBeenCalled();
+  });
+
+  it("a Team reader gets the pill and the sheet, no card button and no Group controls", () => {
+    render(
+      <MobileChrome name="R" teamName="Owls" stageKind="discuss">
+        <p>roster</p>
+      </MobileChrome>
+    );
+    expect(screen.queryByRole("button", { name: "Add card" })).toBeNull();
+    expect(screen.queryByTestId("selection-bar")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Board menu" }));
+    expect(screen.getByText(/Kept by Owls/)).toBeTruthy();
+  });
+
+  it("surfaces the tap-selection's Group control in the bar", () => {
+    const onGroup = vi.fn();
+    render(
+      <MobileChrome
+        name="R"
+        stageKind="group"
+        selection={{ count: 2, inCluster: 0, clusters: [], onGroup, onAddTo: vi.fn(), onRemove: vi.fn(), onClear: vi.fn() }}
+      >
+        <p />
+      </MobileChrome>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Group 2 cards" }));
+    expect(onGroup).toHaveBeenCalled();
+  });
+
+  it("a card is written from the bar through the composer's prompt picker, with no spatial step", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    function Phone() {
+      const [composing, setComposing] = useState(false);
+      return (
+        <>
+          <MobileChrome name="R" stageKind="collect" onCompose={() => setComposing(true)}>
+            <p />
+          </MobileChrome>
+          <CardComposer
+            open={composing}
+            onOpenChange={setComposing}
+            prompts={prompts}
+            viewerName="Ada"
+            attribution="named"
+            hidden
+            onSubmit={onSubmit}
+          />
+        </>
+      );
+    }
+    render(<Phone />);
+    fireEvent.click(screen.getByRole("button", { name: "Add card" }));
+    const picker = screen.getByLabelText("Prompt") as HTMLSelectElement;
+    fireEvent.change(picker, { target: { value: "p2" } });
+    fireEvent.change(screen.getByLabelText("Your card"), { target: { value: "Try mob sessions" } });
+    fireEvent.click(screen.getByRole("button", { name: "Post card" }));
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledWith("p2", "Try mob sessions"));
+  });
+});

--- a/src/components/retro/mobile-chrome.tsx
+++ b/src/components/retro/mobile-chrome.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Menu, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { StageKind } from "@/convex/model/retroFormats";
+import { ADD_CARD, BOARD_MENU, TEAMLESS_DISCLOSURE, keptByTeam } from "@/convex/retroCopy";
+import { StagePill } from "./stage-pill";
+import { SelectionBar, type SelectionBarProps } from "./selection-bar";
+
+export interface MobileChromeProps {
+  name: string;
+  /** The Team that keeps the retro, for the disclosure line; undefined for a teamless one. */
+  teamName?: string;
+  stageKind: StageKind;
+  timeboxMinutes?: number;
+  enteredAt?: number;
+  /** The tap-selection, for the Group controls; absent for a Team reader. */
+  selection?: Omit<SelectionBarProps, "className">;
+  /** Opens the composer; absent for a Team reader. */
+  onCompose?: () => void;
+  /** What the bottom sheet holds: the stage strip, the roster, the menu. */
+  children: ReactNode;
+}
+
+/**
+ * The phone's chrome (spec §10.4, ADR-0011): a full-bleed canvas under one
+ * stage pill, one bottom sheet holding everything the desktop header and
+ * strip hold, no minimap, and one card-creation button that opens the
+ * composer with its prompt picker — the phone's dominant case is async
+ * collection, which needs no spatial step. A tap-selection surfaces its
+ * Group controls in the same bar.
+ */
+export function MobileChrome({
+  name,
+  teamName,
+  stageKind,
+  timeboxMinutes,
+  enteredAt,
+  selection,
+  onCompose,
+  children,
+}: MobileChromeProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div className="pointer-events-none absolute top-3 left-3 z-10">
+        <div className="pointer-events-auto">
+          <StagePill kind={stageKind} timeboxMinutes={timeboxMinutes} enteredAt={enteredAt} />
+        </div>
+      </div>
+      <div
+        data-testid="mobile-bar"
+        className="absolute inset-x-0 bottom-0 z-10 flex flex-col gap-2 border-t bg-white/95 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:bg-surface-1/95"
+      >
+        {selection && <SelectionBar {...selection} />}
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" size="icon" aria-label={BOARD_MENU} onClick={() => setOpen(true)}>
+            <Menu className="size-4" />
+          </Button>
+          {onCompose && (
+            <Button type="button" className="flex-1" onClick={onCompose}>
+              <Plus className="size-4" />
+              {ADD_CARD}
+            </Button>
+          )}
+        </div>
+      </div>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="bottom" data-testid="board-sheet" className="max-h-[85vh] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>{name}</SheetTitle>
+            <SheetDescription>{teamName ? keptByTeam(teamName) : TEAMLESS_DISCLOSURE}</SheetDescription>
+          </SheetHeader>
+          {children}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
-import { ReactFlow, ReactFlowProvider, type Node, type NodeTypes } from "@xyflow/react";
+import { ReactFlow, ReactFlowProvider, useStore, type Node, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Plus, Users } from "lucide-react";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
@@ -19,6 +19,11 @@ import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
 import { CardNodeView, type CardNode } from "./card-node";
 import { ClusterNodeView, type ClusterNode, type ClusterChipActions } from "./cluster-node";
+import { HullNodeView, type HullNode } from "./hull-node";
+import { hullsFor } from "./hulls";
+import { MobileChrome } from "./mobile-chrome";
+import { cardSizeAt, zoomLevelOf, type ZoomLevel } from "./zoom";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { SelectionBar } from "./selection-bar";
 import { clusterChips, tidyPositions } from "./clusters";
 import type { ClusterActions } from "./use-cluster-actions";
@@ -66,13 +71,27 @@ interface RetroBoardProps {
 }
 
 // Outside the component so React Flow sees one stable object.
-const nodeTypes: NodeTypes = { zone: PromptZoneNodeView, card: CardNodeView, cluster: ClusterNodeView };
+const nodeTypes: NodeTypes = {
+  zone: PromptZoneNodeView,
+  card: CardNodeView,
+  cluster: ClusterNodeView,
+  hull: HullNodeView,
+};
 
 /** React Flow elevates a selected node to 1000; a chip stays above its members either way. */
 const CHIP_Z_INDEX = 1001;
 
-/** The card size the chip centroid and tidy assume; never stored (spec §10.2). */
+/** The card size the chip centroid, hulls and tidy assume; never stored (spec §10.2). */
 const CARD_SIZE = { width: CARD_WIDTH, height: CARD_MIN_HEIGHT };
+
+const selectZoomLevel = (state: { transform: [number, number, number] }) => zoomLevelOf(state.transform[2]);
+
+/** Inside the provider: reports the semantic level whenever the viewport crosses a boundary. */
+function ZoomLevelSync({ onLevel }: { onLevel: (level: ZoomLevel) => void }) {
+  const level = useStore(selectZoomLevel);
+  useEffect(() => onLevel(level), [level, onLevel]);
+  return null;
+}
 
 const noMoves = () => {};
 
@@ -86,7 +105,13 @@ const noMoves = () => {};
  *
  * The root shows the shared stage (`data-stage`); the viewer's own view may
  * sit on another entry (`data-view-stage`) without moving anyone
- * (ADR-0010). `data-zoom-level` is fixed to `detail` until the zoom PR.
+ * (ADR-0010). `data-zoom-level` follows the viewport through the three
+ * semantic levels (spec §10.2); the cards and the chips read the level, the
+ * board stores nothing about it.
+ *
+ * On a phone (spec §10.4) the header and strip give way to one stage pill
+ * and one bottom sheet, the canvas pans on one finger, and grouping is
+ * tap-select-then-group with the selection held in the hand.
  *
  * Clusters are identities (spec §10.3): the chip at the members' centroid
  * is derived here from the cluster rows and the cards' derived positions,
@@ -111,6 +136,8 @@ export function RetroBoard({
   const [viewStageId, setViewStageId] = useState<string | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
   const [composing, setComposing] = useState(false);
+  const [level, setLevel] = useState<ZoomLevel>("detail");
+  const isMobile = useIsMobile();
   const viewStage = retro.stages.find((stage) => stage.id === viewStageId) ?? currentStage;
 
   // The page is titled by the retro's name (spec §18.1). Set here rather than
@@ -137,7 +164,7 @@ export function RetroBoard({
     [zones]
   );
 
-  const hand = useHand({ cards, onDrop: viewer?.cards.move ?? noMoves });
+  const hand = useHand({ cards, onDrop: viewer?.cards.move ?? noMoves, tapSelect: isMobile });
 
   const namesById = useMemo(() => new Map(users.map((user) => [user._id as string, user.name])), [users]);
   const tintByPrompt = useMemo(
@@ -164,7 +191,8 @@ export function RetroBoard({
           type: "card",
           position: hand.positions.get(card.clientId) ?? card.position,
           ...(hand.measured.has(card.clientId) ? { measured: hand.measured.get(card.clientId) } : {}),
-          selected: hand.selected.has(card.clientId),
+          // On a phone the selection stays out of React Flow's view (see useHand).
+          selected: !isMobile && hand.selected.has(card.clientId),
           draggable: editable,
           data: {
             card,
@@ -174,28 +202,47 @@ export function RetroBoard({
               : {}),
             ...(editingBy.has(card.clientId) ? { editingBy: editingBy.get(card.clientId) } : {}),
             editable,
+            level,
+            ...(isMobile && hand.selected.has(card.clientId) ? { tapSelected: true } : {}),
             ...(viewer && editable
               ? { onEditText: viewer.cards.editText, onDelete: viewer.cards.remove, onEditing: viewer.onEditing }
               : {}),
           },
         };
       }),
-    [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy]
+    [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy, level, isMobile]
   );
 
-  const chips = useMemo(
+  /** The cards as geometry, positions read through the hand. */
+  const members = useMemo(
     () =>
-      clusterChips(
-        clusters,
-        cards.map((card) => ({
-          clientId: card.clientId,
-          position: hand.positions.get(card.clientId) ?? card.position,
-          ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
-        })),
-        CARD_SIZE
-      ),
-    [clusters, cards, hand.positions]
+      cards.map((card) => ({
+        clientId: card.clientId,
+        position: hand.positions.get(card.clientId) ?? card.position,
+        ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
+      })),
+    [cards, hand.positions]
   );
+
+  // Hulls only while the shared pointer is in `group` (spec §10.3); the
+  // card box is the level's, so a hull hugs what is drawn.
+  const hullNodes = useMemo<HullNode[]>(() => {
+    const size = cardSizeAt(level);
+    return hullsFor(currentStage.kind, members, { width: size.width, height: size.height ?? CARD_MIN_HEIGHT }).map(
+      (hull) => ({
+        id: `hull-${hull.key}`,
+        type: "hull",
+        position: hull.position,
+        draggable: false,
+        selectable: false,
+        focusable: false,
+        zIndex: -1,
+        data: { hull },
+      })
+    );
+  }, [currentStage.kind, members, level]);
+
+  const chips = useMemo(() => clusterChips(clusters, members, CARD_SIZE), [clusters, members]);
 
   const clusterActions = viewer?.clusters;
   const moveCards = viewer?.cards.move;
@@ -234,9 +281,10 @@ export function RetroBoard({
     [chips, viewer, chipActions]
   );
 
+  // Zones, then hulls (same z, later in order so they draw above), cards, chips.
   const nodes = useMemo<Node[]>(
-    () => [...zoneNodes, ...cardNodes, ...clusterNodes],
-    [zoneNodes, cardNodes, clusterNodes]
+    () => [...zoneNodes, ...hullNodes, ...cardNodes, ...clusterNodes],
+    [zoneNodes, hullNodes, cardNodes, clusterNodes]
   );
 
   const selectedIds = useMemo(
@@ -267,6 +315,18 @@ export function RetroBoard({
     clusterActions?.removeFrom(selectedIds);
     clearSelection();
   }, [clusterActions, selectedIds, clearSelection]);
+  const selection = viewer
+    ? {
+        count: selectedIds.length,
+        inCluster: selectedInCluster,
+        clusters: clusterTargets,
+        onGroup,
+        onAddTo,
+        onRemove,
+        onClear: clearSelection,
+      }
+    : undefined;
+
 
   const onSubmitCard = useCallback(
     async (promptId: string, text: string) => {
@@ -286,13 +346,106 @@ export function RetroBoard({
   const onlineCount = viewer ? users.filter((user) => user.isOnline).length : undefined;
   const writerSet = useMemo(() => (named ? new Set(writers) : undefined), [named, writers]);
 
+  const canvas = (
+    <ReactFlowProvider>
+      <ReactFlow
+        nodes={nodes}
+        nodeTypes={nodeTypes}
+        onNodesChange={hand.onNodesChange}
+        onNodeDragStop={hand.onNodeDragStop}
+        fitView
+        fitViewOptions={{ padding: 0.1, maxZoom: 1 }}
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.1}
+        maxZoom={4}
+        nodesConnectable={false}
+        onlyRenderVisibleElements
+        panOnScroll
+        // A phone pans on one finger; a desktop pans on the primary button
+        // and trackpad and draws a marquee on drag.
+        panOnDrag={isMobile ? true : [1, 2]}
+        selectionOnDrag={!isMobile}
+        zoomOnPinch
+        preventScrolling={false}
+      >
+        <CanvasDotsBackground />
+        <ZoomLevelSync onLevel={setLevel} />
+      </ReactFlow>
+    </ReactFlowProvider>
+  );
+
+  const composer = viewer && (
+    <CardComposer
+      open={composing}
+      onOpenChange={setComposing}
+      prompts={retro.format.prompts}
+      viewerName={viewer.name}
+      attribution={retro.attribution}
+      hidden={currentStage.cardsVisible === "hidden"}
+      onSubmit={onSubmitCard}
+    />
+  );
+
+  const roster = (
+    <RetroRoster
+      users={users}
+      currentStage={currentStage}
+      myUserId={viewer?.userId}
+      onSetReady={viewer?.onSetReady}
+      writers={writerSet}
+      cardCount={cards.length}
+    />
+  );
+
+  const stageNav = (
+    <StageNav
+      stages={retro.stages}
+      currentStageId={currentStage.id}
+      viewStageId={viewStageId}
+      onView={setViewStageId}
+      controls={viewer?.controls}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <div
+        className="relative h-dvh w-screen overflow-hidden bg-white dark:bg-surface-1"
+        data-testid="retro-board"
+        data-stage={currentStage.kind}
+        data-view-stage={viewStage.kind}
+        data-zoom-level={level}
+        data-chrome="mobile"
+      >
+        {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
+        {canvas}
+        <MobileChrome
+          name={name}
+          teamName={team?.name}
+          stageKind={currentStage.kind}
+          timeboxMinutes={currentStage.timeboxMinutes}
+          enteredAt={retro.currentStageEnteredAt}
+          selection={selection}
+          onCompose={viewer ? () => setComposing(true) : undefined}
+        >
+          {banner}
+          {stageNav}
+          {menu && <div className="flex justify-end">{menu}</div>}
+          {roster}
+        </MobileChrome>
+        {composer}
+      </div>
+    );
+  }
+
   return (
     <div
       className="flex h-screen w-screen flex-col bg-white dark:bg-surface-1"
       data-testid="retro-board"
       data-stage={currentStage.kind}
       data-view-stage={viewStage.kind}
-      data-zoom-level="detail"
+      data-zoom-level={level}
+      data-chrome="desktop"
     >
       <RetroHeader
         name={name}
@@ -319,46 +472,14 @@ export function RetroBoard({
         }
       />
       {banner}
-      <StageNav
-        stages={retro.stages}
-        currentStageId={currentStage.id}
-        viewStageId={viewStageId}
-        onView={setViewStageId}
-        controls={viewer?.controls}
-      />
+      {stageNav}
       <div className="relative flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1">
           {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
-          <ReactFlowProvider>
-            <ReactFlow
-              nodes={nodes}
-              nodeTypes={nodeTypes}
-              onNodesChange={hand.onNodesChange}
-              onNodeDragStop={hand.onNodeDragStop}
-              fitView
-              fitViewOptions={{ padding: 0.1, maxZoom: 1 }}
-              proOptions={{ hideAttribution: true }}
-              minZoom={0.1}
-              maxZoom={4}
-              nodesConnectable={false}
-              onlyRenderVisibleElements
-              panOnScroll
-              panOnDrag={[1, 2]}
-              selectionOnDrag
-              preventScrolling={false}
-            >
-              <CanvasDotsBackground />
-            </ReactFlow>
-          </ReactFlowProvider>
-          {viewer && (
+          {canvas}
+          {selection && (
             <SelectionBar
-              count={selectedIds.length}
-              inCluster={selectedInCluster}
-              clusters={clusterTargets}
-              onGroup={onGroup}
-              onAddTo={onAddTo}
-              onRemove={onRemove}
-              onClear={clearSelection}
+              {...selection}
               className="absolute top-3 left-3 rounded-lg border bg-white/95 p-1.5 shadow-md dark:bg-surface-2/95"
             />
           )}
@@ -374,29 +495,10 @@ export function RetroBoard({
           )}
         </div>
         {rosterOpen && (
-          <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">
-            <RetroRoster
-              users={users}
-              currentStage={currentStage}
-              myUserId={viewer?.userId}
-              onSetReady={viewer?.onSetReady}
-              writers={writerSet}
-              cardCount={cards.length}
-            />
-          </aside>
+          <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{roster}</aside>
         )}
       </div>
-      {viewer && (
-        <CardComposer
-          open={composing}
-          onOpenChange={setComposing}
-          prompts={retro.format.prompts}
-          viewerName={viewer.name}
-          attribution={retro.attribution}
-          hidden={currentStage.cardsVisible === "hidden"}
-          onSubmit={onSubmitCard}
-        />
-      )}
+      {composer}
     </div>
   );
 }

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -18,17 +18,17 @@ import { StageNav, type StageControls } from "./stage-nav";
 import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
 import { CardNodeView, type CardNode } from "./card-node";
-import { ClusterNodeView, type ClusterNode, type ClusterChipActions } from "./cluster-node";
+import { ClusterNodeView, type ClusterNode, type ClusterChipActions, type ClusterTarget } from "./cluster-node";
 import { HullNodeView, type HullNode } from "./hull-node";
 import { hullsFor } from "./hulls";
 import { MobileChrome } from "./mobile-chrome";
 import { cardSizeAt, zoomLevelOf, type ZoomLevel } from "./zoom";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { SelectionBar } from "./selection-bar";
-import { clusterChips, tidyPositions } from "./clusters";
+import { clusterChips, tidyPositions, type Member, type Size } from "./clusters";
 import type { ClusterActions } from "./use-cluster-actions";
 import { CardComposer } from "./card-composer";
-import { CARD_MIN_HEIGHT, CARD_WIDTH, placeNewCard, type BoardCard } from "./cards";
+import { CARD_MIN_HEIGHT, placeNewCard, type BoardCard } from "./cards";
 import { useHand } from "./use-hand";
 import { editingOf } from "./readiness";
 import type { CardActions } from "./use-card-actions";
@@ -81,8 +81,6 @@ const nodeTypes: NodeTypes = {
 /** React Flow elevates a selected node to 1000; a chip stays above its members either way. */
 const CHIP_Z_INDEX = 1001;
 
-/** The card size the chip centroid, hulls and tidy assume; never stored (spec §10.2). */
-const CARD_SIZE = { width: CARD_WIDTH, height: CARD_MIN_HEIGHT };
 
 const selectZoomLevel = (state: { transform: [number, number, number] }) => zoomLevelOf(state.transform[2]);
 
@@ -213,22 +211,30 @@ export function RetroBoard({
     [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy, level, isMobile]
   );
 
-  /** The cards as geometry, positions read through the hand. */
-  const members = useMemo(
+  /** The cards as geometry: positions read through the hand, heights as measured. */
+  const members = useMemo<Member<Id<"retroClusters">>[]>(
     () =>
-      cards.map((card) => ({
-        clientId: card.clientId,
-        position: hand.positions.get(card.clientId) ?? card.position,
-        ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
-      })),
-    [cards, hand.positions]
+      cards.map((card) => {
+        const measured = hand.measured.get(card.clientId);
+        return {
+          clientId: card.clientId,
+          position: hand.positions.get(card.clientId) ?? card.position,
+          ...(card.clusterId !== undefined ? { clusterId: card.clusterId } : {}),
+          ...(measured ? { height: measured.height } : {}),
+        };
+      }),
+    [cards, hand.positions, hand.measured]
   );
+  /** The level's card box, for a card not yet measured. */
+  const cardSize = useMemo<Size>(() => {
+    const size = cardSizeAt(level);
+    return { width: size.width, height: size.height ?? CARD_MIN_HEIGHT };
+  }, [level]);
 
   // Hulls only while the shared pointer is in `group` (spec §10.3); the
-  // card box is the level's, so a hull hugs what is drawn.
+  // card box is what is drawn, so a hull hugs it.
   const hullNodes = useMemo<HullNode[]>(() => {
-    const size = cardSizeAt(level);
-    return hullsFor(currentStage.kind, members, { width: size.width, height: size.height ?? CARD_MIN_HEIGHT }).map(
+    return hullsFor(currentStage.kind, members, cardSize).map(
       (hull) => ({
         id: `hull-${hull.key}`,
         type: "hull",
@@ -240,26 +246,28 @@ export function RetroBoard({
         data: { hull },
       })
     );
-  }, [currentStage.kind, members, level]);
+  }, [currentStage.kind, members, cardSize]);
 
-  const chips = useMemo(() => clusterChips(clusters, members, CARD_SIZE), [clusters, members]);
+  const chips = useMemo(() => clusterChips(clusters, members, cardSize), [clusters, members, cardSize]);
 
   const clusterActions = viewer?.clusters;
   const moveCards = viewer?.cards.move;
   const chipActions = useMemo<ClusterChipActions | undefined>(() => {
     if (!clusterActions || !moveCards) return undefined;
     return {
-      rename: (clusterId, name) => clusterActions.rename(clusterId as Id<"retroClusters">, name),
-      merge: (from, into) => clusterActions.merge(from as Id<"retroClusters">, into as Id<"retroClusters">),
-      dissolve: (clusterId) => clusterActions.dissolve(clusterId as Id<"retroClusters">),
+      rename: clusterActions.rename,
+      merge: clusterActions.merge,
+      dissolve: clusterActions.dissolve,
       tidy: (clusterId) => {
-        const members = cards
-          .filter((card) => card.clusterId === clusterId)
-          .map((card) => ({ clientId: card.clientId, position: hand.positions.get(card.clientId) ?? card.position }));
-        moveCards(tidyPositions(members, CARD_SIZE));
+        moveCards(
+          tidyPositions(
+            members.filter((member) => member.clusterId === clusterId),
+            cardSize
+          )
+        );
       },
     };
-  }, [clusterActions, moveCards, cards, hand.positions]);
+  }, [clusterActions, moveCards, members, cardSize]);
 
   const clusterNodes = useMemo<ClusterNode[]>(
     () =>
@@ -295,9 +303,10 @@ export function RetroBoard({
     () => cards.filter((card) => hand.selected.has(card.clientId) && card.clusterId !== undefined).length,
     [cards, hand.selected]
   );
-  const clusterTargets = useMemo(
-    () => clusters.map((cluster) => ({ clusterId: cluster._id as string, name: cluster.name })),
-    [clusters]
+  // Only a cluster with members is a target: an emptied one keeps its row but shows nowhere.
+  const clusterTargets = useMemo<ClusterTarget[]>(
+    () => chips.map((chip) => ({ clusterId: chip.clusterId, name: chip.name })),
+    [chips]
   );
   const clearSelection = hand.clearSelection;
   const onGroup = useCallback(() => {
@@ -305,8 +314,8 @@ export function RetroBoard({
     clearSelection();
   }, [clusterActions, selectedIds, clearSelection]);
   const onAddTo = useCallback(
-    (clusterId: string) => {
-      clusterActions?.addTo(clusterId as Id<"retroClusters">, selectedIds);
+    (clusterId: Id<"retroClusters">) => {
+      clusterActions?.addTo(clusterId, selectedIds);
       clearSelection();
     },
     [clusterActions, selectedIds, clearSelection]

--- a/src/components/retro/selection-bar.test.tsx
+++ b/src/components/retro/selection-bar.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 import { SelectionBar } from "./selection-bar";
+import type { ClusterId } from "./cluster-node";
 
 afterEach(cleanup);
 
@@ -47,7 +48,7 @@ describe("SelectionBar", () => {
       <SelectionBar
         count={1}
         inCluster={1}
-        clusters={[{ clusterId: "k1", name: "Group 1" }, { clusterId: "k2", name: "Demo" }]}
+        clusters={[{ clusterId: "k1" as ClusterId, name: "Group 1" }, { clusterId: "k2" as ClusterId, name: "Demo" }]}
         {...h}
       />
     );

--- a/src/components/retro/selection-bar.tsx
+++ b/src/components/retro/selection-bar.tsx
@@ -16,6 +16,7 @@ import {
   selectedCards,
 } from "@/convex/retroCopy";
 import { cn } from "@/lib/utils";
+import type { ClusterTarget } from "./cluster-node";
 
 export interface SelectionBarProps {
   /** How many cards are selected; the bar renders nothing for none. */
@@ -23,9 +24,9 @@ export interface SelectionBarProps {
   /** How many of them already belong to a cluster. */
   inCluster: number;
   /** The clusters on the board, as "Add to group" targets. */
-  clusters: readonly { clusterId: string; name: string }[];
+  clusters: readonly ClusterTarget[];
   onGroup: () => void;
-  onAddTo: (clusterId: string) => void;
+  onAddTo: (clusterId: ClusterTarget["clusterId"]) => void;
   onRemove: () => void;
   onClear: () => void;
   className?: string;

--- a/src/components/retro/use-hand.test.tsx
+++ b/src/components/retro/use-hand.test.tsx
@@ -142,10 +142,6 @@ describe("useHand", () => {
     });
     expect([...hook.result.current.selected]).toEqual(["b"]);
     act(() => {
-      hook.result.current.toggleSelected("a");
-    });
-    expect([...hook.result.current.selected].sort()).toEqual(["a", "b"]);
-    act(() => {
       hook.result.current.clearSelection();
     });
     expect(hook.result.current.selected.size).toBe(0);

--- a/src/components/retro/use-hand.test.tsx
+++ b/src/components/retro/use-hand.test.tsx
@@ -30,7 +30,7 @@ const node = (id: string, x: number, y: number): Node => ({ id, position: { x, y
  * applies the optimistic value to the cards synchronously — what
  * `withOptimisticUpdate` does before the request leaves.
  */
-function harness(initial: BoardCard[]) {
+function harness(initial: BoardCard[], tapSelect = false) {
   const drops: Move[][] = [];
   return {
     drops,
@@ -38,6 +38,7 @@ function harness(initial: BoardCard[]) {
       const [cards, setCards] = useState(initial);
       const hand = useHand({
         cards,
+        tapSelect,
         onDrop: (moves) => {
           drops.push(moves);
           setCards((prev) =>
@@ -121,5 +122,32 @@ describe("useHand", () => {
       hook.result.current.onNodesChange([{ type: "select", id: "a", selected: false }]);
     });
     expect([...hook.result.current.selected]).toEqual(["b"]);
+  });
+
+  it("tap-select toggles a card per select:true, ignores select:false, and clears on demand", () => {
+    const { hook } = harness([card("a"), card("b")], true);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "select", id: "a", selected: true }]);
+    });
+    act(() => {
+      // A second tap elsewhere: React Flow would deselect the first; a tap keeps it.
+      hook.result.current.onNodesChange([
+        { type: "select", id: "a", selected: false },
+        { type: "select", id: "b", selected: true },
+      ]);
+    });
+    expect([...hook.result.current.selected].sort()).toEqual(["a", "b"]);
+    act(() => {
+      hook.result.current.onNodesChange([{ type: "select", id: "a", selected: true }]);
+    });
+    expect([...hook.result.current.selected]).toEqual(["b"]);
+    act(() => {
+      hook.result.current.toggleSelected("a");
+    });
+    expect([...hook.result.current.selected].sort()).toEqual(["a", "b"]);
+    act(() => {
+      hook.result.current.clearSelection();
+    });
+    expect(hook.result.current.selected.size).toBe(0);
   });
 });

--- a/src/components/retro/use-hand.ts
+++ b/src/components/retro/use-hand.ts
@@ -104,16 +104,6 @@ export function useHand({ cards, onDrop, tapSelect = false }: UseHandArgs) {
     }
   }, [tapSelect]);
 
-  /** A tap on a card: in or out of the selection. */
-  const toggleSelected = useCallback((clientId: string) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(clientId)) next.delete(clientId);
-      else next.add(clientId);
-      return next;
-    });
-  }, []);
-
   const onNodeDragStop = useCallback(
     (_event: MouseEvent | TouchEvent, _node: Node, nodes: Node[]) => {
       const moves = nodes.map((n) => ({ clientId: n.id, position: n.position }));
@@ -137,5 +127,5 @@ export function useHand({ cards, onDrop, tapSelect = false }: UseHandArgs) {
     return map;
   }, [cards, overrides]);
 
-  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop, clearSelection, toggleSelected };
+  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop, clearSelection };
 }

--- a/src/components/retro/use-hand.ts
+++ b/src/components/retro/use-hand.ts
@@ -27,6 +27,15 @@ interface UseHandArgs {
    * (`withOptimisticUpdate`), so the derived position never jumps.
    */
   onDrop: (moves: Move[]) => void;
+  /**
+   * Tap-select (spec §10.4): on touch, a tap toggles a card in the
+   * selection held here. The board then renders every node unselected to
+   * React Flow, so each tap arrives as a fresh `select: true` change (the
+   * pointer-down React Flow does deliver on touch, where no click follows)
+   * and toggles; the `select: false` changes React Flow would use to
+   * replace the selection are ignored.
+   */
+  tapSelect?: boolean;
 }
 
 /**
@@ -35,7 +44,7 @@ interface UseHandArgs {
  * with the override read ahead of it; nothing is written on pointer-move,
  * and every drop is one write.
  */
-export function useHand({ cards, onDrop }: UseHandArgs) {
+export function useHand({ cards, onDrop, tapSelect = false }: UseHandArgs) {
   const [overrides, setOverrides] = useState<ReadonlyMap<string, Position>>(new Map());
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   // What React Flow measured per node. Derived nodes are rebuilt from the
@@ -46,12 +55,15 @@ export function useHand({ cards, onDrop }: UseHandArgs) {
   const onNodesChange = useCallback((changes: NodeChange[]) => {
     const moved: [string, Position][] = [];
     const selection: [string, boolean][] = [];
+    const tapped: string[] = [];
     const sized: [string, Measured][] = [];
     for (const change of changes) {
       if (change.type === "position" && change.dragging && change.position) {
         moved.push([change.id, change.position]);
-      } else if (change.type === "select") {
+      } else if (change.type === "select" && !tapSelect) {
         selection.push([change.id, change.selected]);
+      } else if (change.type === "select" && change.selected) {
+        tapped.push(change.id);
       } else if (change.type === "dimensions" && change.dimensions) {
         sized.push([change.id, change.dimensions]);
       }
@@ -80,6 +92,26 @@ export function useHand({ cards, onDrop }: UseHandArgs) {
         return next;
       });
     }
+    if (tapped.length > 0) {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const id of tapped) {
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+        }
+        return next;
+      });
+    }
+  }, [tapSelect]);
+
+  /** A tap on a card: in or out of the selection. */
+  const toggleSelected = useCallback((clientId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(clientId)) next.delete(clientId);
+      else next.add(clientId);
+      return next;
+    });
   }, []);
 
   const onNodeDragStop = useCallback(
@@ -105,5 +137,5 @@ export function useHand({ cards, onDrop }: UseHandArgs) {
     return map;
   }, [cards, overrides]);
 
-  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop, clearSelection };
+  return { overrides, selected, measured, positions, onNodesChange, onNodeDragStop, clearSelection, toggleSelected };
 }

--- a/src/components/retro/zoom.test.ts
+++ b/src/components/retro/zoom.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Zoom-level derivation (spec §10.2, §21.1): the three levels at both
+ * boundaries, the card size per level, and the headline clamp.
+ */
+import { describe, it, expect } from "vitest";
+import { cardSizeAt, headlineOf, zoomLevelOf } from "./zoom";
+
+describe("zoomLevelOf", () => {
+  it("is detail above 0.70, headline from 0.35 to 0.70 inclusive, shape below 0.35", () => {
+    expect(zoomLevelOf(4)).toBe("detail");
+    expect(zoomLevelOf(0.71)).toBe("detail");
+    expect(zoomLevelOf(0.7)).toBe("headline");
+    expect(zoomLevelOf(0.5)).toBe("headline");
+    expect(zoomLevelOf(0.35)).toBe("headline");
+    expect(zoomLevelOf(0.349)).toBe("shape");
+    expect(zoomLevelOf(0.1)).toBe("shape");
+  });
+});
+
+describe("cardSizeAt", () => {
+  it("fixes the height below detail and leaves it to the text at detail", () => {
+    expect(cardSizeAt("detail")).toEqual({ width: 200, height: undefined });
+    expect(cardSizeAt("headline")).toEqual({ width: 200, height: 56 });
+    expect(cardSizeAt("shape")).toEqual({ width: 200, height: 96 });
+  });
+});
+
+describe("headlineOf", () => {
+  it("takes the first line, trimmed, and clamps a long one with an ellipsis", () => {
+    expect(headlineOf("  keep the demo \nsecond line")).toBe("keep the demo");
+    expect(headlineOf("x".repeat(80), 10)).toBe("xxxxxxxxx…");
+    expect(headlineOf("")).toBe("");
+  });
+});

--- a/src/components/retro/zoom.ts
+++ b/src/components/retro/zoom.ts
@@ -1,0 +1,51 @@
+/**
+ * Semantic zoom (spec §10.2, ADR-0011): three levels derived from the
+ * viewport zoom. Zooming out changes resolution, never loses information:
+ * detail draws the full card, headline the clamped first line and tint,
+ * shape a tinted block with cluster labels held at constant screen size as
+ * the content. Card size is a function of level and is never stored.
+ */
+
+import { CARD_MIN_HEIGHT, CARD_WIDTH } from "./cards";
+
+export type ZoomLevel = "detail" | "headline" | "shape";
+
+/** Above this zoom the card is drawn in full. */
+export const DETAIL_ABOVE = 0.7;
+/** Below this zoom the card is a tinted block. */
+export const SHAPE_BELOW = 0.35;
+
+/** detail above 0.70; headline from 0.35 to 0.70 inclusive; shape below 0.35. */
+export function zoomLevelOf(zoom: number): ZoomLevel {
+  if (zoom > DETAIL_ABOVE) return "detail";
+  if (zoom < SHAPE_BELOW) return "shape";
+  return "headline";
+}
+
+export interface CardSize {
+  width: number;
+  /** The fixed height at headline and shape; `undefined` at detail, where the text sets it. */
+  height: number | undefined;
+}
+
+export const HEADLINE_HEIGHT = 56;
+/** The shape block is the minimum card height, so centroids and tidy agree with detail. */
+export const SHAPE_HEIGHT = CARD_MIN_HEIGHT;
+
+/** The card's box per level: width always, height fixed below detail. */
+export function cardSizeAt(level: ZoomLevel): CardSize {
+  switch (level) {
+    case "detail":
+      return { width: CARD_WIDTH, height: undefined };
+    case "headline":
+      return { width: CARD_WIDTH, height: HEADLINE_HEIGHT };
+    case "shape":
+      return { width: CARD_WIDTH, height: SHAPE_HEIGHT };
+  }
+}
+
+/** The first line of a card, clamped for the headline level. */
+export function headlineOf(text: string, maxChars = 60): string {
+  const line = text.split(/\r?\n/, 1)[0]?.trim() ?? "";
+  return line.length > maxChars ? `${line.slice(0, maxChars - 1).trimEnd()}…` : line;
+}

--- a/tests/retro/MANUAL.md
+++ b/tests/retro/MANUAL.md
@@ -1,0 +1,47 @@
+# Retro board: manual checklist (spec §21.4)
+
+Run before a release that touches the canvas, on a real phone and a real
+tablet. Nothing here is automated: these are the gestures a headless browser
+cannot fake faithfully.
+
+Seed: a retro at `group` with six cards across two prompts, two of them
+already in a cluster.
+
+## Real touch drag
+
+- [ ] Drag your own card with one finger: it follows the finger, nothing
+      else moves, and it settles where it was dropped for a second browser.
+- [ ] Drag another person's card as a participant at defaults: it does not
+      move (own-card rights, spec §8.1).
+- [ ] One-finger drag on empty canvas pans; it never draws a marquee.
+
+## Pinch zoom
+
+- [ ] Pinch out past 0.70: cards go from headline to detail
+      (`data-zoom-level` on the board root follows).
+- [ ] Pinch in below 0.35: cards become tinted blocks and every cluster
+      chip stays the same size on screen.
+- [ ] Pinch never scrolls the page behind the canvas.
+
+## Proximity hulls on touch
+
+- [ ] In `group`, drag a card next to another: a dashed hull appears around
+      both; drag it away again and the hull dissolves.
+- [ ] Hulls never appear in any other stage, and never around a card that
+      is already in a cluster.
+
+## Tap-select-then-group
+
+- [ ] Tap two cards: both show a selection ring and the bar reads
+      "2 selected". Tap one again: it leaves the selection.
+- [ ] "Group 2 cards" forms a cluster; neither card moves; the chip sits
+      between them.
+
+## The bottom sheet on iOS Safari
+
+- [ ] The sheet opens from the menu button, scrolls inside itself, and
+      closes on the X and on a swipe down.
+- [ ] The stage strip, the roster and the retro menu all work inside it.
+- [ ] "Add card" opens the composer above the keyboard; the prompt picker
+      and the text field are both reachable; posting closes it.
+- [ ] The safe area at the bottom keeps the bar above the home indicator.


### PR DESCRIPTION
Part (b) of #293, spec §10.2, §10.4, ADR-0011. Stacked on the clusters PR.

Semantic zoom derives a level from the viewport: detail above 0.70, headline from 0.35 to 0.70, shape below 0.35. Card size is a function of the level and never stored. Cluster chips hold constant screen size at shape zoom. Proximity hulls are drawn only while the shared pointer is in `group`, have no identity, ignore grouped cards, and dissolve when a member moves.

On a phone the board is a full-bleed canvas under one stage pill and one bottom bar: a board menu opening the sheet with the stage strip, roster and menu, and one card button that opens the composer with its prompt picker, so a card can be written without a spatial step. Tap-select-then-group replaces marquee selection. No minimap.

Also carries the review refactors: chip, hull and tidy geometry read a card's measured height, cluster ids are typed through the chip and selection bar, and the unused tap toggle is gone.

Tests: zoom-level derivation at both boundaries, hulls only in `group`, tap-select state, card rendering per level, the mobile chrome writing a card through the composer.

Checked by hand: desktop zoom levels and hull behaviour in Chrome; the phone chrome on a Pixel 5 viewport via Playwright. Real touch drag, pinch zoom and iOS Safari remain on the checklist in `tests/retro/MANUAL.md`.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd