### PR TITLE
feat(retro): dots and the tally (#294)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -44,6 +44,7 @@ import type * as model_retro from "../model/retro.js";
 import type * as model_retroCards from "../model/retroCards.js";
 import type * as model_retroClusters from "../model/retroClusters.js";
 import type * as model_retroFormats from "../model/retroFormats.js";
+import type * as model_retroVotes from "../model/retroVotes.js";
 import type * as model_roles from "../model/roles.js";
 import type * as model_roomAggregate from "../model/roomAggregate.js";
 import type * as model_rooms from "../model/rooms.js";
@@ -113,6 +114,7 @@ declare const fullApi: ApiFromModules<{
   "model/retroCards": typeof model_retroCards;
   "model/retroClusters": typeof model_retroClusters;
   "model/retroFormats": typeof model_retroFormats;
+  "model/retroVotes": typeof model_retroVotes;
   "model/roles": typeof model_roles;
   "model/roomAggregate": typeof model_roomAggregate;
   "model/rooms": typeof model_rooms;

--- a/convex/model/retroClusters.ts
+++ b/convex/model/retroClusters.ts
@@ -5,6 +5,7 @@ import { updateRoomActivity } from "./rooms";
 import { refusal } from "./refusal";
 import { getCardByClientId, type CardActor } from "./retroCards";
 import { MAX_BOARD_ROWS } from "./retro";
+import { dotsOnCluster } from "./retroVotes";
 import {
   CARD_NOT_FOUND,
   CLUSTER_NAME_REQUIRED,
@@ -179,21 +180,39 @@ export async function mergeClusters(
   const from = await requireCluster(ctx, args.room._id, args.from);
   const into = await requireCluster(ctx, args.room._id, args.into);
   await requireCardManagement(ctx, args.room, args.actor);
-  const members = await membersOf(ctx, from._id);
-  await Promise.all(members.map((card) => ctx.db.patch(card._id, { clusterId: into._id })));
+  const [members, dots] = await Promise.all([membersOf(ctx, from._id), dotsOnCluster(ctx, args.room._id, from._id)]);
+  await Promise.all([
+    ...members.map((card) => ctx.db.patch(card._id, { clusterId: into._id })),
+    // The merged cluster's dots follow it (spec §10.3).
+    ...dots.map((dot) => ctx.db.patch(dot._id, { target: { kind: "cluster" as const, id: into._id } })),
+  ]);
   await ctx.db.delete(from._id);
   await updateRoomActivity(ctx, args.room);
 }
 
-/** Dissolve a cluster (`cardManagement`): every member's `clusterId` nulled, the row deleted. */
+export type DissolveOutcome = { dissolved: true } | { dissolved: false; votes: number };
+
+/**
+ * Dissolve a cluster (`cardManagement`): every member's `clusterId` nulled,
+ * the row deleted. A cluster with dots is dissolved only with consent
+ * (spec §10.3, §19): without `removeVotes` nothing changes and the count
+ * comes back for the confirmation; with it the dots go too.
+ */
 export async function dissolveCluster(
   ctx: MutationCtx,
-  args: { room: Doc<"rooms">; actor: CardActor; clusterId: Id<"retroClusters"> }
-): Promise<void> {
+  args: { room: Doc<"rooms">; actor: CardActor; clusterId: Id<"retroClusters">; removeVotes?: boolean }
+): Promise<DissolveOutcome> {
   const cluster = await requireCluster(ctx, args.room._id, args.clusterId);
   await requireCardManagement(ctx, args.room, args.actor);
-  const members = await membersOf(ctx, cluster._id);
-  await Promise.all(members.map((card) => ctx.db.patch(card._id, { clusterId: undefined })));
+  const [members, dots] = await Promise.all([membersOf(ctx, cluster._id), dotsOnCluster(ctx, args.room._id, cluster._id)]);
+  if (dots.length > 0 && args.removeVotes !== true) {
+    return { dissolved: false, votes: dots.length };
+  }
+  await Promise.all([
+    ...members.map((card) => ctx.db.patch(card._id, { clusterId: undefined })),
+    ...dots.map((dot) => ctx.db.delete(dot._id)),
+  ]);
   await ctx.db.delete(cluster._id);
   await updateRoomActivity(ctx, args.room);
+  return { dissolved: true };
 }

--- a/convex/model/retroClusters.ts
+++ b/convex/model/retroClusters.ts
@@ -26,10 +26,12 @@ import {
  * calling the one move batch. Every act is correct in every stage
  * (ADR-0010) and bumps the activity chokepoint (spec §14).
  *
- * Dots and action sources arrive with #294 and #296: merge re-points dots,
- * dissolve deletes them behind the confirmation and nulls an action's
- * source. A cluster emptied by a membership change is removed as a dissolve
- * of nothing; those tickets treat it as one.
+ * Dots (spec §11): merge re-points a cluster's dots, dissolve deletes them
+ * behind the confirmation. A cluster emptied by a membership change keeps
+ * its row (deleting one is dissolve, which is gated) but loses its dots:
+ * with no chip to carry them they could be neither seen nor taken back,
+ * and would hold the voter's budget for nothing. Action sources arrive
+ * with #296.
  */
 
 export const MAX_CLUSTER_NAME = 80;
@@ -105,18 +107,28 @@ async function defaultName(ctx: QueryCtx, roomId: Id<"rooms">): Promise<string> 
  * cluster the change leaves empty keeps its row: deleting one is dissolve,
  * which is `cardManagement` (spec §4.2), while membership is open to
  * everyone. Only merge removes a row (spec §10.3). An empty cluster draws
- * no chip and is deleted with the room.
+ * no chip and is deleted with the room; its dots go with the last member.
  */
 async function repoint(
   ctx: MutationCtx,
+  roomId: Id<"rooms">,
   cards: readonly Doc<"retroCards">[],
   clusterId: Id<"retroClusters"> | undefined
 ): Promise<void> {
+  const vacated = new Set<Id<"retroClusters">>();
+  for (const card of cards) {
+    if (card.clusterId !== undefined && card.clusterId !== clusterId) vacated.add(card.clusterId);
+  }
   await Promise.all(
     cards.map((card) =>
       ctx.db.patch(card._id, clusterId === undefined ? { clusterId: undefined } : { clusterId })
     )
   );
+  for (const id of vacated) {
+    if ((await membersOf(ctx, id)).length > 0) continue;
+    const dots = await dotsOnCluster(ctx, roomId, id);
+    await Promise.all(dots.map((dot) => ctx.db.delete(dot._id)));
+  }
 }
 
 /**
@@ -134,7 +146,7 @@ export async function formCluster(
     name: await defaultName(ctx, args.room._id),
     createdAt: Date.now(),
   });
-  await repoint(ctx, cards, clusterId);
+  await repoint(ctx, args.room._id, cards, clusterId);
   await updateRoomActivity(ctx, args.room);
   return clusterId;
 }
@@ -146,7 +158,7 @@ export async function addToCluster(
 ): Promise<void> {
   const cluster = await requireCluster(ctx, args.room._id, args.clusterId);
   const cards = await requireCards(ctx, args.room._id, args.clientIds);
-  await repoint(ctx, cards, cluster._id);
+  await repoint(ctx, args.room._id, cards, cluster._id);
   await updateRoomActivity(ctx, args.room);
 }
 
@@ -156,7 +168,7 @@ export async function removeFromCluster(
   args: { room: Doc<"rooms">; actor: CardActor; clientIds: string[] }
 ): Promise<void> {
   const cards = await requireCards(ctx, args.room._id, args.clientIds);
-  await repoint(ctx, cards, undefined);
+  await repoint(ctx, args.room._id, cards, undefined);
   await updateRoomActivity(ctx, args.room);
 }
 

--- a/convex/model/retroVotes.ts
+++ b/convex/model/retroVotes.ts
@@ -185,9 +185,8 @@ export async function dotsOnCluster(
   roomId: Id<"rooms">,
   clusterId: Id<"retroClusters">
 ): Promise<Doc<"retroVotes">[]> {
-  const rows = await ctx.db
+  return ctx.db
     .query("retroVotes")
-    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .withIndex("by_room_target", (q) => q.eq("roomId", roomId).eq("target.id", clusterId))
     .take(MAX_VOTE_ROWS);
-  return rows.filter((row) => row.target.kind === "cluster" && row.target.id === clusterId);
 }

--- a/convex/model/retroVotes.ts
+++ b/convex/model/retroVotes.ts
@@ -1,0 +1,193 @@
+import { MutationCtx, QueryCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import { updateRoomActivity } from "./rooms";
+import { refusal } from "./refusal";
+import type { CardActor } from "./retroCards";
+import { MAX_BOARD_ROWS, requireRetro } from "./retro";
+import { currentStageOf, type StageEntry } from "./retroFormats";
+import {
+  CARD_NOT_FOUND,
+  CLUSTER_NOT_FOUND,
+  DOT_NOT_FOUND,
+  NO_VOTE_BUDGET,
+  TOPIC_VOTES_CAPPED,
+  VOTE_BUDGET_SPENT,
+} from "../retroCopy";
+
+/**
+ * Dots (spec §11, ADR-0016): one row per dot on a topic — a cluster or a
+ * loose card — scoped to the stage entry that collected it. The budget is
+ * a count of the voter's rows for the entry, so stacking is free and a
+ * second `vote` entry starts fresh. Any entry may carry a budget; the only
+ * `stage` refusal is an entry without one, never a kind check (ADR-0010).
+ */
+
+export type TopicRef = Doc<"retroVotes">["target"];
+
+/** How many dots one read carries; a retro never approaches it. */
+export const MAX_VOTE_ROWS = MAX_BOARD_ROWS;
+
+/** The tally's key for a topic: its row id. */
+export const topicKey = (target: TopicRef): string => target.id;
+
+/** The current entry, refused with `stage` when it carries no budget. */
+async function requireVotingEntry(ctx: QueryCtx, roomId: Id<"rooms">): Promise<StageEntry> {
+  const entry = currentStageOf(await requireRetro(ctx, roomId));
+  if (entry.voteBudget === undefined) throw refusal("stage", NO_VOTE_BUDGET);
+  return entry;
+}
+
+/** The target exists and belongs to the room, else `missing`. */
+async function requireTopic(ctx: QueryCtx, roomId: Id<"rooms">, target: TopicRef): Promise<void> {
+  if (target.kind === "card") {
+    const card = await ctx.db.get(target.id);
+    if (!card || card.roomId !== roomId) throw refusal("missing", CARD_NOT_FOUND);
+  } else {
+    const cluster = await ctx.db.get(target.id);
+    if (!cluster || cluster.roomId !== roomId) throw refusal("missing", CLUSTER_NOT_FOUND);
+  }
+}
+
+async function ownRows(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  stageEntryId: string,
+  voterId: Id<"users">
+): Promise<Doc<"retroVotes">[]> {
+  return ctx.db
+    .query("retroVotes")
+    .withIndex("by_room_entry_voter", (q) => q.eq("roomId", roomId).eq("stageEntryId", stageEntryId).eq("voterId", voterId))
+    .take(MAX_VOTE_ROWS);
+}
+
+const sameTopic = (a: TopicRef, b: TopicRef) => a.kind === b.kind && a.id === b.id;
+
+/** Place one dot (everyone with a budget): refused `budget` at the entry's or the topic's cap. */
+export async function placeDot(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; target: TopicRef }
+): Promise<void> {
+  const entry = await requireVotingEntry(ctx, args.room._id);
+  await requireTopic(ctx, args.room._id, args.target);
+  const rows = await ownRows(ctx, args.room._id, entry.id, args.actor.user._id);
+  if (rows.length >= entry.voteBudget!) throw refusal("budget", VOTE_BUDGET_SPENT);
+  if (entry.maxPerTopic !== undefined && rows.filter((row) => sameTopic(row.target, args.target)).length >= entry.maxPerTopic) {
+    throw refusal("budget", TOPIC_VOTES_CAPPED);
+  }
+  await ctx.db.insert("retroVotes", {
+    roomId: args.room._id,
+    stageEntryId: entry.id,
+    voterId: args.actor.user._id,
+    target: args.target,
+  });
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Take one of the voter's own dots off a topic; none there is `missing`. */
+export async function removeDot(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; target: TopicRef }
+): Promise<void> {
+  const entry = await requireVotingEntry(ctx, args.room._id);
+  const rows = await ownRows(ctx, args.room._id, entry.id, args.actor.user._id);
+  const row = rows.find((candidate) => sameTopic(candidate.target, args.target));
+  if (!row) throw refusal("missing", DOT_NOT_FOUND);
+  await ctx.db.delete(row._id);
+  await updateRoomActivity(ctx, args.room);
+}
+
+export interface TallyRead {
+  /** Which entry's dots these are. */
+  stageEntryId: string;
+  /** The current entry shows its tally; hidden on a `vote` entry by the seed. */
+  visible: boolean;
+  /** Dots per topic for everyone, empty while hidden; a cluster's is its own plus its members'. */
+  counts: Record<string, number>;
+  /** The viewer's own dots per topic, always. */
+  mine: Record<string, number>;
+  /** The viewer's rows on the entry. */
+  spent: number;
+  /** The current entry's budget and cap; absent when it takes no dots. */
+  budget?: number;
+  maxPerTopic?: number;
+}
+
+/**
+ * The entry whose dots the board shows: the current one when it takes
+ * dots, else the nearest earlier entry that did — the round a `discuss`
+ * entry walks (spec §12.1) — else the current one, with nothing in it.
+ */
+export function tallyEntryOf(retro: { stages: readonly StageEntry[]; currentStageId: string }): StageEntry {
+  const index = retro.stages.findIndex((stage) => stage.id === retro.currentStageId);
+  for (let i = Math.max(index, 0); i >= 0; i--) {
+    if (retro.stages[i].voteBudget !== undefined) return retro.stages[i];
+  }
+  return currentStageOf(retro);
+}
+
+/**
+ * `retro.tally` (spec §9, §8.2): per viewer and small. Counts are
+ * aggregate and carry no voter in either attribution mode; the viewer's
+ * own dots are theirs to see whatever the entry shows.
+ */
+export async function tally(ctx: QueryCtx, args: { roomId: Id<"rooms">; viewerId: Id<"users"> }): Promise<TallyRead> {
+  const retro = await requireRetro(ctx, args.roomId);
+  const current = currentStageOf(retro);
+  const entry = tallyEntryOf(retro);
+  const [rows, cards] = await Promise.all([
+    ctx.db
+      .query("retroVotes")
+      .withIndex("by_room_entry", (q) => q.eq("roomId", args.roomId).eq("stageEntryId", entry.id))
+      .take(MAX_VOTE_ROWS),
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
+      .take(MAX_BOARD_ROWS),
+  ]);
+  const clusterOf = new Map<string, Id<"retroClusters">>();
+  for (const card of cards) {
+    if (card.clusterId !== undefined) clusterOf.set(card._id, card.clusterId);
+  }
+  const visible = current.tallyVisible === "visible";
+  const counts: Record<string, number> = {};
+  const mine: Record<string, number> = {};
+  let spent = 0;
+  const bump = (record: Record<string, number>, key: string) => {
+    record[key] = (record[key] ?? 0) + 1;
+  };
+  for (const row of rows) {
+    const key = topicKey(row.target);
+    const own = row.voterId === args.viewerId;
+    if (own) {
+      spent += 1;
+      bump(mine, key);
+    }
+    if (!visible) continue;
+    bump(counts, key);
+    // A dot on a member card carries into its cluster's tally (ADR-0016).
+    const clusterId = row.target.kind === "card" ? clusterOf.get(row.target.id) : undefined;
+    if (clusterId !== undefined) bump(counts, clusterId);
+  }
+  return {
+    stageEntryId: entry.id,
+    visible,
+    counts,
+    mine,
+    spent: current.id === entry.id ? spent : 0,
+    ...(current.voteBudget !== undefined ? { budget: current.voteBudget } : {}),
+    ...(current.maxPerTopic !== undefined ? { maxPerTopic: current.maxPerTopic } : {}),
+  };
+}
+
+/** Every dot on a cluster, across entries. */
+export async function dotsOnCluster(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  clusterId: Id<"retroClusters">
+): Promise<Doc<"retroVotes">[]> {
+  const rows = await ctx.db
+    .query("retroVotes")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .take(MAX_VOTE_ROWS);
+  return rows.filter((row) => row.target.kind === "cluster" && row.target.id === clusterId);
+}

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -456,6 +456,9 @@ export async function deleteUserByAuthUserId(
  * Links an anonymous user account to a new permanent account.
  * Transfers all memberships, votes, and canvas node ownerships.
  */
+/** How many dots one account linking re-points; an anonymous account never casts more. */
+const MAX_LINKED_VOTES = 5000;
+
 export async function linkAnonymousToPermanent(
   ctx: MutationCtx,
   args: {
@@ -653,15 +656,13 @@ export async function linkAnonymousToPermanent(
     }
 
     // Dots always store their voter (spec §8.2): re-point the anonymous
-    // account's rows in every room it attended.
-    for (const membership of memberships) {
-      const dots = await ctx.db
-        .query("retroVotes")
-        .withIndex("by_room", (q) => q.eq("roomId", membership.roomId))
-        .collect();
-      for (const dot of dots) {
-        if (dot.voterId === user._id) await ctx.db.patch(dot._id, { voterId: existingPermanent._id });
-      }
+    // account's rows, read by voter and bounded like the cards above.
+    const dots = await ctx.db
+      .query("retroVotes")
+      .withIndex("by_voter", (q) => q.eq("voterId", user._id))
+      .take(MAX_LINKED_VOTES);
+    for (const dot of dots) {
+      await ctx.db.patch(dot._id, { voterId: existingPermanent._id });
     }
 
     // Delete the old anonymous user record

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -652,6 +652,18 @@ export async function linkAnonymousToPermanent(
       }
     }
 
+    // Dots always store their voter (spec §8.2): re-point the anonymous
+    // account's rows in every room it attended.
+    for (const membership of memberships) {
+      const dots = await ctx.db
+        .query("retroVotes")
+        .withIndex("by_room", (q) => q.eq("roomId", membership.roomId))
+        .collect();
+      for (const dot of dots) {
+        if (dot.voterId === user._id) await ctx.db.patch(dot._id, { voterId: existingPermanent._id });
+      }
+    }
+
     // Delete the old anonymous user record
     await ctx.db.delete(user._id);
     return;

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -4,11 +4,13 @@ import type { Id } from "./_generated/dataModel";
 import * as Retro from "./model/retro";
 import * as RetroCards from "./model/retroCards";
 import * as RetroClusters from "./model/retroClusters";
+import * as RetroVotes from "./model/retroVotes";
 import {
   joinPolicyValidator,
   retroFormatValidator,
   retroStageValidator,
   stageKindValidator,
+  topicRefValidator,
   visibilityValidator,
 } from "./schema";
 import { refusal } from "./model/refusal";
@@ -409,10 +411,37 @@ export const mergeClusters = mutation({
 
 /** Dissolve a cluster (`cardManagement`): every member's `clusterId` nulled, the row deleted. */
 export const dissolveCluster = mutation({
-  args: { roomId: v.id("rooms"), clusterId: v.id("retroClusters") },
+  args: { roomId: v.id("rooms"), clusterId: v.id("retroClusters"), removeVotes: v.optional(v.boolean()) },
   handler: async (ctx, args) => {
     const { roomId, ...rest } = args;
-    await RetroClusters.dissolveCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+    return await RetroClusters.dissolveCluster(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Place one dot on a topic within the current entry's budget (spec §11). */
+export const placeDot = mutation({
+  args: { roomId: v.id("rooms"), target: topicRefValidator },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroVotes.placeDot(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Take one of the viewer's own dots off a topic (spec §11). */
+export const removeDot = mutation({
+  args: { roomId: v.id("rooms"), target: topicRefValidator },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroVotes.removeDot(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** The tally (spec §9): counts when the entry shows them, the viewer's own dots always. */
+export const tally = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user } = await requireRoomReader(ctx, args.roomId);
+    return await RetroVotes.tally(ctx, { roomId: args.roomId, viewerId: user._id });
   },
 });
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -336,3 +336,23 @@ export const CLUSTER_ACT_FAILED = "That did not go through. Try again.";
 // --- Mobile chrome (spec §10.4) ---
 
 export const BOARD_MENU = "Board menu";
+
+// Dots (spec §11, §19).
+/** Refusal `stage`: the current entry carries no budget. */
+export const NO_VOTE_BUDGET = "This stage takes no votes";
+/** Refusal `budget`: the voter's rows for the entry equal the budget. */
+export const VOTE_BUDGET_SPENT = "All your votes are placed";
+/** Refusal `budget`: the voter's dots on the topic equal `maxPerTopic`. */
+export const TOPIC_VOTES_CAPPED = "No more votes on this topic";
+/** Refusal `missing`: no own dot to take off the topic. */
+export const DOT_NOT_FOUND = "You have no vote here";
+/** The vote UI's line in an anonymous retro (spec §19). */
+export const VOTE_ANONYMOUS_NOTE = "Nobody is shown how you voted.";
+export const votesLeft = (left: number, budget: number) => `${left} of ${budget} ${budget === 1 ? "vote" : "votes"} left`;
+export const votesCount = (n: number) => `${n} ${n === 1 ? "vote" : "votes"}`;
+export const ADD_DOT = "Vote";
+export const REMOVE_DOT = "Remove vote";
+export const DISSOLVE_WITH_VOTES_TITLE = "Dissolve group";
+export const DISSOLVE_CONFIRM_BUTTON = "Dissolve";
+export const CANCEL_BUTTON = "Cancel";
+export const DOT_ACT_FAILED = "That vote did not go through. Try again.";

--- a/convex/retroVotes.test.ts
+++ b/convex/retroVotes.test.ts
@@ -1,0 +1,366 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+import * as Users from "./model/users";
+
+// Dots (spec §11, §9, §8.2, ADR-0016): one row per dot on a topic, scoped to
+// the stage entry that collected it. The budget is a count of the voter's
+// rows for the entry; `maxPerTopic` caps one topic. Any entry may carry a
+// budget, so the only `stage` refusal is an entry without one. The tally is
+// per viewer: aggregate counts when the entry shows them, own dots always,
+// and never a voter.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string) => seedNamedUser(t, authUserId, authUserId);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+async function cardsOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function votesOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroVotes")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function clustersOf(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("retroClusters")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function userId(t: T, authUserId: string): Promise<Id<"users">> {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("users")
+      .withIndex("by_auth_user", (q) => q.eq("authUserId", authUserId))
+      .unique()
+  ))!._id;
+}
+
+/** The refusal's code, or undefined for a plain error. */
+async function codeOf(p: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await p;
+    return "resolved";
+  } catch (error) {
+    return error instanceof ConvexError ? (error.data as { code: string }).code : undefined;
+  }
+}
+
+/**
+ * An owner and a participant in a fresh teamless retro with three cards,
+ * advanced to the seeded `vote` entry (budget 5, no per-topic cap) unless
+ * told otherwise.
+ */
+async function seedRetro(t: T, opts: { attribution?: "named" | "anonymous"; advance?: boolean } = {}) {
+  await seedUser(t, "owner");
+  await seedUser(t, "guest");
+  const roomId = await as(t, "owner").mutation(api.retro.create, {
+    name: "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+  });
+  await as(t, "guest").mutation(api.users.join, { roomId, name: "G", authUserId: "guest" });
+  let retro = await retroRow(t, roomId);
+  if (opts.attribution === "anonymous") {
+    await t.run((ctx) => ctx.db.patch(retro._id, { attribution: "anonymous" }));
+  }
+  const promptId = retro.format.prompts[0].id;
+  const write = (who: string, clientId: string) =>
+    as(t, who).mutation(api.retro.createCard, { roomId, clientId, text: clientId, promptId, position: { x: 0, y: 0 } });
+  await write("owner", "o1");
+  await write("owner", "o2");
+  await write("guest", "g1");
+  const vote = retro.stages.find((s) => s.kind === "vote")!;
+  if (opts.advance !== false) {
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: vote.id });
+  }
+  retro = await retroRow(t, roomId);
+  const cards = await cardsOf(t, roomId);
+  const cardId = (clientId: string) => cards.find((c) => c.clientId === clientId)!._id;
+  const onCard = (clientId: string) => ({ kind: "card" as const, id: cardId(clientId) });
+  return { roomId, retro, stages: retro.stages, vote, promptId, cardId, onCard };
+}
+
+async function patchStage(t: T, roomId: Id<"rooms">, stageId: string, patch: Record<string, unknown>) {
+  const retro = await retroRow(t, roomId);
+  await t.run((ctx) =>
+    ctx.db.patch(retro._id, {
+      stages: retro.stages.map((s) => (s.id === stageId ? { ...s, ...patch } : s)),
+    })
+  );
+}
+
+describe("retro.placeDot and removeDot (spec §11)", () => {
+  it("a dot is one row on the entry with the voter always stored; remove deletes one", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, vote, onCard } = await seedRetro(t);
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    const rows = await votesOf(t, roomId);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.stageEntryId).toBe(vote.id);
+      expect(row.voterId).toBe(await userId(t, "guest"));
+      expect(row.target).toEqual(onCard("o1"));
+    }
+    await as(t, "guest").mutation(api.retro.removeDot, { roomId, target: onCard("o1") });
+    expect(await votesOf(t, roomId)).toHaveLength(1);
+    // Nothing to remove is `missing`; another voter's dot is not yours to remove.
+    await as(t, "guest").mutation(api.retro.removeDot, { roomId, target: onCard("o1") });
+    expect(await codeOf(as(t, "owner").mutation(api.retro.removeDot, { roomId, target: onCard("o1") }))).toBe("missing");
+    expect(await codeOf(as(t, "guest").mutation(api.retro.removeDot, { roomId, target: onCard("o1") }))).toBe("missing");
+  });
+
+  it("the budget is the voter's rows for the entry: the sixth dot is `budget`, whatever the topic", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard } = await seedRetro(t);
+    const me = as(t, "guest");
+    for (const clientId of ["o1", "o1", "o2", "g1", "g1"]) {
+      await me.mutation(api.retro.placeDot, { roomId, target: onCard(clientId) });
+    }
+    expect(await codeOf(me.mutation(api.retro.placeDot, { roomId, target: onCard("o2") }))).toBe("budget");
+    // Another voter has their own budget.
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("o2") });
+    // Removing one frees one.
+    await me.mutation(api.retro.removeDot, { roomId, target: onCard("g1") });
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o2") });
+    expect((await votesOf(t, roomId)).length).toBe(6);
+  });
+
+  it("maxPerTopic caps one topic for one voter with `budget`, under the budget", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, vote, onCard } = await seedRetro(t);
+    await patchStage(t, roomId, vote.id, { maxPerTopic: 1 });
+    const me = as(t, "guest");
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    expect(await codeOf(me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") }))).toBe("budget");
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o2") });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    expect((await votesOf(t, roomId)).length).toBe(3);
+  });
+
+  it("an entry without a budget refuses with `stage`; any entry with one takes dots (ADR-0010)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, onCard } = await seedRetro(t, { advance: false });
+    const me = as(t, "guest");
+    expect(await codeOf(me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") }))).toBe("stage");
+    expect(await codeOf(me.mutation(api.retro.removeDot, { roomId, target: onCard("o1") }))).toBe("stage");
+    // A budget on the collect entry: the kind is never the test.
+    await patchStage(t, roomId, stages[0].id, { voteBudget: 2 });
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    expect(await codeOf(me.mutation(api.retro.placeDot, { roomId, target: onCard("o2") }))).toBe("budget");
+    expect((await votesOf(t, roomId)).every((r) => r.stageEntryId === stages[0].id)).toBe(true);
+    // Close carries a budget too, when given one.
+    const close = stages.find((s) => s.kind === "close")!;
+    await patchStage(t, roomId, close.id, { voteBudget: 1 });
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: close.id });
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("g1") });
+    await me.mutation(api.retro.removeDot, { roomId, target: onCard("g1") });
+  });
+
+  it("a second vote entry starts a fresh budget; the first entry's dots stay", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, vote, onCard } = await seedRetro(t);
+    const me = as(t, "guest");
+    for (let i = 0; i < 5; i++) await me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    expect(await codeOf(me.mutation(api.retro.placeDot, { roomId, target: onCard("o1") }))).toBe("budget");
+
+    const second = await as(t, "owner").mutation(api.retro.addStage, { roomId, kind: "vote" });
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: second });
+    await me.mutation(api.retro.placeDot, { roomId, target: onCard("o2") });
+    const rows = await votesOf(t, roomId);
+    expect(rows.filter((r) => r.stageEntryId === vote.id)).toHaveLength(5);
+    expect(rows.filter((r) => r.stageEntryId === second)).toHaveLength(1);
+  });
+
+  it("refuses an unknown or foreign target with `missing`, and a non-member with a guard error", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard } = await seedRetro(t);
+    await seedUser(t, "stranger");
+    const otherRoom = await as(t, "stranger").mutation(api.retro.create, { name: "O", formatName: DEFAULT_RETRO_FORMAT.name });
+    const otherCluster = await t.run((ctx) =>
+      ctx.db.insert("retroClusters", { roomId: otherRoom, name: "Elsewhere", createdAt: Date.now() })
+    );
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: otherCluster } }))
+    ).toBe("missing");
+    expect(await codeOf(as(t, "stranger").mutation(api.retro.placeDot, { roomId, target: onCard("o1") }))).toBeUndefined();
+  });
+});
+
+describe("retro.tally (spec §9, §8.2)", () => {
+  it("hides the counts on the vote entry, always shows own dots, and carries the entry's budget", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard, cardId } = await seedRetro(t);
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+
+    const guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.visible).toBe(false);
+    expect(guest.counts).toEqual({});
+    expect(guest.mine).toEqual({ [cardId("o1")]: 2 });
+    expect(guest.spent).toBe(2);
+    expect(guest.budget).toBe(5);
+    expect(guest.maxPerTopic).toBeUndefined();
+
+    const owner = await as(t, "owner").query(api.retro.tally, { roomId });
+    expect(owner.counts).toEqual({});
+    expect(owner.mine).toEqual({ [cardId("o1")]: 1 });
+    expect(owner.spent).toBe(1);
+  });
+
+  it("shows the counts once the entry does, and after advance; the entry's own rows only", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, stages, vote, onCard, cardId } = await seedRetro(t);
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("g1") });
+
+    await patchStage(t, roomId, vote.id, { tallyVisible: "visible" });
+    let guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.visible).toBe(true);
+    expect(guest.counts).toEqual({ [cardId("o1")]: 2, [cardId("g1")]: 1 });
+    expect(guest.mine).toEqual({ [cardId("o1")]: 1 });
+
+    // The discuss entry shows the vote entry's tally: the last entry with dots.
+    const discuss = stages.find((s) => s.kind === "discuss")!;
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: discuss.id });
+    guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.visible).toBe(true);
+    expect(guest.counts).toEqual({ [cardId("o1")]: 2, [cardId("g1")]: 1 });
+    expect(guest.budget).toBeUndefined();
+  });
+
+  it("a cluster's tally is its own dots plus its members'; a Team reader reads it", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, vote, onCard, cardId } = await seedRetro(t);
+    await patchStage(t, roomId, vote.id, { tallyVisible: "visible" });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    const clusterId = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1", "o2"] });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: clusterId } });
+    await as(t, "owner").mutation(api.retro.placeDot, { roomId, target: onCard("o2") });
+
+    const guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.counts[clusterId]).toBe(3);
+    expect(guest.counts[cardId("o1")]).toBe(1);
+    expect(guest.counts[cardId("o2")]).toBe(1);
+    // Own dots stay where they were placed: a dot on a member is removed from the member.
+    expect(guest.mine).toEqual({ [cardId("o1")]: 1 });
+    const owner = await as(t, "owner").query(api.retro.tally, { roomId });
+    expect(owner.mine).toEqual({ [clusterId]: 1, [cardId("o2")]: 1 });
+  });
+
+  it("in an anonymous retro the voter is stored and never read; the ratchet leaves it", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, vote, onCard, cardId } = await seedRetro(t, { attribution: "anonymous" });
+    await patchStage(t, roomId, vote.id, { tallyVisible: "visible" });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    const guestId = await userId(t, "guest");
+    expect((await votesOf(t, roomId))[0].voterId).toBe(guestId);
+
+    const owner = await as(t, "owner").query(api.retro.tally, { roomId });
+    expect(owner.counts).toEqual({ [cardId("o1")]: 1 });
+    expect(owner.mine).toEqual({});
+    expect(JSON.stringify(owner)).not.toContain(guestId);
+    const guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.mine).toEqual({ [cardId("o1")]: 1 });
+    expect(JSON.stringify(guest)).not.toContain(guestId);
+
+    // A named retro ratcheted after voting keeps every voter (spec §8.2).
+    const named = await seedRetro(t);
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId: named.roomId, target: named.onCard("g1") });
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId: named.roomId });
+    expect((await retroRow(t, named.roomId)).attribution).toBe("anonymous");
+    expect((await votesOf(t, named.roomId)).map((r) => r.voterId)).toEqual([guestId]);
+  });
+});
+
+describe("dots under grouping (spec §10.3, ADR-0016)", () => {
+  it("merge re-points the cluster's dots; dissolve asks first and then deletes them", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard } = await seedRetro(t);
+    const owner = as(t, "owner");
+    const a = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    const b = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o2"] });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: a } });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: b } });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("g1") });
+
+    await owner.mutation(api.retro.mergeClusters, { roomId, from: a, into: b });
+    let rows = await votesOf(t, roomId);
+    expect(rows.filter((r) => r.target.kind === "cluster").map((r) => r.target.id)).toEqual([b, b]);
+
+    // Dissolve without consent: nothing changes, the count comes back.
+    expect(await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: b })).toEqual({ dissolved: false, votes: 2 });
+    expect(await clustersOf(t, roomId)).toHaveLength(1);
+    expect(await votesOf(t, roomId)).toHaveLength(3);
+    expect(await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: b, removeVotes: true })).toEqual({ dissolved: true });
+    expect(await clustersOf(t, roomId)).toHaveLength(0);
+    rows = await votesOf(t, roomId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].target).toEqual(onCard("g1"));
+    // A cluster without dots dissolves at once.
+    const c = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    expect(await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: c })).toEqual({ dissolved: true });
+  });
+
+  it("dissolving with dots is still `cardManagement`, refused before any count is told", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedRetro(t);
+    const a = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: a } });
+    expect(await codeOf(as(t, "guest").mutation(api.retro.dissolveCluster, { roomId, clusterId: a }))).toBe("forbidden");
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.dissolveCluster, { roomId, clusterId: a, removeVotes: true }))
+    ).toBe("forbidden");
+    expect(await votesOf(t, roomId)).toHaveLength(1);
+  });
+});
+
+describe("account linking (spec §13, §15.2)", () => {
+  it("linking an anonymous account to a permanent one re-points its dots", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard } = await seedRetro(t);
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    const anonymousId = await userId(t, "guest");
+    // The permanent account the guest signs in as.
+    const permanentId = await seedNamedUser(t, "perm", "P", "permanent");
+    await t.run((ctx) =>
+      Users.linkAnonymousToPermanent(ctx, { oldAuthUserId: "guest", newAuthUserId: "perm", email: "p@example.com" })
+    );
+    const rows = await votesOf(t, roomId);
+    expect(rows.map((r) => r.voterId)).toEqual([permanentId]);
+    expect(await t.run((ctx) => ctx.db.get(anonymousId))).toBeNull();
+  });
+});

--- a/convex/retroVotes.test.ts
+++ b/convex/retroVotes.test.ts
@@ -262,7 +262,7 @@ describe("retro.tally (spec §9, §8.2)", () => {
     expect(guest.budget).toBeUndefined();
   });
 
-  it("a cluster's tally is its own dots plus its members'; a Team reader reads it", async () => {
+  it("a cluster's tally is its own dots plus its members'", async () => {
     const t = convexTest(schema, modules);
     const { roomId, vote, onCard, cardId } = await seedRetro(t);
     await patchStage(t, roomId, vote.id, { tallyVisible: "visible" });
@@ -333,6 +333,21 @@ describe("dots under grouping (spec §10.3, ADR-0016)", () => {
     // A cluster without dots dissolves at once.
     const c = await owner.mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
     expect(await owner.mutation(api.retro.dissolveCluster, { roomId, clusterId: c })).toEqual({ dissolved: true });
+  });
+
+  it("a cluster emptied by a membership change keeps its row and loses its dots, freeing the budget", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, onCard, cardId } = await seedRetro(t);
+    const a = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["o1"] });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: { kind: "cluster", id: a } });
+    await as(t, "guest").mutation(api.retro.placeDot, { roomId, target: onCard("o1") });
+    await as(t, "guest").mutation(api.retro.removeFromCluster, { roomId, clientIds: ["o1"] });
+    expect(await clustersOf(t, roomId)).toHaveLength(1);
+    const rows = await votesOf(t, roomId);
+    expect(rows.map((r) => r.target)).toEqual([onCard("o1")]);
+    const guest = await as(t, "guest").query(api.retro.tally, { roomId });
+    expect(guest.spent).toBe(1);
+    expect(guest.mine).toEqual({ [cardId("o1")]: 1 });
   });
 
   it("dissolving with dots is still `cardManagement`, refused before any count is told", async () => {

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -650,6 +650,36 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     }
   });
 
+  it("every dot mutation bumps (spec §14)", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedTeamRetro(t, false);
+    const retro = (await t.run((ctx) =>
+      ctx.db.query("retros").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    const me = as(t, "auth-member");
+    await me.mutation(api.retro.createCard, { roomId, clientId: "c1", text: "c1", promptId: retro.format.prompts[0].id, position: { x: 0, y: 0 } });
+    const card = (await t.run((ctx) =>
+      ctx.db.query("retroCards").withIndex("by_room", (q) => q.eq("roomId", roomId)).unique()
+    ))!;
+    // A budget on the current entry: the kind is never the test (ADR-0010).
+    await t.run((ctx) =>
+      ctx.db.patch(retro._id, {
+        stages: retro.stages.map((s) => (s.id === retro.currentStageId ? { ...s, voteBudget: 3 } : s)),
+      })
+    );
+    const target = { kind: "card" as const, id: card._id };
+    const acts = [
+      () => me.mutation(api.retro.placeDot, { roomId, target }),
+      () => me.mutation(api.retro.removeDot, { roomId, target }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+  });
+
   it("ratchet bumps (spec §14)", async () => {
     const t = convexTest(schema, modules);
     const { roomId, stale } = await seedTeamRetro(t, false);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -291,7 +291,9 @@ export default defineSchema({
   })
     .index("by_room", ["roomId"]) // The cascade reads every room-owned table by this name
     .index("by_room_entry", ["roomId", "stageEntryId"])
-    .index("by_room_entry_voter", ["roomId", "stageEntryId", "voterId"]),
+    .index("by_room_entry_voter", ["roomId", "stageEntryId", "voterId"])
+    .index("by_room_target", ["roomId", "target.id"]) // a topic's dots across entries: merge, dissolve
+    .index("by_voter", ["voterId"]), // account linking re-points a voter's rows
 
   // An action item (ADR-0017): one home, denormalised to the Team.
   retroActions: defineTable({

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -13,6 +13,8 @@ import { mergeCards, type BoardCard } from "@/components/retro/cards";
 import { readinessOf } from "@/components/retro/readiness";
 import { useCardActions } from "@/components/retro/use-card-actions";
 import { useClusterActions } from "@/components/retro/use-cluster-actions";
+import { useDotActions } from "@/components/retro/use-dot-actions";
+import type { TallyRead } from "@/convex/model/retroVotes";
 import { useEditKeys, type EditKeyStore } from "@/components/retro/use-edit-keys";
 import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
@@ -74,6 +76,11 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const editKeys = useEditKeys(roomId);
   const mineArgs = useMemo(() => ({ roomId, editKeys: editKeys.keys }), [roomId, editKeys.keys]);
   const mine = useQuery(api.retro.mine, isMember ? mineArgs : "skip");
+  // The tally is mounted only while the shared pointer is in `vote` or
+  // `discuss` (spec §9, ADR-0016); elsewhere the board carries no dots.
+  const tallyKind = board ? currentStageOf(board.retro).kind : undefined;
+  const tallyMounted = canRead && (tallyKind === "vote" || tallyKind === "discuss");
+  const tally = useQuery(api.retro.tally, tallyMounted ? { roomId } : "skip");
   // A re-keyed subscription answers a beat later; hold the last answer so
   // the viewer's own cards never flash to silhouettes in between.
   const [settledMine, setSettledMine] = useState(mine);
@@ -122,6 +129,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
         writers={board.writers}
         users={offlineUsers}
         team={team}
+        tally={tally}
         banner={
           <div
             data-testid="team-reader-banner"
@@ -149,6 +157,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
       userId={membership!._id}
       myTeams={(myTeams ?? []) as MyTeam[]}
       editKeys={editKeys}
+      tally={tally}
     />
   );
 }
@@ -162,6 +171,7 @@ interface AttendeeBoardProps {
   userId: Id<"users">;
   myTeams: MyTeam[];
   editKeys: EditKeyStore;
+  tally?: TallyRead;
 }
 
 /**
@@ -171,7 +181,7 @@ interface AttendeeBoardProps {
  * wiring. Its own component so the presence hook — which has no skip —
  * mounts only once a membership exists; a Team reader never heartbeats.
  */
-function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, editKeys }: AttendeeBoardProps) {
+function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, editKeys, tally }: AttendeeBoardProps) {
   const { retro } = board;
   const users = useRoomPresence(roomId, userId, roomData.users);
   const setRetroPresence = useSingleFlightMutation(
@@ -188,6 +198,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
   );
   const cardActions = useCardActions(roomId, writer);
   const clusterActions = useClusterActions(roomId);
+  const dotActions = useDotActions(roomId, tally);
   const currentStageId = currentStageOf(retro).id;
   // The payload is written whole, so an editing write carries readiness
   // too: the viewer's last toggle for this entry, else what their presence
@@ -239,9 +250,10 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       controls,
       cards: cardActions,
       clusters: clusterActions,
+      dots: dotActions,
       cardManagement,
     }),
-    [userId, me?.name, writePresence, controls, cardActions, clusterActions, cardManagement]
+    [userId, me?.name, writePresence, controls, cardActions, clusterActions, dotActions, cardManagement]
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
@@ -255,6 +267,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       users={users}
       team={team}
       viewer={viewer}
+      tally={tally}
       menu={
         <RetroMenu
           roomId={roomId}

--- a/src/components/retro/card-node.test.tsx
+++ b/src/components/retro/card-node.test.tsx
@@ -99,4 +99,27 @@ describe("CardNodeView", () => {
     expect(root.getAttribute("aria-label")).toBe("Hidden card");
     expect(root.textContent).toBe("");
   });
+
+  it("dots (spec §11): the tally hidden shows own dots only; the count at headline; none without a tally", () => {
+    const onPlace = vi.fn();
+    const onRemove = vi.fn();
+    renderCard({ card: base, color: "green", editable: false, dots: { mine: 2, onPlace, onRemove } });
+    let dots = screen.getByTestId("dots");
+    expect(dots.getAttribute("data-count")).toBe("");
+    expect(dots.getAttribute("data-mine")).toBe("2");
+    fireEvent.click(screen.getByRole("button", { name: "Vote" }));
+    expect(onPlace).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Remove vote" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    renderCard({ card: base, color: "green", editable: false, level: "headline", dots: { count: 4, mine: 0, onPlace } });
+    dots = screen.getByTestId("dots");
+    expect(dots.textContent).toContain("4 votes");
+    expect(screen.queryByRole("button", { name: "Vote" })).toBeNull();
+    cleanup();
+
+    renderCard({ card: base, color: "green", editable: false });
+    expect(screen.queryByTestId("dots")).toBeNull();
+  });
 });

--- a/src/components/retro/card-node.tsx
+++ b/src/components/retro/card-node.tsx
@@ -89,9 +89,7 @@ export const CardNodeView = memo(function CardNodeView({ data, selected: flowSel
         style={{ width: size.width, height: size.height }}
       >
         <p className="truncate">{headlineOf(card.text ?? "")}</p>
-        {dots && (dots.count !== undefined || dots.mine > 0) && (
-          <DotControls count={dots.count} mine={dots.mine} className="ml-auto shrink-0" />
-        )}
+        {dots && <DotControls count={dots.count} mine={dots.mine} className="ml-auto shrink-0" />}
       </div>
     );
   }

--- a/src/components/retro/card-node.tsx
+++ b/src/components/retro/card-node.tsx
@@ -17,6 +17,7 @@ import { tintClasses } from "./tints";
 import type { BoardCard } from "./cards";
 import { useCardDraft } from "./use-card-draft";
 import { cardSizeAt, headlineOf, type ZoomLevel } from "./zoom";
+import { DotControls, type DotControlsProps } from "./dot-controls";
 
 // A type alias: React Flow node data must satisfy Record<string, unknown>.
 export type CardNodeData = {
@@ -33,6 +34,8 @@ export type CardNodeData = {
   level?: ZoomLevel;
   /** In the tap-selection (spec §10.4), which the board keeps out of React Flow's own. */
   tapSelected?: boolean;
+  /** The card's dots while the tally is mounted (spec §11); a grouped card's own dots only. */
+  dots?: DotControlsProps;
   onEditText?: (clientId: string, text: string) => Promise<void>;
   onDelete?: (clientId: string) => void;
   /** The editing indicator: the card focused, or none. */
@@ -50,7 +53,7 @@ export type CardNode = Node<CardNodeData, "card">;
  * contract the tests read; `data-late` is a placeholder until #295.
  */
 export const CardNodeView = memo(function CardNodeView({ data, selected: flowSelected }: NodeProps<CardNode>) {
-  const { card, color, authorName, editingBy, editable, level = "detail" } = data;
+  const { card, color, authorName, editingBy, editable, level = "detail", dots } = data;
   const selected = flowSelected || data.tapSelected === true;
   const tint = tintClasses(color);
   const size = cardSizeAt(level);
@@ -86,6 +89,9 @@ export const CardNodeView = memo(function CardNodeView({ data, selected: flowSel
         style={{ width: size.width, height: size.height }}
       >
         <p className="truncate">{headlineOf(card.text ?? "")}</p>
+        {dots && (dots.count !== undefined || dots.mine > 0) && (
+          <DotControls count={dots.count} mine={dots.mine} className="ml-auto shrink-0" />
+        )}
       </div>
     );
   }
@@ -116,6 +122,7 @@ export const CardNodeView = memo(function CardNodeView({ data, selected: flowSel
       ) : (
         <p className="whitespace-pre-wrap break-words">{card.text}</p>
       )}
+      {dots && <DotControls {...dots} />}
       <div className="flex min-h-5 items-center gap-2 text-xs text-muted-foreground">
         {authorName && (
           <span data-testid="author-chip" className={cn("truncate font-medium", tint.label)}>

--- a/src/components/retro/cluster-node.test.tsx
+++ b/src/components/retro/cluster-node.test.tsx
@@ -19,6 +19,22 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     <button role="menuitem" onClick={onClick} disabled={disabled}>{children}</button>
   ),
 }));
+vi.mock("@/components/ui/alert-dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    AlertDialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="alertdialog">{children}</div> : null,
+    AlertDialogContent: pass,
+    AlertDialogHeader: pass,
+    AlertDialogFooter: pass,
+    AlertDialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    AlertDialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    AlertDialogAction: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+      <button onClick={onClick}>{children}</button>
+    ),
+    AlertDialogCancel: ({ children }: { children?: ReactNode }) => <button>{children}</button>,
+  };
+});
 vi.mock("@/components/ui/dialog", () => {
   const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
   return {
@@ -63,7 +79,7 @@ function renderChip(data: ClusterNode["data"], zoom = 1) {
 const actions = () => ({
   rename: vi.fn().mockResolvedValue(true),
   merge: vi.fn().mockResolvedValue(true),
-  dissolve: vi.fn().mockResolvedValue(true),
+  dissolve: vi.fn().mockResolvedValue("done"),
   tidy: vi.fn(),
 });
 
@@ -108,8 +124,40 @@ describe("ClusterNodeView", () => {
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Tidy" }));
     expect(acts.tidy).toHaveBeenCalledWith("k1");
-    fireEvent.click(screen.getByRole("menuitem", { name: "Dissolve group" }));
-    expect(acts.dissolve).toHaveBeenCalledWith("k1");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Dissolve group" }));
+    });
+    expect(acts.dissolve).toHaveBeenCalledWith("k1", undefined);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("dissolving a cluster with dots asks with the count, then dissolves with consent (spec §19)", async () => {
+    const acts = actions();
+    acts.dissolve.mockResolvedValueOnce({ votes: 4 }).mockResolvedValueOnce("done");
+    renderChip({ chip, others, decision: allowed, actions: acts });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Dissolve group" }));
+    });
+    const confirm = within(screen.getByRole("alertdialog"));
+    expect(confirm.getByText("Dissolve this group? Its 4 votes are removed.")).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(confirm.getByRole("button", { name: "Dissolve" }));
+    });
+    expect(acts.dissolve).toHaveBeenLastCalledWith("k1", true);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("shows the cluster's dots and takes one either way (spec §11)", () => {
+    const onPlace = vi.fn();
+    const onRemove = vi.fn();
+    renderChip({ chip, others, dots: { count: 3, mine: 1, onPlace, onRemove } });
+    const dots = screen.getByTestId("dots");
+    expect(dots.getAttribute("data-count")).toBe("3");
+    expect(dots.getAttribute("data-mine")).toBe("1");
+    fireEvent.click(screen.getByRole("button", { name: "Vote" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove vote" }));
+    expect(onPlace).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
   it("merge is disabled when there is no other cluster", () => {

--- a/src/components/retro/cluster-node.tsx
+++ b/src/components/retro/cluster-node.tsx
@@ -18,13 +18,27 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ResolvedDecision } from "@/convex/permissions";
 import { MAX_CLUSTER_NAME } from "@/convex/model/retroClusters";
 import {
+  CANCEL_BUTTON,
+  DISSOLVE_CONFIRM_BUTTON,
   DISSOLVE_GROUP,
+  DISSOLVE_WITH_VOTES_TITLE,
   GROUP_MENU,
+  dissolveClusterConfirm,
   GROUP_NAME_LABEL,
   MERGE_GROUP,
   MERGE_GROUP_BUTTON,
@@ -37,6 +51,8 @@ import {
 } from "@/convex/retroCopy";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { ClusterChip } from "./clusters";
+import { DotControls, type DotControlsProps } from "./dot-controls";
+import type { DissolveResult } from "./use-cluster-actions";
 import { zoomLevelOf } from "./zoom";
 
 /** The `cardManagement` acts on one cluster, as the board wires them. */
@@ -45,7 +61,7 @@ export type ClusterId = Id<"retroClusters">;
 export interface ClusterChipActions {
   rename: (clusterId: ClusterId, name: string) => Promise<boolean>;
   merge: (from: ClusterId, into: ClusterId) => Promise<boolean>;
-  dissolve: (clusterId: ClusterId) => Promise<boolean>;
+  dissolve: (clusterId: ClusterId, removeVotes?: boolean) => Promise<DissolveResult>;
   /** Tidy: the board computes the positions and issues the one move batch. */
   tidy: (clusterId: ClusterId) => void;
 }
@@ -64,6 +80,8 @@ export type ClusterNodeData = {
   /** The `cardManagement` decision; absent for a Team reader, who gets the label alone. */
   decision?: ResolvedDecision;
   actions?: ClusterChipActions;
+  /** The cluster's dots — its own plus its members' — while the tally is mounted (spec §9). */
+  dots?: DotControlsProps;
 };
 
 export type ClusterNode = Node<ClusterNodeData, "cluster">;
@@ -80,11 +98,18 @@ const selectZoom = (state: { transform: [number, number, number] }) => state.tra
  * content (spec §10.2).
  */
 export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps<ClusterNode>) {
-  const { chip, others, decision, actions } = data;
+  const { chip, others, decision, actions, dots } = data;
   const zoom = useStore(selectZoom);
   const level = zoomLevelOf(zoom);
   const [renaming, setRenaming] = useState(false);
   const [merging, setMerging] = useState(false);
+  /** The dot count a dissolve came back with, awaiting consent (spec §19). */
+  const [dissolving, setDissolving] = useState<number | null>(null);
+  const dissolve = async (removeVotes?: boolean) => {
+    if (!actions) return;
+    const outcome = await actions.dissolve(chip.clusterId, removeVotes);
+    setDissolving(typeof outcome === "object" ? outcome.votes : null);
+  };
   const managed = decision !== undefined && actions !== undefined;
   const allowed = managed && decision.allowed;
   const scale = level === "shape" ? 1 / zoom : 1;
@@ -107,6 +132,7 @@ export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps
           {chip.name}
         </span>
         <span className="text-muted-foreground font-normal">{cardsCount(chip.count)}</span>
+        {dots && <DotControls {...dots} />}
         {managed && (
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -128,7 +154,7 @@ export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps
                 {MERGE_GROUP}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => actions.tidy(chip.clusterId)}>{TIDY_GROUP}</DropdownMenuItem>
-              <DropdownMenuItem variant="destructive" onClick={() => void actions.dissolve(chip.clusterId)}>
+              <DropdownMenuItem variant="destructive" onClick={() => void dissolve()}>
                 {DISSOLVE_GROUP}
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -148,6 +174,22 @@ export const ClusterNodeView = memo(function ClusterNodeView({ data }: NodeProps
           onClose={() => setMerging(false)}
           onMerge={(into) => actions.merge(chip.clusterId, into)}
         />
+      )}
+      {managed && dissolving !== null && (
+        <AlertDialog open onOpenChange={(open) => !open && setDissolving(null)}>
+          <AlertDialogContent data-testid="dissolve-confirm" className="nodrag nowheel">
+            <AlertDialogHeader>
+              <AlertDialogTitle>{DISSOLVE_WITH_VOTES_TITLE}</AlertDialogTitle>
+              <AlertDialogDescription>{dissolveClusterConfirm(dissolving)}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{CANCEL_BUTTON}</AlertDialogCancel>
+              <AlertDialogAction variant="destructive" onClick={() => void dissolve(true)}>
+                {DISSOLVE_CONFIRM_BUTTON}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
     </div>
   );

--- a/src/components/retro/dot-controls.tsx
+++ b/src/components/retro/dot-controls.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Minus, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ADD_DOT, REMOVE_DOT, votesCount } from "@/convex/retroCopy";
+import type { TopicDots } from "./dots";
+
+export interface DotControlsProps extends TopicDots {
+  /** Place a dot; absent when the topic takes none, which hides the button. */
+  onPlace?: () => void;
+  /** Take one of the viewer's own dots off; absent when there is nothing to take. */
+  onRemove?: () => void;
+  className?: string;
+}
+
+/**
+ * A topic's dots (spec §11, §10.8): the aggregate when the entry shows it,
+ * the viewer's own always, and — while the entry takes dots — one button
+ * each way. Nothing here decides the budget: the tap goes to the hook,
+ * which refuses locally at the cap with the reason.
+ */
+export function DotControls({ count, mine, onPlace, onRemove, className }: DotControlsProps) {
+  if (count === undefined && mine === 0 && !onPlace && !onRemove) return null;
+  return (
+    <div
+      data-testid="dots"
+      data-count={count ?? ""}
+      data-mine={mine}
+      className={cn("nodrag flex items-center gap-1 text-xs", className)}
+      // A tap on a dot is a vote, not a selection of the card under it.
+      onClick={(e) => e.stopPropagation()}
+    >
+      {count !== undefined && (
+        <span className="rounded-full bg-black/5 px-2 py-0.5 font-medium tabular-nums dark:bg-white/10">
+          {votesCount(count)}
+        </span>
+      )}
+      {mine > 0 && (
+        <span
+          aria-label={`${mine} of your ${mine === 1 ? "vote" : "votes"}`}
+          className="flex items-center gap-0.5"
+        >
+          {Array.from({ length: Math.min(mine, 5) }, (_, i) => (
+            <span key={i} className="size-2 rounded-full bg-primary" />
+          ))}
+          {mine > 5 && <span className="tabular-nums">{mine}</span>}
+        </span>
+      )}
+      {onRemove && (
+        <Button type="button" variant="ghost" size="icon-xs" aria-label={REMOVE_DOT} disabled={mine === 0} onClick={onRemove}>
+          <Minus className="size-3" />
+        </Button>
+      )}
+      {onPlace && (
+        <Button type="button" variant="outline" size="icon-xs" aria-label={ADD_DOT} onClick={onPlace}>
+          <Plus className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/retro/dot-controls.tsx
+++ b/src/components/retro/dot-controls.tsx
@@ -32,13 +32,13 @@ export function DotControls({ count, mine, onPlace, onRemove, className }: DotCo
       onClick={(e) => e.stopPropagation()}
     >
       {count !== undefined && (
-        <span className="rounded-full bg-black/5 px-2 py-0.5 font-medium tabular-nums dark:bg-white/10">
+        <span className="rounded-full bg-black/5 px-2 py-0.5 font-medium tabular-nums dark:bg-surface-3">
           {votesCount(count)}
         </span>
       )}
       {mine > 0 && (
         <span
-          aria-label={`${mine} of your ${mine === 1 ? "vote" : "votes"}`}
+          aria-label={`Your ${votesCount(mine)}`}
           className="flex items-center gap-0.5"
         >
           {Array.from({ length: Math.min(mine, 5) }, (_, i) => (

--- a/src/components/retro/dots.test.ts
+++ b/src/components/retro/dots.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The local dot rule (spec §10.8): a dot is refused in the browser when the
+ * viewer's own count in the tally equals the entry's budget or the topic's
+ * `maxPerTopic`, by the same reading the server enforces.
+ */
+import { describe, it, expect } from "vitest";
+import type { TallyRead } from "@/convex/model/retroVotes";
+import { dotRefusal, dotsLeft, dotsOf } from "./dots";
+
+const tally = (patch: Partial<TallyRead> = {}): TallyRead => ({
+  stageEntryId: "v1",
+  visible: false,
+  counts: {},
+  mine: {},
+  spent: 0,
+  budget: 5,
+  ...patch,
+});
+
+describe("dotRefusal", () => {
+  it("lands under the budget, refuses the sixth dot, and refuses without a budget or a tally", () => {
+    expect(dotRefusal(tally({ spent: 4 }), "t")).toBeNull();
+    expect(dotRefusal(tally({ spent: 5 }), "t")).toBe("All your votes are placed");
+    expect(dotRefusal(tally({ budget: undefined }), "t")).toBe("This stage takes no votes");
+    expect(dotRefusal(undefined, "t")).toBe("This stage takes no votes");
+  });
+
+  it("caps one topic at maxPerTopic by own dots there, leaving other topics open", () => {
+    const capped = tally({ spent: 1, maxPerTopic: 1, mine: { t: 1 } });
+    expect(dotRefusal(capped, "t")).toBe("No more votes on this topic");
+    expect(dotRefusal(capped, "u")).toBeNull();
+  });
+});
+
+describe("dotsOf and dotsLeft", () => {
+  it("shows the aggregate only when the entry does, own dots always, and the remainder of the budget", () => {
+    const hidden = tally({ spent: 2, counts: { t: 7 }, mine: { t: 2 } });
+    expect(dotsOf(hidden, "t")).toEqual({ mine: 2 });
+    expect(dotsOf(tally({ visible: true, counts: { t: 7 }, mine: { t: 2 } }), "t")).toEqual({ count: 7, mine: 2 });
+    expect(dotsOf(tally({ visible: true }), "t")).toEqual({ count: 0, mine: 0 });
+    expect(dotsOf(undefined, "t")).toEqual({ mine: 0 });
+    expect(dotsLeft(hidden)).toBe(3);
+    expect(dotsLeft(tally({ budget: undefined }))).toBeUndefined();
+    expect(dotsLeft(tally({ spent: 9 }))).toBe(0);
+  });
+});

--- a/src/components/retro/dots.ts
+++ b/src/components/retro/dots.ts
@@ -1,0 +1,39 @@
+import type { TallyRead } from "@/convex/model/retroVotes";
+import { NO_VOTE_BUDGET, TOPIC_VOTES_CAPPED, VOTE_BUDGET_SPENT } from "@/convex/retroCopy";
+
+/**
+ * Dots on the client (spec §10.8, §11): the local refusal reads the same
+ * rule the server enforces — the viewer's own count in the tally against
+ * the entry's budget and the topic's cap — so a sixth dot never leaves the
+ * browser. Pure, so a node test proves it.
+ */
+
+/** Why a dot on the topic would be refused, or null when it would land. */
+export function dotRefusal(tally: TallyRead | undefined, topicKey: string): string | null {
+  if (!tally || tally.budget === undefined) return NO_VOTE_BUDGET;
+  if (tally.spent >= tally.budget) return VOTE_BUDGET_SPENT;
+  if (tally.maxPerTopic !== undefined && (tally.mine[topicKey] ?? 0) >= tally.maxPerTopic) return TOPIC_VOTES_CAPPED;
+  return null;
+}
+
+export interface TopicDots {
+  /** Everyone's dots, when the entry shows them. */
+  count?: number;
+  /** The viewer's own dots on the topic. */
+  mine: number;
+}
+
+/** What the topic shows: the aggregate when visible, own dots always. */
+export function dotsOf(tally: TallyRead | undefined, topicKey: string): TopicDots {
+  if (!tally) return { mine: 0 };
+  return {
+    ...(tally.visible ? { count: tally.counts[topicKey] ?? 0 } : {}),
+    mine: tally.mine[topicKey] ?? 0,
+  };
+}
+
+/** The viewer's remaining dots on the current entry, when it takes any. */
+export function dotsLeft(tally: TallyRead | undefined): number | undefined {
+  if (!tally || tally.budget === undefined) return undefined;
+  return Math.max(0, tally.budget - tally.spent);
+}

--- a/src/components/retro/dots.ts
+++ b/src/components/retro/dots.ts
@@ -1,4 +1,4 @@
-import type { TallyRead } from "@/convex/model/retroVotes";
+import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
 import { NO_VOTE_BUDGET, TOPIC_VOTES_CAPPED, VOTE_BUDGET_SPENT } from "@/convex/retroCopy";
 
 /**
@@ -8,11 +8,14 @@ import { NO_VOTE_BUDGET, TOPIC_VOTES_CAPPED, VOTE_BUDGET_SPENT } from "@/convex/
  * browser. Pure, so a node test proves it.
  */
 
+/** The tally's key for a topic: its row id, as the server keys it. */
+export const topicKey = (target: TopicRef): string => target.id;
+
 /** Why a dot on the topic would be refused, or null when it would land. */
-export function dotRefusal(tally: TallyRead | undefined, topicKey: string): string | null {
+export function dotRefusal(tally: TallyRead | undefined, key: string): string | null {
   if (!tally || tally.budget === undefined) return NO_VOTE_BUDGET;
   if (tally.spent >= tally.budget) return VOTE_BUDGET_SPENT;
-  if (tally.maxPerTopic !== undefined && (tally.mine[topicKey] ?? 0) >= tally.maxPerTopic) return TOPIC_VOTES_CAPPED;
+  if (tally.maxPerTopic !== undefined && (tally.mine[key] ?? 0) >= tally.maxPerTopic) return TOPIC_VOTES_CAPPED;
   return null;
 }
 

--- a/src/components/retro/mobile-chrome.test.tsx
+++ b/src/components/retro/mobile-chrome.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/components/ui/sheet", () => {
 });
 
 import { MobileChrome } from "./mobile-chrome";
+import { VoteBudget } from "./vote-budget";
 import { CardComposer } from "./card-composer";
 import { useState } from "react";
 
@@ -114,5 +115,18 @@ describe("MobileChrome", () => {
     fireEvent.change(screen.getByLabelText("Your card"), { target: { value: "Try mob sessions" } });
     fireEvent.click(screen.getByRole("button", { name: "Post card" }));
     await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledWith("p2", "Try mob sessions"));
+  });
+
+  it("carries the vote budget in the bar while the entry takes dots, with the anonymous line (spec §11, §19)", () => {
+    render(
+      <MobileChrome name="R" stageKind="vote" note={<VoteBudget left={3} budget={5} anonymous />}>
+        <p />
+      </MobileChrome>
+    );
+    const budget = screen.getByTestId("vote-budget");
+    expect(screen.getByTestId("mobile-bar").contains(budget)).toBe(true);
+    expect(budget.getAttribute("data-left")).toBe("3");
+    expect(budget.textContent).toContain("3 of 5 votes left");
+    expect(budget.textContent).toContain("Nobody is shown how you voted.");
   });
 });

--- a/src/components/retro/mobile-chrome.tsx
+++ b/src/components/retro/mobile-chrome.tsx
@@ -26,6 +26,8 @@ export interface MobileChromeProps {
   selection?: Omit<SelectionBarProps, "className">;
   /** Opens the composer; absent for a Team reader. */
   onCompose?: () => void;
+  /** A line in the bar: the vote budget while the entry takes dots. */
+  note?: ReactNode;
   /** What the bottom sheet holds: the stage strip, the roster, the menu. */
   children: ReactNode;
 }
@@ -46,6 +48,7 @@ export function MobileChrome({
   enteredAt,
   selection,
   onCompose,
+  note,
   children,
 }: MobileChromeProps) {
   const [open, setOpen] = useState(false);
@@ -60,6 +63,7 @@ export function MobileChrome({
         data-testid="mobile-bar"
         className="absolute inset-x-0 bottom-0 z-10 flex flex-col gap-2 border-t bg-white/95 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:bg-surface-1/95"
       >
+        {note}
         {selection && <SelectionBar {...selection} />}
         <div className="flex items-center gap-2">
           <Button type="button" variant="outline" size="icon" aria-label={BOARD_MENU} onClick={() => setOpen(true)}>

--- a/src/components/retro/optimistic.test.ts
+++ b/src/components/retro/optimistic.test.ts
@@ -11,7 +11,18 @@ import { getFunctionName, type FunctionReference } from "convex/server";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { BoardRead, FullCard } from "@/convex/model/retro";
-import { applyAddToCluster, applyCreate, applyDelete, applyFormCluster, applyMove, applyTextEdit, applyUngroup } from "./optimistic";
+import type { TallyRead } from "@/convex/model/retroVotes";
+import {
+  applyAddToCluster,
+  applyCreate,
+  applyDelete,
+  applyFormCluster,
+  applyMove,
+  applyPlaceDot,
+  applyRemoveDot,
+  applyTextEdit,
+  applyUngroup,
+} from "./optimistic";
 
 const roomId = "room-1" as Id<"rooms">;
 const me = "u-me" as Id<"users">;
@@ -73,6 +84,7 @@ const full = (clientId: string, authorId: Id<"users">, text = clientId): FullCar
 // `api.retro.board` names "retro:board"; the fake keys on the last segment.
 const BOARD = getFunctionName(api.retro.board).split(/[:.]/).pop()!;
 const MINE = getFunctionName(api.retro.mine).split(/[:.]/).pop()!;
+const TALLY = getFunctionName(api.retro.tally).split(/[:.]/).pop()!;
 
 describe("applyCreate", () => {
   it("in collect inserts a silhouette into board, the full card into mine, and names the writer", () => {
@@ -195,5 +207,54 @@ describe("group and ungroup (spec §10.7): clusterId in board only", () => {
     expect(next.cards.map((c) => c.clusterId)).toEqual([undefined, "k1", undefined]);
     expect(next.cards.map((c) => "clusterId" in c)).toEqual([false, true, false]);
     expect(next.clusters.map((k) => k._id)).toEqual(["k1", "k2"]);
+  });
+});
+
+describe("dots (spec §10.7): a dot patches retro.tally only", () => {
+  const tally = (patch: Partial<TallyRead> = {}): TallyRead => ({
+    stageEntryId: "v1",
+    visible: false,
+    counts: {},
+    mine: {},
+    spent: 0,
+    budget: 5,
+    ...patch,
+  });
+  const onCard = { kind: "card" as const, id: "id-a" as Id<"retroCards"> };
+
+  it("applyPlaceDot bumps own dots and the spend; the aggregate only where the entry shows it", () => {
+    const { store, writes, value } = fakeStore({ [TALLY]: tally(), [BOARD]: board("visible", [full("a", me)]) });
+    applyPlaceDot(store, { roomId, target: onCard });
+    expect(writes).toEqual([TALLY]);
+    expect(value<TallyRead>(TALLY)).toEqual(tally({ mine: { "id-a": 1 }, spent: 1 }));
+
+    const shown = fakeStore({ [TALLY]: tally({ visible: true, counts: { "id-a": 2 } }) });
+    applyPlaceDot(shown.store, { roomId, target: onCard });
+    expect(shown.value<TallyRead>(TALLY).counts).toEqual({ "id-a": 3 });
+  });
+
+  it("a dot on a grouped card also counts for its cluster, read from the cached board (ADR-0016)", () => {
+    const { store, value } = fakeStore({
+      [TALLY]: tally({ visible: true }),
+      [BOARD]: board("visible", [inCluster(full("a", me), "k1")], [cluster("k1", "Group 1")]),
+    });
+    applyPlaceDot(store, { roomId, target: onCard });
+    expect(value<TallyRead>(TALLY).counts).toEqual({ "id-a": 1, k1: 1 });
+    applyRemoveDot(store, { roomId, target: onCard });
+    expect(value<TallyRead>(TALLY)).toEqual(tally({ visible: true }));
+  });
+
+  it("applyRemoveDot takes one own dot off and never goes below none", () => {
+    const { store, value } = fakeStore({ [TALLY]: tally({ visible: true, counts: { "id-a": 2 }, mine: { "id-a": 1 }, spent: 1 }) });
+    applyRemoveDot(store, { roomId, target: onCard });
+    expect(value<TallyRead>(TALLY)).toEqual(tally({ visible: true, counts: { "id-a": 1 } }));
+    applyRemoveDot(store, { roomId, target: onCard });
+    expect(value<TallyRead>(TALLY)).toEqual(tally({ visible: true, counts: { "id-a": 1 } }));
+  });
+
+  it("does nothing when the tally is not cached", () => {
+    const { store, writes } = fakeStore({ [BOARD]: board("visible") });
+    applyPlaceDot(store, { roomId, target: onCard });
+    expect(writes).toEqual([]);
   });
 });

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -5,6 +5,7 @@ import type { BoardRead, FullCard, ProjectedCard } from "@/convex/model/retro";
 import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import { nextGroupName } from "@/convex/retroCopy";
+import { topicKey } from "./dots";
 
 /**
  * Optimistic functions (ADR-0022, spec §10.7): one synchronous pure
@@ -214,7 +215,7 @@ const shifted = (record: Record<string, number>, key: string, by: number): Recor
 
 /** A dot placed or removed: own dots and the spend always, the aggregate only where it shows (spec §10.7). */
 function applyDot(store: OptimisticLocalStore, args: DotArgs, by: 1 | -1): void {
-  const key = args.target.id;
+  const key = topicKey(args.target);
   const clusterId = clusterOfTarget(store, args.target);
   patchTally(store, (tally) => {
     if (by === -1 && (tally.mine[key] ?? 0) === 0) return tally;

--- a/src/components/retro/optimistic.ts
+++ b/src/components/retro/optimistic.ts
@@ -2,6 +2,7 @@ import type { OptimisticLocalStore } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { BoardRead, FullCard, ProjectedCard } from "@/convex/model/retro";
+import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import { nextGroupName } from "@/convex/retroCopy";
 
@@ -142,11 +143,6 @@ export interface UngroupArgs {
   clientIds: string[];
 }
 
-/**
- * Point the named cards at a cluster (or none) and drop any cluster this
- * change left empty — the server's own rule, no more: a row that was
- * already empty is the server's to remove.
- */
 /** Re-point the named cards; a cluster left empty keeps its row, as on the server. */
 function repointBoard(board: BoardRead, clientIds: readonly string[], clusterId: Id<"retroClusters"> | undefined): BoardRead {
   const named = new Set(clientIds);
@@ -183,4 +179,58 @@ export function applyAddToCluster(store: OptimisticLocalStore, args: AddToCluste
 
 export function applyUngroup(store: OptimisticLocalStore, args: UngroupArgs): void {
   patchBoard(store, (board) => repointBoard(board, args.clientIds, undefined));
+}
+
+export interface DotArgs {
+  roomId: Id<"rooms">;
+  target: TopicRef;
+}
+
+/**
+ * The cluster a card target's dot also counts for (ADR-0016), read from
+ * the cached board; undefined for a cluster target or a loose card.
+ */
+function clusterOfTarget(store: OptimisticLocalStore, target: TopicRef): Id<"retroClusters"> | undefined {
+  if (target.kind !== "card") return undefined;
+  for (const { value } of store.getAllQueries(api.retro.board)) {
+    const card = value?.cards.find((candidate) => candidate._id === target.id);
+    if (card?.clusterId !== undefined) return card.clusterId;
+  }
+  return undefined;
+}
+
+function patchTally(store: OptimisticLocalStore, patch: (tally: TallyRead) => TallyRead): void {
+  for (const { args, value } of store.getAllQueries(api.retro.tally)) {
+    if (value === undefined) continue;
+    store.setQuery(api.retro.tally, args, patch(value));
+  }
+}
+
+const shifted = (record: Record<string, number>, key: string, by: number): Record<string, number> => {
+  const next = (record[key] ?? 0) + by;
+  const { [key]: _dropped, ...rest } = record;
+  return next > 0 ? { ...rest, [key]: next } : rest;
+};
+
+/** A dot placed or removed: own dots and the spend always, the aggregate only where it shows (spec §10.7). */
+function applyDot(store: OptimisticLocalStore, args: DotArgs, by: 1 | -1): void {
+  const key = args.target.id;
+  const clusterId = clusterOfTarget(store, args.target);
+  patchTally(store, (tally) => {
+    if (by === -1 && (tally.mine[key] ?? 0) === 0) return tally;
+    let counts = tally.counts;
+    if (tally.visible) {
+      counts = shifted(counts, key, by);
+      if (clusterId !== undefined) counts = shifted(counts, clusterId, by);
+    }
+    return { ...tally, counts, mine: shifted(tally.mine, key, by), spent: Math.max(0, tally.spent + by) };
+  });
+}
+
+export function applyPlaceDot(store: OptimisticLocalStore, args: DotArgs): void {
+  applyDot(store, args, 1);
+}
+
+export function applyRemoveDot(store: OptimisticLocalStore, args: DotArgs): void {
+  applyDot(store, args, -1);
 }

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -34,7 +34,7 @@ import { editingOf } from "./readiness";
 import type { CardActions } from "./use-card-actions";
 import type { DotActions } from "./use-dot-actions";
 import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
-import { dotsLeft, dotsOf } from "./dots";
+import { dotsLeft, dotsOf, topicKey } from "./dots";
 import type { DotControlsProps } from "./dot-controls";
 import { VoteBudget } from "./vote-budget";
 
@@ -181,7 +181,7 @@ export function RetroBoard({
   const dotsFor = useCallback(
     (target: TopicRef, topic: boolean): DotControlsProps | undefined => {
       if (tally === undefined) return undefined;
-      const shown = dotsOf(tally, target.id);
+      const shown = dotsOf(tally, topicKey(target));
       return {
         ...(topic ? shown : { mine: shown.mine }),
         ...(takesDots && topic ? { onPlace: () => dotActions!.place(target) } : {}),

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -32,6 +32,11 @@ import { CARD_MIN_HEIGHT, placeNewCard, type BoardCard } from "./cards";
 import { useHand } from "./use-hand";
 import { editingOf } from "./readiness";
 import type { CardActions } from "./use-card-actions";
+import type { DotActions } from "./use-dot-actions";
+import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
+import { dotsLeft, dotsOf } from "./dots";
+import type { DotControlsProps } from "./dot-controls";
+import { VoteBudget } from "./vote-budget";
 
 /** What an attendee brings to the board that a Team reader does not. */
 export interface BoardViewer {
@@ -44,6 +49,8 @@ export interface BoardViewer {
   controls: StageControls;
   cards: CardActions;
   clusters: ClusterActions;
+  /** The dot writes (spec §11); present whenever the tally is. */
+  dots?: DotActions;
   /** Another person's card, and a cluster's rename, merge, tidy and dissolve, only under this decision (spec §4.2). */
   cardManagement: ResolvedDecision;
 }
@@ -64,6 +71,8 @@ interface RetroBoardProps {
   team?: RetroTeam;
   /** The attendee's presence and stageFlow wiring; absent for a Team reader. */
   viewer?: BoardViewer;
+  /** The tally, mounted only while the shared pointer is in `vote` or `discuss` (spec §9). */
+  tally?: TallyRead;
   /** The header's menu, for attendees. */
   menu?: ReactNode;
   /** A line under the header: the non-attending Team reader's (ADR-0009). */
@@ -128,6 +137,7 @@ export function RetroBoard({
   viewer,
   menu,
   banner,
+  tally,
 }: RetroBoardProps) {
   const currentStage = currentStageOf(retro);
   /** The viewer's own view; null follows the shared pointer. */
@@ -163,6 +173,23 @@ export function RetroBoard({
   );
 
   const hand = useHand({ cards, onDrop: viewer?.cards.move ?? noMoves, tapSelect: isMobile });
+
+  // Dots (spec §11): a topic is a cluster or a loose card; a grouped card
+  // shows and gives back the viewer's own dots on it, and takes no more.
+  const dotActions = viewer?.dots;
+  const takesDots = tally !== undefined && tally.budget !== undefined && dotActions !== undefined;
+  const dotsFor = useCallback(
+    (target: TopicRef, topic: boolean): DotControlsProps | undefined => {
+      if (tally === undefined) return undefined;
+      const shown = dotsOf(tally, target.id);
+      return {
+        ...(topic ? shown : { mine: shown.mine }),
+        ...(takesDots && topic ? { onPlace: () => dotActions!.place(target) } : {}),
+        ...(takesDots && (topic || shown.mine > 0) ? { onRemove: () => dotActions!.remove(target) } : {}),
+      };
+    },
+    [tally, takesDots, dotActions]
+  );
 
   const namesById = useMemo(() => new Map(users.map((user) => [user._id as string, user.name])), [users]);
   const tintByPrompt = useMemo(
@@ -202,13 +229,16 @@ export function RetroBoard({
             editable,
             level,
             ...(isMobile && hand.selected.has(card.clientId) ? { tapSelected: true } : {}),
+            ...(tally !== undefined && !card.hidden
+              ? { dots: dotsFor({ kind: "card", id: card._id }, card.clusterId === undefined) }
+              : {}),
             ...(viewer && editable
               ? { onEditText: viewer.cards.editText, onDelete: viewer.cards.remove, onEditing: viewer.onEditing }
               : {}),
           },
         };
       }),
-    [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy, level, isMobile]
+    [cards, viewer, hand.positions, hand.measured, hand.selected, tintByPrompt, named, namesById, editingBy, level, isMobile, tally, dotsFor]
   );
 
   /** The cards as geometry: positions read through the hand, heights as measured. */
@@ -235,7 +265,7 @@ export function RetroBoard({
   // card box is what is drawn, so a hull hugs it.
   const hullNodes = useMemo<HullNode[]>(() => {
     return hullsFor(currentStage.kind, members, cardSize).map(
-      (hull) => ({
+      (hull): HullNode => ({
         id: `hull-${hull.key}`,
         type: "hull",
         position: hull.position,
@@ -243,10 +273,13 @@ export function RetroBoard({
         selectable: false,
         focusable: false,
         zIndex: -1,
+        // A rebuilt node is hidden until React Flow measures it again;
+        // the hand keeps what it measured (spec §10.5).
+        ...(hand.measured.has(`hull-${hull.key}`) ? { measured: hand.measured.get(`hull-${hull.key}`) } : {}),
         data: { hull },
       })
     );
-  }, [currentStage.kind, members, cardSize]);
+  }, [currentStage.kind, members, cardSize, hand.measured]);
 
   const chips = useMemo(() => clusterChips(clusters, members, cardSize), [clusters, members, cardSize]);
 
@@ -271,7 +304,7 @@ export function RetroBoard({
 
   const clusterNodes = useMemo<ClusterNode[]>(
     () =>
-      chips.map((chip) => ({
+      chips.map((chip): ClusterNode => ({
         id: `cluster-${chip.clusterId}`,
         type: "cluster",
         position: chip.position,
@@ -280,13 +313,17 @@ export function RetroBoard({
         focusable: false,
         // Above a selected card, which React Flow elevates to 1000.
         zIndex: CHIP_Z_INDEX,
+        ...(hand.measured.has(`cluster-${chip.clusterId}`)
+          ? { measured: hand.measured.get(`cluster-${chip.clusterId}`) }
+          : {}),
         data: {
           chip,
           others: chips.filter((other) => other.clusterId !== chip.clusterId),
           ...(viewer && chipActions ? { decision: viewer.cardManagement, actions: chipActions } : {}),
+          ...(tally !== undefined ? { dots: dotsFor({ kind: "cluster", id: chip.clusterId }, true) } : {}),
         },
       })),
-    [chips, viewer, chipActions]
+    [chips, viewer, chipActions, tally, dotsFor, hand.measured]
   );
 
   // Zones, then hulls (same z, later in order so they draw above), cards, chips.
@@ -351,6 +388,12 @@ export function RetroBoard({
     },
     [viewer, zones, cards]
   );
+
+  const left = dotsLeft(tally);
+  const budget =
+    viewer && tally?.budget !== undefined && left !== undefined ? (
+      <VoteBudget left={left} budget={tally.budget} anonymous={retro.attribution === "anonymous"} />
+    ) : null;
 
   const onlineCount = viewer ? users.filter((user) => user.isOnline).length : undefined;
   const writerSet = useMemo(() => (named ? new Set(writers) : undefined), [named, writers]);
@@ -436,6 +479,7 @@ export function RetroBoard({
           enteredAt={retro.currentStageEnteredAt}
           selection={selection}
           onCompose={viewer ? () => setComposing(true) : undefined}
+          note={budget}
         >
           {banner}
           {stageNav}
@@ -486,12 +530,15 @@ export function RetroBoard({
         <div className="relative min-w-0 flex-1">
           {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
           {canvas}
-          {selection && (
-            <SelectionBar
-              {...selection}
-              className="absolute top-3 left-3 rounded-lg border bg-white/95 p-1.5 shadow-md dark:bg-surface-2/95"
-            />
-          )}
+          <div className="absolute top-3 left-3 flex flex-col items-start gap-2">
+            {budget && <div className="rounded-lg border bg-white/95 px-2.5 py-1.5 shadow-md dark:bg-surface-2/95">{budget}</div>}
+            {selection && (
+              <SelectionBar
+                {...selection}
+                className="rounded-lg border bg-white/95 p-1.5 shadow-md dark:bg-surface-2/95"
+              />
+            )}
+          </div>
           {viewer && (
             <Button
               type="button"

--- a/src/components/retro/use-cluster-actions.test.tsx
+++ b/src/components/retro/use-cluster-actions.test.tsx
@@ -83,17 +83,26 @@ describe("useClusterActions: group and ungroup", () => {
 });
 
 describe("useClusterActions: cardManagement acts", () => {
-  it("rename, merge and dissolve resolve true on success and pass their arguments through", async () => {
-    mocks.outcomes.push(() => Promise.resolve(), () => Promise.resolve(), () => Promise.resolve());
+  it("rename, merge and dissolve resolve on success and pass their arguments through", async () => {
+    mocks.outcomes.push(() => Promise.resolve(), () => Promise.resolve(), () => Promise.resolve({ dissolved: true }));
     const { result } = renderHook(() => useClusterActions(roomId));
     expect(await result.current.rename(k1, "Demo")).toBe(true);
     expect(await result.current.merge(k1, k2)).toBe(true);
-    expect(await result.current.dissolve(k2)).toBe(true);
+    expect(await result.current.dissolve(k2)).toBe("done");
     expect(mocks.calls).toEqual([
       { fn: "retro.renameCluster", args: { roomId, clusterId: k1, name: "Demo" } },
       { fn: "retro.mergeClusters", args: { roomId, from: k1, into: k2 } },
       { fn: "retro.dissolveCluster", args: { roomId, clusterId: k2 } },
     ]);
+  });
+
+  it("dissolving a cluster with dots hands back the count, then goes through with consent (spec §19)", async () => {
+    mocks.outcomes.push(() => Promise.resolve({ dissolved: false, votes: 4 }), () => Promise.resolve({ dissolved: true }));
+    const { result } = renderHook(() => useClusterActions(roomId));
+    expect(await result.current.dissolve(k1)).toEqual({ votes: 4 });
+    expect(await result.current.dissolve(k1, true)).toBe("done");
+    expect(mocks.calls[1]).toEqual({ fn: "retro.dissolveCluster", args: { roomId, clusterId: k1, removeVotes: true } });
+    expect(mocks.toast.error).not.toHaveBeenCalled();
   });
 
   it("a refused rename resolves false and toasts the refusal's copy", async () => {

--- a/src/components/retro/use-cluster-actions.ts
+++ b/src/components/retro/use-cluster-actions.ts
@@ -17,8 +17,14 @@ export interface ClusterActions {
   /** The `cardManagement` acts resolve to whether they went through; a refusal toasts its reason. */
   rename: (clusterId: Id<"retroClusters">, name: string) => Promise<boolean>;
   merge: (from: Id<"retroClusters">, into: Id<"retroClusters">) => Promise<boolean>;
-  dissolve: (clusterId: Id<"retroClusters">) => Promise<boolean>;
+  /**
+   * Dissolve: done, failed, or — when the cluster has dots and no consent
+   * was given — the count to confirm with (spec §10.3, §19).
+   */
+  dissolve: (clusterId: Id<"retroClusters">, removeVotes?: boolean) => Promise<DissolveResult>;
 }
+
+export type DissolveResult = "done" | "failed" | { votes: number };
 
 /** The refusal's reason, or the fallback for a failure that outlived its retries. */
 function surface(error: unknown): void {
@@ -92,7 +98,15 @@ export function useClusterActions(roomId: Id<"rooms">): ClusterActions {
   );
 
   const dissolve = useCallback<ClusterActions["dissolve"]>(
-    (clusterId) => act(dissolveCluster({ roomId, clusterId })),
+    async (clusterId, removeVotes) => {
+      try {
+        const outcome = await dissolveCluster({ roomId, clusterId, ...(removeVotes ? { removeVotes } : {}) });
+        return outcome.dissolved ? "done" : { votes: outcome.votes };
+      } catch (error) {
+        surface(error);
+        return "failed";
+      }
+    },
     [dissolveCluster, roomId]
   );
 

--- a/src/components/retro/use-dot-actions.test.tsx
+++ b/src/components/retro/use-dot-actions.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The dot writes (spec §10.8, §11): a dot past the budget or the topic's
+ * cap is refused in the browser and never sent; one under it is sent and
+ * retried on a transient failure; a server refusal toasts its reason.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { ConvexError } from "convex/values";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { TallyRead } from "@/convex/model/retroVotes";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as { fn: string; args: unknown }[],
+  outcomes: [] as (() => Promise<unknown>)[],
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/convex/_generated/api", () => ({
+  api: { retro: { placeDot: "retro.placeDot", removeDot: "retro.removeDot" } },
+}));
+vi.mock("convex/react", () => ({
+  useMutation: (ref: string) => {
+    const fn = async (args: unknown) => {
+      mocks.calls.push({ fn: ref, args });
+      const next = mocks.outcomes.shift();
+      return next ? await next() : undefined;
+    };
+    return Object.assign(fn, { withOptimisticUpdate: () => fn });
+  },
+}));
+vi.mock("@/lib/toast", () => ({ toast: mocks.toast }));
+
+import { useDotActions } from "./use-dot-actions";
+
+const roomId = "room1" as Id<"rooms">;
+const onCard = { kind: "card" as const, id: "c1" as Id<"retroCards"> };
+const tally = (patch: Partial<TallyRead> = {}): TallyRead => ({
+  stageEntryId: "v1",
+  visible: false,
+  counts: {},
+  mine: {},
+  spent: 0,
+  budget: 5,
+  ...patch,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.calls.length = 0;
+  mocks.outcomes.length = 0;
+  mocks.toast.error.mockClear();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("useDotActions", () => {
+  it("refuses the sixth dot locally: a toast, no call", () => {
+    const { result } = renderHook(() => useDotActions(roomId, tally({ spent: 5 })));
+    result.current.place(onCard);
+    expect(mocks.calls).toEqual([]);
+    expect(mocks.toast.error).toHaveBeenCalledWith("All your votes are placed");
+  });
+
+  it("refuses a capped topic locally, and sends a dot elsewhere", async () => {
+    mocks.outcomes.push(() => Promise.resolve());
+    const { result } = renderHook(() => useDotActions(roomId, tally({ spent: 1, maxPerTopic: 1, mine: { c1: 1 } })));
+    result.current.place(onCard);
+    expect(mocks.calls).toEqual([]);
+    expect(mocks.toast.error).toHaveBeenCalledWith("No more votes on this topic");
+    const elsewhere = { kind: "cluster" as const, id: "k1" as Id<"retroClusters"> };
+    result.current.place(elsewhere);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(mocks.calls).toEqual([{ fn: "retro.placeDot", args: { roomId, target: elsewhere } }]);
+  });
+
+  it("a forced dot the server refuses with `budget` toasts the reason and is not retried", async () => {
+    mocks.outcomes.push(() => Promise.reject(new ConvexError({ code: "budget", message: "All your votes are placed" })));
+    const { result } = renderHook(() => useDotActions(roomId, tally({ spent: 4 })));
+    result.current.place(onCard);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.toast.error).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith("All your votes are placed");
+  });
+
+  it("remove retries a transient failure and stays silent on success", async () => {
+    mocks.outcomes.push(() => Promise.reject(new Error("network")), () => Promise.resolve());
+    const { result } = renderHook(() => useDotActions(roomId, tally({ spent: 1, mine: { c1: 1 } })));
+    result.current.remove(onCard);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(mocks.calls.map((c) => c.fn)).toEqual(["retro.removeDot", "retro.removeDot"]);
+    expect(mocks.calls[1].args).toEqual({ roomId, target: onCard });
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/retro/use-dot-actions.ts
+++ b/src/components/retro/use-dot-actions.ts
@@ -8,7 +8,7 @@ import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
 import { refusalOf, retryWrite } from "@/lib/write-retry";
 import { toast } from "@/lib/toast";
 import { DOT_ACT_FAILED } from "@/convex/retroCopy";
-import { dotRefusal } from "./dots";
+import { dotRefusal, topicKey } from "./dots";
 import { applyPlaceDot, applyRemoveDot } from "./optimistic";
 
 export interface DotActions {
@@ -37,7 +37,7 @@ export function useDotActions(roomId: Id<"rooms">, tally: TallyRead | undefined)
 
   const place = useCallback<DotActions["place"]>(
     (target) => {
-      const refused = dotRefusal(tally, target.id);
+      const refused = dotRefusal(tally, topicKey(target));
       if (refused) {
         toast.error(refused);
         return;

--- a/src/components/retro/use-dot-actions.ts
+++ b/src/components/retro/use-dot-actions.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { TallyRead, TopicRef } from "@/convex/model/retroVotes";
+import { refusalOf, retryWrite } from "@/lib/write-retry";
+import { toast } from "@/lib/toast";
+import { DOT_ACT_FAILED } from "@/convex/retroCopy";
+import { dotRefusal } from "./dots";
+import { applyPlaceDot, applyRemoveDot } from "./optimistic";
+
+export interface DotActions {
+  /** One dot on the topic: refused in the browser at the cap, else optimistic and retried. */
+  place: (target: TopicRef) => void;
+  /** One of the viewer's own dots off the topic. */
+  remove: (target: TopicRef) => void;
+}
+
+/** The refusal's reason, or the fallback for a failure that outlived its retries. */
+function surface(error: unknown): void {
+  toast.error(refusalOf(error)?.message || DOT_ACT_FAILED);
+}
+
+/**
+ * The dot writes (spec §10.7, §10.8, §11): both optimistic against
+ * `retro.tally`, a transient failure retried, a refusal dropped at once
+ * with its reason. The local refusal reads the tally the hook is given, so
+ * a dot past the budget or the topic's cap never leaves the browser.
+ */
+export function useDotActions(roomId: Id<"rooms">, tally: TallyRead | undefined): DotActions {
+  const placeDot = useMutation(api.retro.placeDot);
+  const removeDot = useMutation(api.retro.removeDot);
+  const optimisticPlace = useMemo(() => placeDot.withOptimisticUpdate(applyPlaceDot), [placeDot]);
+  const optimisticRemove = useMemo(() => removeDot.withOptimisticUpdate(applyRemoveDot), [removeDot]);
+
+  const place = useCallback<DotActions["place"]>(
+    (target) => {
+      const refused = dotRefusal(tally, target.id);
+      if (refused) {
+        toast.error(refused);
+        return;
+      }
+      void retryWrite(() => optimisticPlace({ roomId, target })).catch(surface);
+    },
+    [optimisticPlace, roomId, tally]
+  );
+
+  const remove = useCallback<DotActions["remove"]>(
+    (target) => {
+      void retryWrite(() => optimisticRemove({ roomId, target })).catch(surface);
+    },
+    [optimisticRemove, roomId]
+  );
+
+  return useMemo(() => ({ place, remove }), [place, remove]);
+}

--- a/src/components/retro/vote-budget.tsx
+++ b/src/components/retro/vote-budget.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { VOTE_ANONYMOUS_NOTE, votesLeft } from "@/convex/retroCopy";
+
+export interface VoteBudgetProps {
+  left: number;
+  budget: number;
+  /** An anonymous retro says so in the vote UI (spec §19). */
+  anonymous: boolean;
+  className?: string;
+}
+
+/** The viewer's remaining dots on the current entry (spec §11), shown while it takes any. */
+export function VoteBudget({ left, budget, anonymous, className }: VoteBudgetProps) {
+  return (
+    <div
+      data-testid="vote-budget"
+      data-left={left}
+      className={cn("flex flex-col gap-0.5 text-xs", className)}
+    >
+      <span className={cn("font-medium tabular-nums", left === 0 && "text-muted-foreground")}>
+        {votesLeft(left, budget)}
+      </span>
+      {anonymous && <span className="text-muted-foreground">{VOTE_ANONYMOUS_NOTE}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #294. Spec §11, §9, §8.2, §10.7–§10.8, §14, §19; ADR-0016, ADR-0012.

`placeDot` and `removeDot` on the current entry, refused `budget` at the entry's budget or the topic's `maxPerTopic` and `stage` only when the entry carries no budget, so any entry may take dots. One row per dot with the voter always stored. `retro.tally` is per viewer: aggregate counts when the entry shows them, the viewer's own dots always, never a voter; a cluster's tally is its own dots plus its members'. A `discuss` entry reads the round it walks. Merge re-points a cluster's dots. Dissolve hands back the count without consent and deletes the dots with it, behind "Dissolve this group? Its {n} votes are removed." A cluster emptied by a membership change keeps its row and frees its dots. Account linking re-points `voterId`. Both mutations bump room activity.

Client: the tally is mounted only in vote and discuss; a dot past the budget or the topic's cap is refused in the browser with its reason; the optimistic function patches `retro.tally`; dot controls on loose cards and cluster chips, the budget readout, and the anonymous line. Rebuilt chip and hull nodes carry the hand's measured size so React Flow keeps them visible.

Schema: two additive indexes on `retroVotes`, `by_room_target` and `by_voter`. Already on the dev deployment.

Tests: convex-test covers budgets per entry, per-topic caps, the fresh budget on a second entry, cluster sums, merge and dissolve effects, the anonymous projection, the ratchet leaving voters, dots in an unexpected stage, account linking and the activity bump; the cascade was already covered. jsdom covers the local refusal, the optimistic tally patch, the chip's confirmation and the card's dots.

Checked by hand in two browsers: the guest's sixth dot is refused locally with a toast and no request; the owner sees no counts during vote and the count after advancing. The chip path: dots, remove, the confirmation naming the count, cancel, consent. Playwright scenario 6 belongs to #301.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd