### PR TITLE
feat(retro): action items and carryover (#296)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -238,7 +238,7 @@ _Avoid_: team settings (broader), template (that is a format), policy
 
 ### Retro actions
 
-Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253) and not yet built. See [ADR-0017](docs/adr/0017-an-action-item-has-one-home-and-carries-over-by-staying-open.md).
+Decided on [map #253](https://github.com/spokvulcan/poker-planning/issues/253) and built in #296. See [ADR-0017](docs/adr/0017-an-action-item-has-one-home-and-carries-over-by-staying-open.md).
 
 **Action item**:
 A commitment a retro produces: a short text, at most one **owner**, an optional due date, and the **source topic** it answers. Always named, in both **Attribution** modes — anonymity stops at the card ([ADR-0012](docs/adr/0012-an-anonymous-retro-card-has-no-stored-author.md)). It lives in exactly one retro for its whole life, has three states (`open`, `done`, `dropped`, all reversible), and carries no priority, description, comments or count limit. Creating one is never refused by a **stage**; the board invites it only during `discuss` and `close`. Never bare "action" — that word is the **permission decision**'s subject.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -41,6 +41,7 @@ import type * as model_issues from "../model/issues.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as model_refusal from "../model/refusal.js";
 import type * as model_retro from "../model/retro.js";
+import type * as model_retroActions from "../model/retroActions.js";
 import type * as model_retroCards from "../model/retroCards.js";
 import type * as model_retroClusters from "../model/retroClusters.js";
 import type * as model_retroFormats from "../model/retroFormats.js";
@@ -113,6 +114,7 @@ declare const fullApi: ApiFromModules<{
   "model/permissions": typeof model_permissions;
   "model/refusal": typeof model_refusal;
   "model/retro": typeof model_retro;
+  "model/retroActions": typeof model_retroActions;
   "model/retroCards": typeof model_retroCards;
   "model/retroClusters": typeof model_retroClusters;
   "model/retroFormats": typeof model_retroFormats;

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -229,7 +229,7 @@ export function validateStageList(stages: readonly StageEntry[]): StageEntry[] {
 }
 
 /** The retros row of a room, or null for a poker room. */
-async function getRetro(
+export async function getRetro(
   ctx: QueryCtx,
   roomId: Id<"rooms">
 ): Promise<Doc<"retros"> | null> {

--- a/convex/model/retroActions.ts
+++ b/convex/model/retroActions.ts
@@ -232,6 +232,12 @@ export async function deleteAction(
 const sameTopic = (a: TopicRef, b: TopicRef) => a.kind === b.kind && a.id === b.id;
 
 /**
+ * How many action rows one index read carries: a retro's items, a Team's
+ * open items, a source's re-point (ADR-0024: bounded, never a stored counter).
+ */
+export const MAX_ACTION_ROWS = 500;
+
+/**
  * A topic's departure (spec §10.3, §13): the sources naming it are nulled
  * when a cluster is dissolved or a card deleted, and re-pointed to the
  * survivor when clusters merge, so a link never dangles. Bounded like the
@@ -246,7 +252,7 @@ export async function repointSources(
   const rows = await ctx.db
     .query("retroActions")
     .withIndex("by_room", (q) => q.eq("roomId", roomId))
-    .take(MAX_REVIEW_ROWS);
+    .take(MAX_ACTION_ROWS);
   await Promise.all(
     rows
       .filter((row) => row.source !== undefined && sameTopic(row.source, from))
@@ -255,9 +261,6 @@ export async function repointSources(
 }
 
 // --- Reads (spec §13, §5): this retro's items, the review, the team page ---
-
-/** How many rows one team-index read carries (ADR-0024: bounded, never a stored counter). */
-export const MAX_REVIEW_ROWS = 500;
 
 /** How many memberships one room's reassign roster carries. */
 const MAX_ROSTER_ROWS = 500;
@@ -301,11 +304,13 @@ export interface ActionRoomRead {
   name: string;
   /** Every attendee, for the reassign picker: an owner must attend (spec §13). */
   members: { userId: Id<"users">; name: string }[];
+  /** Whether the viewer attends; a Team reader reads and acts on nothing (ADR-0009). */
+  attending: boolean;
 }
 
 export interface ActionsRead {
   items: ActionRead[];
-  /** The rooms the items belong to, once each. */
+  /** The rooms the items belong to, once each; a retro's own read carries its room even with no items. */
   rooms: ActionRoomRead[];
 }
 
@@ -390,16 +395,20 @@ async function sourceOf(
 export async function projectActions(
   ctx: QueryCtx,
   viewer: Doc<"users">,
-  actions: readonly Doc<"retroActions">[]
+  actions: readonly Doc<"retroActions">[],
+  /** Rooms in the read whatever the rows: the retro whose panel composes the next item. */
+  always: readonly Id<"rooms">[] = []
 ): Promise<ActionsRead> {
   const users = new Map<Id<"users">, Doc<"users"> | null>();
   const contexts = new Map<Id<"rooms">, RoomContext | null>();
+  const contextOf = async (roomId: Id<"rooms">) => {
+    if (!contexts.has(roomId)) contexts.set(roomId, await loadRoomContext(ctx, viewer, roomId, users));
+    return contexts.get(roomId) ?? null;
+  };
+  for (const roomId of always) await contextOf(roomId);
   const items: ActionRead[] = [];
   for (const action of actions) {
-    if (!contexts.has(action.roomId)) {
-      contexts.set(action.roomId, await loadRoomContext(ctx, viewer, action.roomId, users));
-    }
-    const context = contexts.get(action.roomId);
+    const context = await contextOf(action.roomId);
     if (!context) continue;
     const [owner, creator] = await Promise.all([
       action.ownerId !== undefined ? userOf(ctx, users, action.ownerId) : null,
@@ -428,7 +437,14 @@ export async function projectActions(
   }
   const rooms: ActionRoomRead[] = [];
   for (const [roomId, context] of contexts) {
-    if (context) rooms.push({ roomId, name: context.room.name, members: context.members });
+    if (context) {
+      rooms.push({
+        roomId,
+        name: context.room.name,
+        members: context.members,
+        attending: context.membership !== null,
+      });
+    }
   }
   return { items, rooms };
 }
@@ -444,8 +460,8 @@ export async function roomActions(
   const rows = await ctx.db
     .query("retroActions")
     .withIndex("by_room", (q) => q.eq("roomId", roomId))
-    .take(MAX_REVIEW_ROWS);
-  return projectActions(ctx, viewer, rows.sort(byCreation));
+    .take(MAX_ACTION_ROWS);
+  return projectActions(ctx, viewer, rows.sort(byCreation), [roomId]);
 }
 
 /** The Team's open items from the index, a bounded window, oldest first. */
@@ -453,7 +469,7 @@ async function openTeamRows(ctx: QueryCtx, teamId: Id<"teams">): Promise<Doc<"re
   const rows = await ctx.db
     .query("retroActions")
     .withIndex("by_team_status", (q) => q.eq("teamId", teamId).eq("status", "open"))
-    .take(MAX_REVIEW_ROWS);
+    .take(MAX_ACTION_ROWS);
   return rows.sort(byCreation);
 }
 

--- a/convex/model/retroActions.ts
+++ b/convex/model/retroActions.ts
@@ -1,0 +1,483 @@
+import { MutationCtx, QueryCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import type { ResolvedDecision } from "../permissions";
+import { resolveRoomAction } from "./auth";
+import { updateRoomActivity } from "./rooms";
+import type { CardActor } from "./retroCards";
+import { refusal } from "./refusal";
+import type { TopicRef } from "./walk";
+import { getRetro, policyOf, projectCard, type FullCard, type ProjectedCard, type ProjectionPolicy } from "./retro";
+import {
+  ACTION_NOT_FOUND,
+  ACTION_NOTE_TOO_LONG,
+  ACTION_TEXT_REQUIRED,
+  ACTION_TEXT_TOO_LONG,
+  CARD_NOT_FOUND,
+  CLUSTER_NOT_FOUND,
+  FORMER_MEMBER,
+  HIDDEN_CARD_LABEL,
+  NOTE_ONLY_ON_LEAVING_OPEN,
+  OWNER_NOT_MEMBER,
+} from "../retroCopy";
+
+/**
+ * Action items (spec §13, ADR-0017): a short text with at most one named
+ * owner, an optional date and an optional source topic, living in exactly
+ * one retro for its whole life and carried over by the fact of still being
+ * open. Creation is never refused and correct in every stage (ADR-0010);
+ * the owner may always edit, complete, drop or reopen their own; anyone
+ * `actionManagement` allows may do so to another's, assign, and delete.
+ * Every act bumps the activity chokepoint (spec §14), completing from the
+ * team page included. Attribution never reaches an action (ADR-0012):
+ * creator and owner are named in both modes.
+ */
+
+export const MAX_ACTION_TEXT = 500;
+export const MAX_ACTION_NOTE = 500;
+
+export type ActionStatus = Doc<"retroActions">["status"];
+
+function validateText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) throw refusal("forbidden", ACTION_TEXT_REQUIRED);
+  if (trimmed.length > MAX_ACTION_TEXT) throw refusal("forbidden", ACTION_TEXT_TOO_LONG);
+  return trimmed;
+}
+
+function validateNote(note: string): string {
+  const trimmed = note.trim();
+  if (trimmed.length > MAX_ACTION_NOTE) throw refusal("forbidden", ACTION_NOTE_TOO_LONG);
+  return trimmed;
+}
+
+/** The row, or a `missing` refusal; a row of another room is missing here too. */
+export async function requireAction(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  actionId: Id<"retroActions">
+): Promise<Doc<"retroActions">> {
+  const action = await ctx.db.get(actionId);
+  if (!action || action.roomId !== roomId) {
+    throw refusal("missing", ACTION_NOT_FOUND);
+  }
+  return action;
+}
+
+/** An owner must attend the retro (spec §13): any member, anonymous accounts included. */
+async function requireOwnerAttends(
+  ctx: QueryCtx,
+  roomId: Id<"rooms">,
+  ownerId: Id<"users">
+): Promise<void> {
+  const membership = await ctx.db
+    .query("roomMemberships")
+    .withIndex("by_room_user", (q) => q.eq("roomId", roomId).eq("userId", ownerId))
+    .unique();
+  if (!membership) throw refusal("forbidden", OWNER_NOT_MEMBER);
+}
+
+/** A source topic must be a live topic of the room; a gone one is `missing`. */
+async function requireSource(ctx: QueryCtx, roomId: Id<"rooms">, source: TopicRef): Promise<void> {
+  const topic = await ctx.db.get(source.id);
+  if (!topic || topic.roomId !== roomId) {
+    throw refusal("missing", source.kind === "card" ? CARD_NOT_FOUND : CLUSTER_NOT_FOUND);
+  }
+}
+
+/** The `actionManagement` decision, resolved at most once per act. */
+function management(ctx: QueryCtx, room: Doc<"rooms">, actor: CardActor): () => Promise<ResolvedDecision> {
+  let decision: Promise<ResolvedDecision> | undefined;
+  return () =>
+    (decision ??= resolveRoomAction(ctx, actor.user, actor.membership, room, {
+      kind: "category",
+      category: "actionManagement",
+    }).then((r) => r.decision));
+}
+
+/**
+ * Own-item rights (spec §4.2): the owner may always edit, complete, drop or
+ * reopen their own; anyone else needs `actionManagement`, read back as a
+ * `forbidden` refusal the client can tell from a failure (ADR-0022).
+ */
+async function requireOwnerOrManagement(
+  ctx: QueryCtx,
+  room: Doc<"rooms">,
+  actor: CardActor,
+  action: Doc<"retroActions">
+): Promise<void> {
+  if (action.ownerId !== undefined && action.ownerId === actor.user._id) return;
+  const decision = await management(ctx, room, actor)();
+  if (!decision.allowed) throw refusal("forbidden", decision.message);
+}
+
+/** Assign and delete are `actionManagement` acts with no owner exception. */
+async function requireManagement(ctx: QueryCtx, room: Doc<"rooms">, actor: CardActor): Promise<void> {
+  const decision = await management(ctx, room, actor)();
+  if (!decision.allowed) throw refusal("forbidden", decision.message);
+}
+
+/**
+ * Create an action item (spec §13): never refused, in every stage. The
+ * creator is named; the owner, when given, must attend; the source, when
+ * given, must be a live topic. The Team is denormalised at write time
+ * (ADR-0016); adoption stamps rows written before it (spec §5).
+ */
+export async function createAction(
+  ctx: MutationCtx,
+  args: {
+    room: Doc<"rooms">;
+    actor: CardActor;
+    text: string;
+    ownerId?: Id<"users">;
+    dueAt?: number;
+    source?: TopicRef;
+  }
+): Promise<Id<"retroActions">> {
+  const text = validateText(args.text);
+  if (args.ownerId !== undefined) await requireOwnerAttends(ctx, args.room._id, args.ownerId);
+  if (args.source !== undefined) await requireSource(ctx, args.room._id, args.source);
+  const now = Date.now();
+  const id = await ctx.db.insert("retroActions", {
+    roomId: args.room._id,
+    ...(args.room.teamId !== undefined ? { teamId: args.room.teamId } : {}),
+    text,
+    ...(args.ownerId !== undefined ? { ownerId: args.ownerId } : {}),
+    ...(args.dueAt !== undefined ? { dueAt: args.dueAt } : {}),
+    ...(args.source !== undefined ? { source: args.source } : {}),
+    status: "open",
+    createdBy: args.actor.user._id,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await updateRoomActivity(ctx, args.room);
+  return id;
+}
+
+/** Edit the text and the due date (own, or under `actionManagement`); `dueAt: null` clears it. */
+export async function updateAction(
+  ctx: MutationCtx,
+  args: {
+    room: Doc<"rooms">;
+    actor: CardActor;
+    actionId: Id<"retroActions">;
+    text?: string;
+    dueAt?: number | null;
+  }
+): Promise<void> {
+  const action = await requireAction(ctx, args.room._id, args.actionId);
+  await requireOwnerOrManagement(ctx, args.room, args.actor, action);
+  await ctx.db.patch(action._id, {
+    ...(args.text !== undefined ? { text: validateText(args.text) } : {}),
+    ...(args.dueAt === null ? { dueAt: undefined } : args.dueAt !== undefined ? { dueAt: args.dueAt } : {}),
+    updatedAt: Date.now(),
+  });
+  await updateRoomActivity(ctx, args.room);
+}
+
+/**
+ * Change the status (own, or under `actionManagement`): `open → done |
+ * dropped → open`, all reversible. The note is invited only on leaving
+ * `open` (ADR-0017) and cleared on reopening, so a note always explains the
+ * status the row shows.
+ */
+export async function setActionStatus(
+  ctx: MutationCtx,
+  args: {
+    room: Doc<"rooms">;
+    actor: CardActor;
+    actionId: Id<"retroActions">;
+    status: ActionStatus;
+    note?: string;
+  }
+): Promise<void> {
+  const action = await requireAction(ctx, args.room._id, args.actionId);
+  await requireOwnerOrManagement(ctx, args.room, args.actor, action);
+  const leavingOpen = action.status === "open" && args.status !== "open";
+  if (args.note !== undefined && args.note.trim() !== "" && !leavingOpen) {
+    throw refusal("forbidden", NOTE_ONLY_ON_LEAVING_OPEN);
+  }
+  const note = leavingOpen && args.note !== undefined ? validateNote(args.note) : undefined;
+  await ctx.db.patch(action._id, {
+    status: args.status,
+    note: args.status === "open" ? undefined : note !== undefined && note !== "" ? note : action.note,
+    updatedAt: Date.now(),
+  });
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Assign or unassign (`actionManagement`, no accept step); the owner must attend. */
+export async function assignAction(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; actionId: Id<"retroActions">; ownerId?: Id<"users"> }
+): Promise<void> {
+  const action = await requireAction(ctx, args.room._id, args.actionId);
+  await requireManagement(ctx, args.room, args.actor);
+  if (args.ownerId !== undefined) await requireOwnerAttends(ctx, args.room._id, args.ownerId);
+  await ctx.db.patch(action._id, { ownerId: args.ownerId, updatedAt: Date.now() });
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Delete (`actionManagement`): a separate act from dropping (ADR-0017). */
+export async function deleteAction(
+  ctx: MutationCtx,
+  args: { room: Doc<"rooms">; actor: CardActor; actionId: Id<"retroActions"> }
+): Promise<void> {
+  const action = await requireAction(ctx, args.room._id, args.actionId);
+  await requireManagement(ctx, args.room, args.actor);
+  await ctx.db.delete(action._id);
+  await updateRoomActivity(ctx, args.room);
+}
+
+/** Whether a stored source names this topic. */
+const sameTopic = (a: TopicRef, b: TopicRef) => a.kind === b.kind && a.id === b.id;
+
+/**
+ * A topic's departure (spec §10.3, §13): the sources naming it are nulled
+ * when a cluster is dissolved or a card deleted, and re-pointed to the
+ * survivor when clusters merge, so a link never dangles. Bounded like the
+ * room's other reads; no chokepoint call, the caller's act bumps.
+ */
+export async function repointSources(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">,
+  from: TopicRef,
+  to?: TopicRef
+): Promise<void> {
+  const rows = await ctx.db
+    .query("retroActions")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .take(MAX_REVIEW_ROWS);
+  await Promise.all(
+    rows
+      .filter((row) => row.source !== undefined && sameTopic(row.source, from))
+      .map((row) => ctx.db.patch(row._id, { source: to, updatedAt: Date.now() }))
+  );
+}
+
+// --- Reads (spec §13, §5): this retro's items, the review, the team page ---
+
+/** How many rows one team-index read carries (ADR-0024: bounded, never a stored counter). */
+export const MAX_REVIEW_ROWS = 500;
+
+/** How many memberships one room's reassign roster carries. */
+const MAX_ROSTER_ROWS = 500;
+
+export interface ActionSourceRead {
+  kind: TopicRef["kind"];
+  id: Id<"retroCards"> | Id<"retroClusters">;
+  /** The cluster's name or the card's text through the projection; never an author. */
+  label: string;
+}
+
+/** What the viewer may do to one item, decided server-side like the guard would (spec §4.2). */
+export interface ActionRights {
+  /** Edit, complete, drop or reopen: own, or under `actionManagement`. */
+  edit: boolean;
+  /** Assign and delete: `actionManagement`. */
+  manage: boolean;
+}
+
+export interface ActionRead {
+  _id: Id<"retroActions">;
+  roomId: Id<"rooms">;
+  roomName: string;
+  text: string;
+  status: ActionStatus;
+  note?: string;
+  dueAt?: number;
+  ownerId?: Id<"users">;
+  /** The owner's name, or the register's former member; absent when unowned. */
+  ownerName?: string;
+  createdBy: Id<"users">;
+  creatorName: string;
+  createdAt: number;
+  updatedAt: number;
+  source?: ActionSourceRead;
+  rights: ActionRights;
+}
+
+export interface ActionRoomRead {
+  roomId: Id<"rooms">;
+  name: string;
+  /** Every attendee, for the reassign picker: an owner must attend (spec §13). */
+  members: { userId: Id<"users">; name: string }[];
+}
+
+export interface ActionsRead {
+  items: ActionRead[];
+  /** The rooms the items belong to, once each. */
+  rooms: ActionRoomRead[];
+}
+
+/** One room's part of the projection, loaded once per read. */
+interface RoomContext {
+  room: Doc<"rooms">;
+  policy: ProjectionPolicy | null;
+  members: { userId: Id<"users">; name: string }[];
+  /** The viewer's membership in this room, or null for a Team reader. */
+  membership: Doc<"roomMemberships"> | null;
+  manage: boolean;
+}
+
+async function loadRoomContext(
+  ctx: QueryCtx,
+  viewer: Doc<"users">,
+  roomId: Id<"rooms">,
+  users: Map<Id<"users">, Doc<"users"> | null>
+): Promise<RoomContext | null> {
+  const room = await ctx.db.get(roomId);
+  if (!room) return null;
+  const [retro, rows] = await Promise.all([
+    getRetro(ctx, roomId),
+    ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(MAX_ROSTER_ROWS),
+  ]);
+  const members: RoomContext["members"] = [];
+  for (const row of rows) {
+    const user = await userOf(ctx, users, row.userId);
+    if (user) members.push({ userId: user._id, name: user.name });
+  }
+  const membership = rows.find((row) => row.userId === viewer._id) ?? null;
+  const manage = membership
+    ? (
+        await resolveRoomAction(ctx, viewer, membership, room, {
+          kind: "category",
+          category: "actionManagement",
+        })
+      ).decision.allowed
+    : false;
+  return { room, policy: retro ? policyOf(retro) : null, members, membership, manage };
+}
+
+async function userOf(
+  ctx: QueryCtx,
+  users: Map<Id<"users">, Doc<"users"> | null>,
+  userId: Id<"users">
+): Promise<Doc<"users"> | null> {
+  if (!users.has(userId)) users.set(userId, await ctx.db.get(userId));
+  return users.get(userId)!;
+}
+
+/** A silhouette has no text (ADR-0015). */
+const isFullCard = (card: ProjectedCard): card is FullCard => "text" in card;
+
+/** A source's label: the cluster's name, or the card's text through the room's projection (ADR-0012, ADR-0015). */
+async function sourceOf(
+  ctx: QueryCtx,
+  context: RoomContext,
+  source: TopicRef
+): Promise<ActionSourceRead | undefined> {
+  if (source.kind === "cluster") {
+    const cluster = await ctx.db.get(source.id);
+    return cluster ? { kind: "cluster", id: cluster._id, label: cluster.name } : undefined;
+  }
+  const card = await ctx.db.get(source.id);
+  if (!card) return undefined;
+  const projected = context.policy ? projectCard(context.policy, null, card) : undefined;
+  const label = projected !== undefined && isFullCard(projected) ? projected.text : HIDDEN_CARD_LABEL;
+  return { kind: "card", id: card._id, label };
+}
+
+/**
+ * The one projection every action read goes through: names by reference
+ * (a missing user is the register's former member), the source's label
+ * through the room's own card projection, and the viewer's rights decided
+ * the way the mutations decide them. Rows of a room that is gone
+ * (mid-cascade) drop out.
+ */
+export async function projectActions(
+  ctx: QueryCtx,
+  viewer: Doc<"users">,
+  actions: readonly Doc<"retroActions">[]
+): Promise<ActionsRead> {
+  const users = new Map<Id<"users">, Doc<"users"> | null>();
+  const contexts = new Map<Id<"rooms">, RoomContext | null>();
+  const items: ActionRead[] = [];
+  for (const action of actions) {
+    if (!contexts.has(action.roomId)) {
+      contexts.set(action.roomId, await loadRoomContext(ctx, viewer, action.roomId, users));
+    }
+    const context = contexts.get(action.roomId);
+    if (!context) continue;
+    const [owner, creator] = await Promise.all([
+      action.ownerId !== undefined ? userOf(ctx, users, action.ownerId) : null,
+      userOf(ctx, users, action.createdBy),
+    ]);
+    const own = context.membership !== null && action.ownerId === viewer._id;
+    const source = action.source !== undefined ? await sourceOf(ctx, context, action.source) : undefined;
+    items.push({
+      _id: action._id,
+      roomId: action.roomId,
+      roomName: context.room.name,
+      text: action.text,
+      status: action.status,
+      ...(action.note !== undefined ? { note: action.note } : {}),
+      ...(action.dueAt !== undefined ? { dueAt: action.dueAt } : {}),
+      ...(action.ownerId !== undefined
+        ? { ownerId: action.ownerId, ownerName: owner?.name ?? FORMER_MEMBER }
+        : {}),
+      createdBy: action.createdBy,
+      creatorName: creator?.name ?? FORMER_MEMBER,
+      createdAt: action.createdAt,
+      updatedAt: action.updatedAt,
+      ...(source ? { source } : {}),
+      rights: { edit: own || context.manage, manage: context.manage },
+    });
+  }
+  const rooms: ActionRoomRead[] = [];
+  for (const [roomId, context] of contexts) {
+    if (context) rooms.push({ roomId, name: context.room.name, members: context.members });
+  }
+  return { items, rooms };
+}
+
+const byCreation = (a: Doc<"retroActions">, b: Doc<"retroActions">) => a.createdAt - b.createdAt;
+
+/** This retro's items, every status, oldest first: the actions panel at any stage (spec §13). */
+export async function roomActions(
+  ctx: QueryCtx,
+  viewer: Doc<"users">,
+  roomId: Id<"rooms">
+): Promise<ActionsRead> {
+  const rows = await ctx.db
+    .query("retroActions")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .take(MAX_REVIEW_ROWS);
+  return projectActions(ctx, viewer, rows.sort(byCreation));
+}
+
+/** The Team's open items from the index, a bounded window, oldest first. */
+async function openTeamRows(ctx: QueryCtx, teamId: Id<"teams">): Promise<Doc<"retroActions">[]> {
+  const rows = await ctx.db
+    .query("retroActions")
+    .withIndex("by_team_status", (q) => q.eq("teamId", teamId).eq("status", "open"))
+    .take(MAX_REVIEW_ROWS);
+  return rows.sort(byCreation);
+}
+
+/**
+ * `retro.reviewActions` (spec §13, ADR-0017): the Team's open items whose
+ * home is another retro, oldest first; this retro's own are never in its
+ * review, and a teamless retro has nothing to carry from. The index is
+ * read with a bound and this room filtered out in code.
+ */
+export async function reviewActions(
+  ctx: QueryCtx,
+  viewer: Doc<"users">,
+  room: Doc<"rooms">
+): Promise<ActionsRead> {
+  if (room.teamId === undefined) return { items: [], rooms: [] };
+  const rows = (await openTeamRows(ctx, room.teamId)).filter((row) => row.roomId !== room._id);
+  return projectActions(ctx, viewer, rows);
+}
+
+/** `teams.openActions` (spec §5): every open item across the Team's retros, oldest first. */
+export async function teamOpenActions(
+  ctx: QueryCtx,
+  viewer: Doc<"users">,
+  teamId: Id<"teams">
+): Promise<ActionsRead> {
+  return projectActions(ctx, viewer, await openTeamRows(ctx, teamId));
+}

--- a/convex/model/retroCards.ts
+++ b/convex/model/retroCards.ts
@@ -6,6 +6,7 @@ import { updateRoomActivity } from "./rooms";
 import { requireRetro } from "./retro";
 import { refusal } from "./refusal";
 import { editKeyOpens, hashEditKey, mintEditKey } from "./editKeys";
+import { repointSources } from "./retroActions";
 import {
   CARD_NOT_FOUND,
   CARD_TEXT_REQUIRED,
@@ -213,13 +214,14 @@ export async function moveCards(
   await updateRoomActivity(ctx, args.room);
 }
 
-/** Delete a card: own, or under `cardManagement`. */
+/** Delete a card: own, or under `cardManagement`. An action item that named it loses its source (spec §13). */
 export async function deleteCard(
   ctx: MutationCtx,
   args: { room: Doc<"rooms">; actor: CardActor; clientId: string; editKey?: string }
 ): Promise<void> {
   const card = await requireCard(ctx, args.room._id, args.clientId);
   await cardRights(ctx, args.room, args.actor)(card, args.editKey);
+  await repointSources(ctx, args.room._id, { kind: "card", id: card._id });
   await ctx.db.delete(card._id);
   await updateRoomActivity(ctx, args.room);
 }

--- a/convex/model/retroClusters.ts
+++ b/convex/model/retroClusters.ts
@@ -6,6 +6,7 @@ import { refusal } from "./refusal";
 import { getCardByClientId, type CardActor } from "./retroCards";
 import { MAX_BOARD_ROWS } from "./retro";
 import { dotsOnCluster } from "./retroVotes";
+import { repointSources } from "./retroActions";
 import {
   CARD_NOT_FOUND,
   CLUSTER_NAME_REQUIRED,
@@ -198,6 +199,7 @@ export async function mergeClusters(
     // The merged cluster's dots follow it (spec §10.3).
     ...dots.map((dot) => ctx.db.patch(dot._id, { target: { kind: "cluster" as const, id: into._id } })),
   ]);
+  await repointSources(ctx, args.room._id, { kind: "cluster", id: from._id }, { kind: "cluster", id: into._id });
   await ctx.db.delete(from._id);
   await updateRoomActivity(ctx, args.room);
 }
@@ -224,6 +226,7 @@ export async function dissolveCluster(
     ...members.map((card) => ctx.db.patch(card._id, { clusterId: undefined })),
     ...dots.map((dot) => ctx.db.delete(dot._id)),
   ]);
+  await repointSources(ctx, args.room._id, { kind: "cluster", id: cluster._id });
   await ctx.db.delete(cluster._id);
   await updateRoomActivity(ctx, args.room);
   return { dissolved: true };

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -458,6 +458,8 @@ export async function deleteUserByAuthUserId(
  */
 /** How many dots one account linking re-points; an anonymous account never casts more. */
 const MAX_LINKED_VOTES = 5000;
+/** How many action items of one room a linking walks; a retro never approaches it. */
+const MAX_LINKED_ACTIONS = 500;
 
 export async function linkAnonymousToPermanent(
   ctx: MutationCtx,
@@ -652,6 +654,23 @@ export async function linkAnonymousToPermanent(
         .collect();
       for (const card of cards) {
         await ctx.db.patch(card._id, { authorId: existingPermanent._id });
+      }
+    }
+
+    // Action items name their creator and owner by reference (ADR-0017):
+    // re-point both in every room the account attended, by room like the
+    // cards. An anonymous account's rows are a handful per room.
+    for (const membership of memberships) {
+      const actions = await ctx.db
+        .query("retroActions")
+        .withIndex("by_room", (q) => q.eq("roomId", membership.roomId))
+        .take(MAX_LINKED_ACTIONS);
+      for (const action of actions) {
+        const patch = {
+          ...(action.ownerId === user._id ? { ownerId: existingPermanent._id } : {}),
+          ...(action.createdBy === user._id ? { createdBy: existingPermanent._id } : {}),
+        };
+        if (Object.keys(patch).length > 0) await ctx.db.patch(action._id, patch);
       }
     }
 

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -6,6 +6,7 @@ import * as RetroCards from "./model/retroCards";
 import * as RetroClusters from "./model/retroClusters";
 import * as RetroVotes from "./model/retroVotes";
 import * as RetroWalk from "./model/retroWalk";
+import * as RetroActions from "./model/retroActions";
 import {
   joinPolicyValidator,
   retroFormatValidator,
@@ -475,6 +476,92 @@ export const tally = query({
   handler: async (ctx, args) => {
     const { user } = await requireRoomReader(ctx, args.roomId);
     return await RetroVotes.tally(ctx, { roomId: args.roomId, viewerId: user._id });
+  },
+});
+
+// --- Action items (spec §13, ADR-0017) ---
+
+const actionStatusValidator = v.union(v.literal("open"), v.literal("done"), v.literal("dropped"));
+
+/** Create an action item: attendance is the only guard (never refused, spec §13). Returns its id. */
+export const createAction = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    text: v.string(),
+    ownerId: v.optional(v.id("users")),
+    dueAt: v.optional(v.number()),
+    source: v.optional(topicRefValidator),
+  },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    return await RetroActions.createAction(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Edit text and due date: own, or under `actionManagement`; `dueAt: null` clears the date. */
+export const updateAction = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    actionId: v.id("retroActions"),
+    text: v.optional(v.string()),
+    dueAt: v.optional(v.union(v.number(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroActions.updateAction(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Done, dropped or back to open: own, or under `actionManagement`; the note only on leaving open. */
+export const setActionStatus = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    actionId: v.id("retroActions"),
+    status: actionStatusValidator,
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroActions.setActionStatus(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Assign or unassign (`actionManagement`); omit `ownerId` to leave it unowned. */
+export const assignAction = mutation({
+  args: { roomId: v.id("rooms"), actionId: v.id("retroActions"), ownerId: v.optional(v.id("users")) },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroActions.assignAction(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** Delete an action item (`actionManagement`). */
+export const deleteAction = mutation({
+  args: { roomId: v.id("rooms"), actionId: v.id("retroActions") },
+  handler: async (ctx, args) => {
+    const { roomId, ...rest } = args;
+    await RetroActions.deleteAction(ctx, { ...(await requireCardActor(ctx, roomId)), ...rest });
+  },
+});
+
+/** This retro's action items at any stage (spec §13): room access (ADR-0009). */
+export const actions = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user } = await requireRoomReader(ctx, args.roomId);
+    return await RetroActions.roomActions(ctx, user, args.roomId);
+  },
+});
+
+/**
+ * The carryover (spec §13, ADR-0017): the Team's open action items from
+ * other retros, oldest first; empty for a teamless retro. Room access.
+ */
+export const reviewActions = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user, room } = await requireRoomReader(ctx, args.roomId);
+    return await RetroActions.reviewActions(ctx, user, room);
   },
 });
 

--- a/convex/retroActions.test.ts
+++ b/convex/retroActions.test.ts
@@ -1,0 +1,534 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { DEFAULT_RETRO_PERMISSIONS } from "./permissions";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+import { FORMER_MEMBER, UNOWNED_ACTION } from "./retroCopy";
+import { MAX_REVIEW_ROWS } from "./model/retroActions";
+import * as Users from "./model/users";
+
+// Action items (spec §13, ADR-0017): a short text with at most one named
+// owner, an optional date and an optional source topic, living in exactly
+// one retro and carried over by staying open. Creation is never refused;
+// the owner may always edit, complete, drop or reopen their own; anyone
+// `actionManagement` allows may do so to another's, assign, and delete.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string, accountType?: "anonymous" | "permanent") =>
+  seedNamedUser(t, authUserId, authUserId, accountType);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+/** The refusal's code, or undefined for a plain error. */
+async function codeOf(p: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await p;
+    return "resolved";
+  } catch (error) {
+    return error instanceof ConvexError ? (error.data as { code: string }).code : undefined;
+  }
+}
+
+const createRetro = (t: T, subject: string, args: { teamId?: Id<"teams">; name?: string } = {}) =>
+  as(t, subject).mutation(api.retro.create, {
+    name: args.name ?? "R",
+    formatName: DEFAULT_RETRO_FORMAT.name,
+    ...(args.teamId ? { teamId: args.teamId } : {}),
+  });
+
+const joinRoom = (t: T, roomId: Id<"rooms">, subject: string) =>
+  as(t, subject).mutation(api.users.join, { roomId, name: subject, authUserId: subject });
+
+/**
+ * A teamless retro at `collect` with an owner and a guest (anonymous) who
+ * attends, and the stage ids by kind.
+ */
+async function seedRetro(t: T) {
+  const ownerId = await seedUser(t, "owner");
+  const guestId = await seedUser(t, "guest", "anonymous");
+  const roomId = await createRetro(t, "owner");
+  await joinRoom(t, roomId, "guest");
+  const retro = await retroRow(t, roomId);
+  const byKind = (kind: string) => retro.stages.find((s) => s.kind === kind)!;
+  const advance = (kind: string) =>
+    as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: byKind(kind).id });
+  const create = (who: string, text = "Do the thing", extra: Record<string, unknown> = {}) =>
+    as(t, who).mutation(api.retro.createAction, { roomId, text, ...extra });
+  return { roomId, ownerId, guestId, retro, byKind, advance, create };
+}
+
+/** A Team with an admin and a member, both permanent accounts. */
+async function seedTeam(t: T) {
+  const adminId = await seedUser(t, "admin", "permanent");
+  const memberId = await seedUser(t, "member", "permanent");
+  const teamId = await as(t, "admin").mutation(api.teams.create, { name: "Acme" });
+  const team = (await t.run((ctx) => ctx.db.get(teamId)))!;
+  await as(t, "member").mutation(api.teams.joinByInvite, { inviteToken: team.inviteToken });
+  return { teamId, adminId, memberId };
+}
+
+const row = (t: T, id: Id<"retroActions">) => t.run((ctx) => ctx.db.get(id));
+
+describe("creating an action item (spec §13)", () => {
+  it("any attendee creates one in every stage, unowned, open, named by its creator", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, guestId, retro, advance, create } = await seedRetro(t);
+
+    for (const stage of retro.stages) {
+      await advance(stage.kind);
+      const id = await create("guest", `In ${stage.kind}`);
+      const action = (await row(t, id))!;
+      expect(action).toMatchObject({
+        roomId,
+        text: `In ${stage.kind}`,
+        status: "open",
+        createdBy: guestId,
+      });
+      expect(action.ownerId).toBeUndefined();
+      expect(action.teamId).toBeUndefined();
+      expect(action.note).toBeUndefined();
+      expect(action.externalRef).toBeUndefined();
+      expect(action.createdAt).toBe(action.updatedAt);
+    }
+  });
+});
+
+describe("ownership (spec §13)", () => {
+  it("an owner must attend the retro, anonymous accounts included; a stranger cannot own", async () => {
+    const t = convexTest(schema, modules);
+    const { guestId, create } = await seedRetro(t);
+    const strangerId = await seedUser(t, "stranger");
+
+    const id = await create("owner", "Owned", { ownerId: guestId });
+    expect((await row(t, id))!.ownerId).toBe(guestId);
+
+    expect(await codeOf(create("owner", "Stray", { ownerId: strangerId }))).toBe("forbidden");
+  });
+
+  it("assign and unassign are actionManagement acts with no accept step", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, ownerId, guestId, create } = await seedRetro(t);
+    const id = await create("owner");
+
+    // Default `everyone`: the guest hands it to the owner, then to nobody.
+    await as(t, "guest").mutation(api.retro.assignAction, { roomId, actionId: id, ownerId });
+    expect((await row(t, id))!.ownerId).toBe(ownerId);
+    await as(t, "guest").mutation(api.retro.assignAction, { roomId, actionId: id });
+    expect((await row(t, id))!.ownerId).toBeUndefined();
+
+    // Under `facilitators`, a participant cannot assign, not even to themself.
+    await t.run((ctx) =>
+      ctx.db.patch(roomId, { permissions: { ...DEFAULT_RETRO_PERMISSIONS, actionManagement: "facilitators" } })
+    );
+    expect(
+      await codeOf(as(t, "guest").mutation(api.retro.assignAction, { roomId, actionId: id, ownerId: guestId }))
+    ).toBe("forbidden");
+    await as(t, "owner").mutation(api.retro.assignAction, { roomId, actionId: id, ownerId: guestId });
+    expect((await row(t, id))!.ownerId).toBe(guestId);
+  });
+});
+
+describe("actionManagement versus owner rights (spec §4.2, §13)", () => {
+  async function seedFacilitatorsOnly(t: T) {
+    const seeded = await seedRetro(t);
+    await t.run((ctx) =>
+      ctx.db.patch(seeded.roomId, {
+        permissions: { ...DEFAULT_RETRO_PERMISSIONS, actionManagement: "facilitators" },
+      })
+    );
+    return seeded;
+  }
+
+  it("the owner may always edit, complete, drop and reopen their own item", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, guestId, create } = await seedFacilitatorsOnly(t);
+    const id = await create("owner", "Mine", { ownerId: guestId });
+    const me = as(t, "guest");
+
+    await me.mutation(api.retro.updateAction, { roomId, actionId: id, text: "Edited", dueAt: 5 });
+    expect((await row(t, id))!).toMatchObject({ text: "Edited", dueAt: 5 });
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "done" });
+    expect((await row(t, id))!.status).toBe("done");
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "open" });
+    expect((await row(t, id))!.status).toBe("open");
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "dropped" });
+    expect((await row(t, id))!.status).toBe("dropped");
+  });
+
+  it("a participant without the category cannot edit, change or delete another's item, nor delete their own", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, guestId, create } = await seedFacilitatorsOnly(t);
+    const theirs = await create("owner", "Theirs");
+    const mine = await create("owner", "Mine", { ownerId: guestId });
+    const me = as(t, "guest");
+
+    expect(await codeOf(me.mutation(api.retro.updateAction, { roomId, actionId: theirs, text: "x" }))).toBe("forbidden");
+    expect(await codeOf(me.mutation(api.retro.setActionStatus, { roomId, actionId: theirs, status: "done" }))).toBe("forbidden");
+    expect(await codeOf(me.mutation(api.retro.deleteAction, { roomId, actionId: theirs }))).toBe("forbidden");
+    // Delete is a separate `actionManagement` act, even on one's own (ADR-0017).
+    expect(await codeOf(me.mutation(api.retro.deleteAction, { roomId, actionId: mine }))).toBe("forbidden");
+    expect(await row(t, mine)).not.toBeNull();
+
+    // The facilitator-level owner may do all of it.
+    await as(t, "owner").mutation(api.retro.setActionStatus, { roomId, actionId: mine, status: "done" });
+    await as(t, "owner").mutation(api.retro.deleteAction, { roomId, actionId: theirs });
+    expect(await row(t, theirs)).toBeNull();
+  });
+
+  it("an unknown or foreign action is missing; a non-member is refused", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, create } = await seedRetro(t);
+    const id = await create("owner");
+    const otherRoom = await createRetro(t, "owner", { name: "Other" });
+    await seedUser(t, "stranger");
+
+    expect(await codeOf(as(t, "owner").mutation(api.retro.deleteAction, { roomId: otherRoom, actionId: id }))).toBe("missing");
+    await expect(as(t, "stranger").mutation(api.retro.createAction, { roomId, text: "x" })).rejects.toThrow();
+  });
+});
+
+describe("the three states and the note (spec §13)", () => {
+  it("open → done | dropped → open, all reversible; the note is written only on leaving open and cleared on reopening", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, create } = await seedRetro(t);
+    const id = await create("owner");
+    const me = as(t, "owner");
+
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "done", note: "Shipped it" });
+    expect((await row(t, id))!).toMatchObject({ status: "done", note: "Shipped it" });
+    // Done to dropped is not leaving open: no note may ride along, the old one stays.
+    expect(
+      await codeOf(me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "dropped", note: "meh" }))
+    ).toBe("forbidden");
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "dropped" });
+    expect((await row(t, id))!).toMatchObject({ status: "dropped", note: "Shipped it" });
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "open" });
+    expect((await row(t, id))!.status).toBe("open");
+    expect((await row(t, id))!.note).toBeUndefined();
+    expect(
+      await codeOf(me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "open", note: "x" }))
+    ).toBe("forbidden");
+    await me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "dropped", note: "Not worth it" });
+    expect((await row(t, id))!).toMatchObject({ status: "dropped", note: "Not worth it" });
+  });
+
+  it("text is trimmed, required and bounded; a source must be a live topic of the room", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, retro, create } = await seedRetro(t);
+    expect(await codeOf(create("owner", "   "))).toBe("forbidden");
+    expect(await codeOf(create("owner", "x".repeat(501)))).toBe("forbidden");
+    const id = await create("owner", "  padded  ");
+    expect((await row(t, id))!.text).toBe("padded");
+
+    const { cardId } = await as(t, "owner").mutation(api.retro.createCard, {
+      roomId,
+      clientId: "c1",
+      text: "A card",
+      promptId: retro.format.prompts[0].id,
+      position: { x: 0, y: 0 },
+    });
+    const sourced = await create("owner", "From the card", { source: { kind: "card", id: cardId } });
+    expect((await row(t, sourced))!.source).toEqual({ kind: "card", id: cardId });
+    await as(t, "owner").mutation(api.retro.deleteCard, { roomId, clientId: "c1" });
+    expect(await codeOf(create("owner", "Gone", { source: { kind: "card", id: cardId } }))).toBe("missing");
+  });
+});
+
+describe("the retro's actions read (spec §13): creator and owner named in both attribution modes", () => {
+  it("an anonymous retro still names creator and owner, a source card renders its text and never an author", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, ownerId, guestId, retro, create } = await seedRetro(t);
+    await as(t, "owner").mutation(api.retro.ratchet, { roomId });
+    const { cardId } = await as(t, "guest").mutation(api.retro.createCard, {
+      roomId,
+      clientId: "c1",
+      text: "The flaky build",
+      promptId: retro.format.prompts[0].id,
+      position: { x: 0, y: 0 },
+    });
+    // Leaving collect for a visible entry reveals the card (spec §8.3).
+    await as(t, "owner").mutation(api.retro.advance, { roomId, toStageId: retro.stages[1].id });
+    const id = await create("guest", "Fix the build", { ownerId, source: { kind: "card", id: cardId } });
+
+    const read = await as(t, "owner").query(api.retro.actions, { roomId });
+    expect(read.items).toHaveLength(1);
+    expect(read.items[0]).toMatchObject({
+      _id: id,
+      text: "Fix the build",
+      status: "open",
+      creatorName: "guest",
+      ownerId,
+      ownerName: "owner",
+      source: { kind: "card", id: cardId, label: "The flaky build" },
+      rights: { edit: true, manage: true },
+    });
+    expect(JSON.stringify(read.items[0].source)).not.toContain(String(guestId));
+    // The reassign picker's roster: every attendee, anonymous included.
+    expect(read.rooms).toEqual([
+      expect.objectContaining({
+        roomId,
+        name: "R",
+        members: expect.arrayContaining([
+          { userId: ownerId, name: "owner" },
+          { userId: guestId, name: "guest" },
+        ]),
+      }),
+    ]);
+  });
+
+  it("a missing owner or creator reads as the register's former member; unowned carries no name", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, guestId, create } = await seedRetro(t);
+    const owned = await create("guest", "Owned", { ownerId: guestId });
+    const unowned = await create("owner", "Unowned");
+    await t.run((ctx) => ctx.db.delete(guestId));
+
+    const read = await as(t, "owner").query(api.retro.actions, { roomId });
+    const byId = new Map(read.items.map((item) => [item._id, item]));
+    expect(byId.get(owned)).toMatchObject({ ownerName: FORMER_MEMBER, creatorName: FORMER_MEMBER });
+    expect(byId.get(unowned)!.ownerId).toBeUndefined();
+    expect(byId.get(unowned)!.ownerName).toBeUndefined();
+    expect(UNOWNED_ACTION).toBe("Nobody owns this yet");
+  });
+
+  it("rights follow the viewer: own or the category to edit, the category to manage, neither for a Team reader", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    await seedUser(t, "reader", "permanent");
+    const team = (await t.run((ctx) => ctx.db.get(teamId)))!;
+    await as(t, "reader").mutation(api.teams.joinByInvite, { inviteToken: team.inviteToken });
+    const roomId = await createRetro(t, "admin", { teamId });
+    await seedUser(t, "guest", "anonymous");
+    await joinRoom(t, roomId, "guest");
+    await joinRoom(t, roomId, "member");
+    await t.run((ctx) =>
+      ctx.db.patch(roomId, { permissions: { ...DEFAULT_RETRO_PERMISSIONS, actionManagement: "facilitators" } })
+    );
+    await as(t, "guest").mutation(api.retro.createAction, { roomId, text: "Mine", ownerId: memberId });
+    await as(t, "guest").mutation(api.retro.createAction, { roomId, text: "Theirs" });
+
+    const rightsFor = async (who: string) =>
+      Object.fromEntries(
+        (await as(t, who).query(api.retro.actions, { roomId })).items.map((i) => [i.text, i.rights])
+      );
+    expect(await rightsFor("admin")).toEqual({
+      Mine: { edit: true, manage: true },
+      Theirs: { edit: true, manage: true },
+    });
+    expect(await rightsFor("guest")).toEqual({
+      Mine: { edit: false, manage: false },
+      Theirs: { edit: false, manage: false },
+    });
+    expect(await rightsFor("member")).toEqual({
+      Mine: { edit: true, manage: false },
+      Theirs: { edit: false, manage: false },
+    });
+    // A Team member who never attended reads through the Team (ADR-0009) and acts on nothing.
+    expect(await rightsFor("reader")).toEqual({
+      Mine: { edit: false, manage: false },
+      Theirs: { edit: false, manage: false },
+    });
+  });
+});
+
+describe("carryover: retro.reviewActions (spec §13, ADR-0017)", () => {
+  /** A Team with two earlier retros and the retro under review, all by the admin. */
+  async function seedHistory(t: T) {
+    const { teamId, adminId, memberId } = await seedTeam(t);
+    const first = await createRetro(t, "admin", { teamId, name: "First" });
+    const second = await createRetro(t, "admin", { teamId, name: "Second" });
+    const current = await createRetro(t, "admin", { teamId, name: "Current" });
+    const at = async (roomId: Id<"rooms">, text: string, createdAt: number, status: "open" | "done" | "dropped" = "open") => {
+      const id = await as(t, "admin").mutation(api.retro.createAction, { roomId, text });
+      await t.run((ctx) => ctx.db.patch(id, { createdAt, status }));
+      return id;
+    };
+    return { teamId, adminId, memberId, first, second, current, at };
+  }
+
+  it("returns the Team's open items from other retros only, oldest first, with their retro's name", async () => {
+    const t = convexTest(schema, modules);
+    const { first, second, current, at } = await seedHistory(t);
+    await at(second, "second-late", 3_000);
+    await at(first, "first-early", 1_000);
+    await at(first, "first-done", 500, "done");
+    await at(second, "second-dropped", 600, "dropped");
+    await at(current, "own-open", 100);
+    await at(first, "first-mid", 2_000);
+
+    const read = await as(t, "admin").query(api.retro.reviewActions, { roomId: current });
+    expect(read.items.map((item) => [item.text, item.roomName])).toEqual([
+      ["first-early", "First"],
+      ["first-mid", "First"],
+      ["second-late", "Second"],
+    ]);
+    expect(read.rooms.map((room) => room.name).sort()).toEqual(["First", "Second"]);
+  });
+
+  it("is empty for a teamless retro", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, create } = await seedRetro(t);
+    await create("owner", "Own");
+    const read = await as(t, "owner").query(api.retro.reviewActions, { roomId });
+    expect(read.items).toEqual([]);
+    expect(read.rooms).toEqual([]);
+  });
+
+  it("is a Team reader's read too, and a stranger's refusal", async () => {
+    const t = convexTest(schema, modules);
+    const { first, current, at } = await seedHistory(t);
+    await at(first, "carry", 1_000);
+    await seedUser(t, "stranger", "permanent");
+
+    const read = await as(t, "member").query(api.retro.reviewActions, { roomId: current });
+    expect(read.items.map((item) => item.text)).toEqual(["carry"]);
+    await expect(as(t, "stranger").query(api.retro.reviewActions, { roomId: current })).rejects.toThrow();
+  });
+
+  it("reads a bounded window of the team index", async () => {
+    const t = convexTest(schema, modules);
+    const { first, current, at } = await seedHistory(t);
+    for (let i = 0; i < MAX_REVIEW_ROWS + 5; i++) await at(first, `a${i}`, i);
+    const read = await as(t, "admin").query(api.retro.reviewActions, { roomId: current });
+    expect(read.items.length).toBeLessThanOrEqual(MAX_REVIEW_ROWS);
+  });
+
+  it("an action written before its retro was adopted into the Team reaches review and the team list afterwards", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, first } = await seedHistory(t);
+    const teamless = await createRetro(t, "admin", { name: "Loose" });
+    const id = await as(t, "admin").mutation(api.retro.createAction, { roomId: teamless, text: "Early" });
+    expect((await as(t, "admin").query(api.retro.reviewActions, { roomId: first })).items).toEqual([]);
+
+    await as(t, "admin").mutation(api.retro.adoptIntoTeam, { roomId: teamless, teamId });
+
+    expect((await as(t, "admin").query(api.retro.reviewActions, { roomId: first })).items.map((i) => i._id)).toEqual([id]);
+    expect((await as(t, "admin").query(api.teams.openActions, { teamId })).items.map((i) => i._id)).toEqual([id]);
+  });
+});
+
+describe("the team page's open-actions list: teams.openActions (spec §5)", () => {
+  it("lists every open item across the Team's retros, oldest first, members only", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    const a = await createRetro(t, "admin", { teamId, name: "A" });
+    const b = await createRetro(t, "member", { teamId, name: "B" });
+    const late = await as(t, "member").mutation(api.retro.createAction, { roomId: b, text: "late", ownerId: memberId });
+    const early = await as(t, "admin").mutation(api.retro.createAction, { roomId: a, text: "early" });
+    await t.run((ctx) => ctx.db.patch(early, { createdAt: 1 }));
+    const done = await as(t, "admin").mutation(api.retro.createAction, { roomId: a, text: "done" });
+    await as(t, "admin").mutation(api.retro.setActionStatus, { roomId: a, actionId: done, status: "done" });
+    await seedUser(t, "stranger", "permanent");
+
+    const read = await as(t, "member").query(api.teams.openActions, { teamId });
+    expect(read.items.map((item) => [item._id, item.roomName, item.rights])).toEqual([
+      [early, "A", { edit: false, manage: false }],
+      [late, "B", { edit: true, manage: true }],
+    ]);
+    await expect(as(t, "stranger").query(api.teams.openActions, { teamId })).rejects.toThrow();
+  });
+});
+
+describe("the source link's life (spec §10.3, §13)", () => {
+  async function seedTopics(t: T) {
+    const seeded = await seedRetro(t);
+    const { roomId, retro } = seeded;
+    const write = async (clientId: string) =>
+      (
+        await as(t, "owner").mutation(api.retro.createCard, {
+          roomId,
+          clientId,
+          text: clientId,
+          promptId: retro.format.prompts[0].id,
+          position: { x: 0, y: 0 },
+        })
+      ).cardId;
+    return { ...seeded, write };
+  }
+
+  it("dissolving a cluster nulls matching sources and leaves the rest", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, write, create } = await seedTopics(t);
+    const c1 = await write("c1");
+    await write("c2");
+    const k = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["c1", "c2"] });
+    const onCluster = await create("owner", "On the cluster", { source: { kind: "cluster", id: k } });
+    const onCard = await create("owner", "On the card", { source: { kind: "card", id: c1 } });
+
+    await as(t, "owner").mutation(api.retro.dissolveCluster, { roomId, clusterId: k });
+
+    expect((await row(t, onCluster))!.source).toBeUndefined();
+    expect((await row(t, onCard))!.source).toEqual({ kind: "card", id: c1 });
+  });
+
+  it("merging re-points sources to the surviving cluster", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, write, create } = await seedTopics(t);
+    await write("c1");
+    await write("c2");
+    const from = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["c1"] });
+    const into = await as(t, "owner").mutation(api.retro.formCluster, { roomId, clientIds: ["c2"] });
+    const id = await create("owner", "Merged", { source: { kind: "cluster", id: from } });
+
+    await as(t, "owner").mutation(api.retro.mergeClusters, { roomId, from, into });
+
+    expect((await row(t, id))!.source).toEqual({ kind: "cluster", id: into });
+  });
+
+  it("deleting a card nulls its source", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, write, create } = await seedTopics(t);
+    const c1 = await write("c1");
+    const id = await create("owner", "On the card", { source: { kind: "card", id: c1 } });
+
+    await as(t, "owner").mutation(api.retro.deleteCard, { roomId, clientId: "c1" });
+
+    expect((await row(t, id))!.source).toBeUndefined();
+  });
+});
+
+describe("the cascade and account linking (spec §13, §15.2)", () => {
+  it("an action dies with its room, and the delete confirmation counts the open ones", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, create } = await seedRetro(t);
+    const open = await create("owner", "open");
+    const done = await create("owner", "done");
+    await as(t, "owner").mutation(api.retro.setActionStatus, { roomId, actionId: done, status: "done" });
+    expect(await as(t, "owner").query(api.retro.deleteCounts, { roomId })).toEqual({ cards: 0, openActions: 1 });
+
+    await as(t, "owner").mutation(api.retro.remove, { roomId });
+    await t.finishAllScheduledFunctions(() => {});
+
+    expect(await row(t, open)).toBeNull();
+    expect(await row(t, done)).toBeNull();
+  });
+
+  it("linking an anonymous account to a permanent one re-points ownerId and createdBy", async () => {
+    const t = convexTest(schema, modules);
+    const { guestId, create } = await seedRetro(t);
+    const mine = await create("guest", "Mine", { ownerId: guestId });
+    const theirs = await create("owner", "Theirs", { ownerId: guestId });
+    const permanentId = await seedUser(t, "perm", "permanent");
+
+    await t.run((ctx) =>
+      Users.linkAnonymousToPermanent(ctx, { oldAuthUserId: "guest", newAuthUserId: "perm", email: "p@example.com" })
+    );
+
+    expect((await row(t, mine))!).toMatchObject({ ownerId: permanentId, createdBy: permanentId });
+    expect((await row(t, theirs))!.ownerId).toBe(permanentId);
+  });
+});

--- a/convex/retroActions.test.ts
+++ b/convex/retroActions.test.ts
@@ -9,7 +9,7 @@ import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
 import { DEFAULT_RETRO_PERMISSIONS } from "./permissions";
 import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
 import { FORMER_MEMBER, UNOWNED_ACTION } from "./retroCopy";
-import { MAX_REVIEW_ROWS } from "./model/retroActions";
+import { MAX_ACTION_ROWS } from "./model/retroActions";
 import * as Users from "./model/users";
 
 // Action items (spec §13, ADR-0017): a short text with at most one named
@@ -343,6 +343,23 @@ describe("the retro's actions read (spec §13): creator and owner named in both 
       Theirs: { edit: false, manage: false },
     });
   });
+
+  it("the read carries the retro's roster and whether the viewer attends, even before its first item", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, memberId } = await seedTeam(t);
+    const roomId = await createRetro(t, "admin", { teamId });
+    // The first item of a retro must be ownable (spec §13): the roster is there with nothing to list.
+    const empty = await as(t, "admin").query(api.retro.actions, { roomId });
+    expect(empty.items).toEqual([]);
+    expect(empty.rooms.map((room) => ({ roomId: room.roomId, attending: room.attending }))).toEqual([
+      { roomId, attending: true },
+    ]);
+    expect(empty.rooms[0].members.map((m) => m.name)).toEqual(["admin"]);
+    // A Team member who never attended reads the same roster and is told so.
+    const reader = await as(t, "member").query(api.retro.actions, { roomId });
+    expect(reader.rooms[0].attending).toBe(false);
+    expect(reader.rooms[0].members.some((m) => m.userId === memberId)).toBe(false);
+  });
 });
 
 describe("carryover: retro.reviewActions (spec §13, ADR-0017)", () => {
@@ -402,9 +419,9 @@ describe("carryover: retro.reviewActions (spec §13, ADR-0017)", () => {
   it("reads a bounded window of the team index", async () => {
     const t = convexTest(schema, modules);
     const { first, current, at } = await seedHistory(t);
-    for (let i = 0; i < MAX_REVIEW_ROWS + 5; i++) await at(first, `a${i}`, i);
+    for (let i = 0; i < MAX_ACTION_ROWS + 5; i++) await at(first, `a${i}`, i);
     const read = await as(t, "admin").query(api.retro.reviewActions, { roomId: current });
-    expect(read.items.length).toBeLessThanOrEqual(MAX_REVIEW_ROWS);
+    expect(read.items.length).toBeLessThanOrEqual(MAX_ACTION_ROWS);
   });
 
   it("an action written before its retro was adopted into the Team reaches review and the team list afterwards", async () => {

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -92,20 +92,18 @@ export const STAGE_LABELS: Record<
 
 export const STAGE_PILL_LABEL = "Stage";
 
+/** The stages whose empty state is about cards; `review` and `close` speak through their panels (spec §13). */
+export type CardStageKind = "collect" | "group" | "vote" | "discuss";
 /**
- * Each kind's empty state (ADR-0010): entering a stage with nothing in it
- * renders an explanation, never a lock.
+ * Each card stage's empty state (ADR-0010): entering a stage with nothing
+ * in it renders an explanation, never a lock. The review's and the close's
+ * lines are `REVIEW_EMPTY` and `ACTIONS_EMPTY`.
  */
-export const STAGE_EMPTY: Record<
-  "collect" | "review" | "group" | "vote" | "discuss" | "close",
-  string
-> = {
+export const STAGE_EMPTY: Record<CardStageKind, string> = {
   collect: "No cards yet. Every prompt has a zone; write into any of them.",
-  review: "No open actions from earlier retros",
   group: "Nothing to group yet. Cards written in Collect show up here.",
   vote: "Nothing to vote on yet. Cards and groups show up here once written.",
   discuss: "Nothing to discuss yet. Topics show up here once cards are written.",
-  close: "No action items yet.",
 };
 export const TIMEBOX_OVER = "Timebox over";
 
@@ -395,10 +393,12 @@ export const ACTION_DONE = "Done";
 export const ACTION_DROP = "Drop";
 export const ACTION_REOPEN = "Reopen";
 export const ACTION_DELETE = "Delete action";
-/** Unowned action (spec §19). */
+export const ACTION_DELETE_TITLE = "Delete this action item?";
+export const ACTION_DELETE_CONFIRM = "Delete";
+/** The composer's source line: drop the topic, keep the text. */
+export const CLEAR_SOURCE = "Clear source";
+/** Unowned action (spec §19): the rendered state, and the owner picker's empty choice. */
 export const UNOWNED_ACTION = "Nobody owns this yet";
-/** The owner picker's empty choice. */
-export const NO_OWNER_OPTION = UNOWNED_ACTION;
 /** Overdue: `dueAt` past and still `open` — a rendering state, not a status. */
 export const OVERDUE = "Overdue";
 export const ACTION_STATUS_LABELS: Record<"open" | "done" | "dropped", string> = {

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -377,3 +377,57 @@ export const CURRENT_TOPIC = "Now";
 /** The late marker on a card (spec §12.3), at every zoom level. */
 export const LATE_CARD_MARKER = "New";
 export const WALK_ACT_FAILED = "That did not go through. Try again.";
+
+// --- Action items (spec §13, §19; ADR-0017) ---
+
+export const ACTIONS_TITLE = "Action items";
+export const ADD_ACTION = "Add action";
+export const ACTION_TEXT_LABEL = "Action";
+export const ACTION_TEXT_PLACEHOLDER = "What will be done";
+export const ACTION_OWNER_LABEL = "Owner";
+export const ACTION_DUE_LABEL = "Due";
+export const ACTION_NOTE_LABEL = "Note";
+export const ACTION_NOTE_PLACEHOLDER = "Why, in a sentence (optional)";
+export const ACTION_SUBMIT = "Add";
+export const ACTION_SAVE = "Save";
+export const ACTION_EDIT = "Edit";
+export const ACTION_DONE = "Done";
+export const ACTION_DROP = "Drop";
+export const ACTION_REOPEN = "Reopen";
+export const ACTION_DELETE = "Delete action";
+/** Unowned action (spec §19). */
+export const UNOWNED_ACTION = "Nobody owns this yet";
+/** The owner picker's empty choice. */
+export const NO_OWNER_OPTION = UNOWNED_ACTION;
+/** Overdue: `dueAt` past and still `open` — a rendering state, not a status. */
+export const OVERDUE = "Overdue";
+export const ACTION_STATUS_LABELS: Record<"open" | "done" | "dropped", string> = {
+  open: "Open",
+  done: "Done",
+  dropped: "Dropped",
+};
+/** Close panel facts (spec §19): never a judgement about the count. */
+export const closeFacts = (n: number, unowned: number) =>
+  `${n} ${n === 1 ? "action" : "actions"}, ${unowned} unowned`;
+/** Review empty state (spec §19). */
+export const REVIEW_EMPTY = "No open actions from earlier retros";
+export const ACTIONS_EMPTY = "No action items yet.";
+export const ownedBy = (name: string) => `Owner: ${name}`;
+export const dueOn = (date: string) => `Due ${date}`;
+export const fromRetro = (name: string) => `From ${name}`;
+export const ACTION_SOURCE_LABEL = "About";
+export const OPEN_ACTIONS_TITLE = "Open action items";
+export const OPEN_ACTIONS_EMPTY = "No open action items across this team's retros.";
+/** A team member who never attended the item's retro reads it and cannot act (ADR-0008). */
+export const NOT_ATTENDING = "Join that retro to act on its action items";
+
+/** Refusal `missing`: an action act naming a row the room does not carry. */
+export const ACTION_NOT_FOUND = "That action item is no longer here";
+export const ACTION_TEXT_REQUIRED = "An action item needs some text";
+export const ACTION_TEXT_TOO_LONG = "An action item holds at most 500 characters";
+export const ACTION_NOTE_TOO_LONG = "A note holds at most 500 characters";
+/** Refusal `forbidden`: an owner who is not a member of the retro. */
+export const OWNER_NOT_MEMBER = "Only someone in this retro can own an action item";
+/** Refusal `forbidden`: a note on a change that does not leave `open`. */
+export const NOTE_ONLY_ON_LEAVING_OPEN = "A note goes with marking an action done or dropped";
+export const ACTION_ACT_FAILED = "That did not go through. Try again.";

--- a/convex/roomActivity.test.ts
+++ b/convex/roomActivity.test.ts
@@ -620,6 +620,27 @@ describe("room activity — the Team's side of a retro bumps (spec §14)", () =>
     }
   });
 
+  it("every action item mutation bumps (spec §14), the team page's completion included", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, memberId } = await seedTeamRetro(t, true);
+    const me = as(t, "auth-member");
+    let id: Id<"retroActions">;
+    const acts = [
+      async () => void (id = await me.mutation(api.retro.createAction, { roomId, text: "Do it" })),
+      () => me.mutation(api.retro.updateAction, { roomId, actionId: id, text: "Do it well", dueAt: 1 }),
+      () => me.mutation(api.retro.assignAction, { roomId, actionId: id, ownerId: memberId }),
+      () => me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "done", note: "ok" }),
+      () => me.mutation(api.retro.setActionStatus, { roomId, actionId: id, status: "open" }),
+      () => me.mutation(api.retro.deleteAction, { roomId, actionId: id }),
+    ];
+    for (const act of acts) {
+      const stale = Date.now() - HOUR - 60_000;
+      await t.run((ctx) => ctx.db.patch(roomId, { lastActivityAt: stale }));
+      await act();
+      await expectBumped(t, roomId, stale);
+    }
+  });
+
   it("every cluster mutation bumps (spec §14)", async () => {
     const t = convexTest(schema, modules);
     const { roomId } = await seedTeamRetro(t, false);

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import * as Teams from "./model/teams";
+import * as RetroActions from "./model/retroActions";
 import { retroDefaultsValidator } from "./schema";
 import { getOptionalAuthUser, requireAuthUser, requireTeamRole } from "./model/auth";
 
@@ -131,5 +132,14 @@ export const listMine = query({
     const user = await getOptionalAuthUser(ctx);
     if (!user) return [];
     return await Teams.listTeamsForUser(ctx, user._id);
+  },
+});
+
+/** The team page's open action items across its retros, oldest first (members only, spec §5). */
+export const openActions = query({
+  args: { teamId: v.id("teams") },
+  handler: async (ctx, args) => {
+    const { user } = await requireTeamRole(ctx, args.teamId, "member");
+    return await RetroActions.teamOpenActions(ctx, user, args.teamId);
   },
 });

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -15,6 +15,8 @@ import { useCardActions } from "@/components/retro/use-card-actions";
 import { useClusterActions } from "@/components/retro/use-cluster-actions";
 import { useDotActions } from "@/components/retro/use-dot-actions";
 import { useWalkActions } from "@/components/retro/use-walk-actions";
+import { useActionActions } from "@/components/retro/use-action-actions";
+import type { ActionsRead } from "@/convex/model/retroActions";
 import type { TallyRead } from "@/convex/model/retroVotes";
 import { useEditKeys, type EditKeyStore } from "@/components/retro/use-edit-keys";
 import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
@@ -82,6 +84,12 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const tallyKind = board ? currentStageOf(board.retro).kind : undefined;
   const tallyMounted = canRead && (tallyKind === "vote" || tallyKind === "discuss");
   const tally = useQuery(api.retro.tally, tallyMounted ? { roomId } : "skip");
+  // The actions panel is reachable at every stage (spec §13), so its read
+  // rides with the board; the carryover is read only when the stage list
+  // carries a `review` entry, which a teamless retro drops at creation.
+  const actions = useQuery(api.retro.actions, canRead ? { roomId } : "skip");
+  const hasReview = board?.retro.stages.some((stage) => stage.kind === "review") ?? false;
+  const review = useQuery(api.retro.reviewActions, canRead && hasReview ? { roomId } : "skip");
   // A re-keyed subscription answers a beat later; hold the last answer so
   // the viewer's own cards never flash to silhouettes in between.
   const [settledMine, setSettledMine] = useState(mine);
@@ -132,6 +140,8 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
         team={team}
         tally={tally}
         walk={board.walk}
+        actions={actions}
+        review={review}
         banner={
           <div
             data-testid="team-reader-banner"
@@ -160,6 +170,8 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
       myTeams={(myTeams ?? []) as MyTeam[]}
       editKeys={editKeys}
       tally={tally}
+      actions={actions}
+      review={review}
     />
   );
 }
@@ -174,6 +186,8 @@ interface AttendeeBoardProps {
   myTeams: MyTeam[];
   editKeys: EditKeyStore;
   tally?: TallyRead;
+  actions?: ActionsRead;
+  review?: ActionsRead;
 }
 
 /**
@@ -183,7 +197,7 @@ interface AttendeeBoardProps {
  * wiring. Its own component so the presence hook — which has no skip —
  * mounts only once a membership exists; a Team reader never heartbeats.
  */
-function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, editKeys, tally }: AttendeeBoardProps) {
+function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, editKeys, tally, actions, review }: AttendeeBoardProps) {
   const { retro } = board;
   const users = useRoomPresence(roomId, userId, roomData.users);
   const setRetroPresence = useSingleFlightMutation(
@@ -202,6 +216,7 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
   const clusterActions = useClusterActions(roomId);
   const dotActions = useDotActions(roomId, tally);
   const walkActions = useWalkActions(roomId);
+  const actionItems = useActionActions();
   const currentStageId = currentStageOf(retro).id;
   // The payload is written whole, so an editing write carries readiness
   // too: the viewer's last toggle for this entry, else what their presence
@@ -255,9 +270,10 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       clusters: clusterActions,
       dots: dotActions,
       walk: walkActions,
+      actionItems,
       cardManagement,
     }),
-    [userId, me?.name, writePresence, controls, cardActions, clusterActions, dotActions, walkActions, cardManagement]
+    [userId, me?.name, writePresence, controls, cardActions, clusterActions, dotActions, walkActions, actionItems, cardManagement]
   );
 
   const role = roomData.users.find((u) => u._id === userId)?.role ?? "participant";
@@ -273,6 +289,8 @@ function AttendeeBoard({ roomId, roomData, board, cards, team, userId, myTeams, 
       viewer={viewer}
       tally={tally}
       walk={board.walk}
+      actions={actions}
+      review={review}
       menu={
         <RetroMenu
           roomId={roomId}

--- a/src/app/team/[teamId]/team-content.test.tsx
+++ b/src/app/team/[teamId]/team-content.test.tsx
@@ -28,6 +28,7 @@ type Team = {
 const mocks = vi.hoisted(() => ({
   team: undefined as Team | undefined,
   retros: [] as unknown[] | undefined,
+  openActions: { items: [], rooms: [] } as { items: unknown[]; rooms: unknown[] } | undefined,
   calls: [] as { fn: string; args: unknown }[],
   fail: {} as Record<string, string>,
   push: vi.fn(),
@@ -37,8 +38,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock("convex/react", async () => {
   const { getFunctionName } = await import("convex/server");
   return {
-    useQuery: (ref: unknown) =>
-      getFunctionName(ref as never) === "retro:listForTeam" ? mocks.retros : mocks.team,
+    useQuery: (ref: unknown) => {
+      const fn = getFunctionName(ref as never);
+      if (fn === "retro:listForTeam") return mocks.retros;
+      if (fn === "teams:openActions") return mocks.openActions;
+      return mocks.team;
+    },
     useMutation: (ref: unknown) => {
       const fn = getFunctionName(ref as never);
       return async (args: unknown) => {
@@ -128,6 +133,7 @@ const calledWith = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c
 const dialog = () => within(screen.getByRole("dialog"));
 
 beforeEach(() => {
+  mocks.openActions = { items: [], rooms: [] };
   mocks.team = team("admin");
   mocks.retros = [];
   mocks.calls = [];
@@ -249,6 +255,44 @@ describe("TeamContent — the Team's retros", () => {
     render(<TeamContent />);
     expect(screen.getByText("No retros yet. Start one and this team keeps it.")).toBeTruthy();
     expect(screen.queryByTestId("retro-rows")).toBeNull();
+  });
+});
+
+describe("TeamContent — the open action items (spec §5, §13)", () => {
+  it("lists the Team's open items with the retro each came from, and completes one in place through the room's mutation", () => {
+    mocks.openActions = {
+      items: [
+        {
+          _id: "a1",
+          roomId: "r1",
+          roomName: "First",
+          text: "Write the runbook",
+          status: "open",
+          createdBy: "u1",
+          creatorName: "Ada",
+          createdAt: 1,
+          updatedAt: 1,
+          rights: { edit: true, manage: false },
+        },
+      ],
+      rooms: [{ roomId: "r1", name: "First", members: [] }],
+    };
+    render(<TeamContent />);
+    const list = screen.getByTestId("team-open-actions");
+    expect(list.getAttribute("data-count")).toBe("1");
+    expect(within(list).getByText("Write the runbook")).toBeTruthy();
+    expect(within(list).getByText(/First/)).toBeTruthy();
+    fireEvent.click(within(list).getByRole("button", { name: "Done" }));
+    fireEvent.click(within(list).getByRole("button", { name: "Save" }));
+    expect(mocks.calls).toEqual([
+      { fn: "retro:setActionStatus", args: { roomId: "r1", actionId: "a1", status: "done" } },
+    ]);
+  });
+
+  it("reads the empty line with nothing open across the Team", () => {
+    mocks.openActions = { items: [], rooms: [] };
+    render(<TeamContent />);
+    expect(screen.getByText("No open action items across this team's retros.")).toBeTruthy();
   });
 });
 

--- a/src/app/team/[teamId]/team-content.test.tsx
+++ b/src/app/team/[teamId]/team-content.test.tsx
@@ -275,7 +275,7 @@ describe("TeamContent — the open action items (spec §5, §13)", () => {
           rights: { edit: true, manage: false },
         },
       ],
-      rooms: [{ roomId: "r1", name: "First", members: [] }],
+      rooms: [{ roomId: "r1", name: "First", members: [], attending: true }],
     };
     render(<TeamContent />);
     const list = screen.getByTestId("team-open-actions");

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -28,7 +28,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { RetroDefaultsPanel, type RetroDefaults } from "@/components/team/retro-defaults-panel";
 import { RetroRows } from "@/components/retro/retro-list";
-import { TEAM_RETROS_EMPTY, TEAM_RETROS_TITLE } from "@/convex/retroCopy";
+import { ActionList } from "@/components/retro/action-list";
+import { useActionActions } from "@/components/retro/use-action-actions";
+import { OPEN_ACTIONS_EMPTY, OPEN_ACTIONS_TITLE, TEAM_RETROS_EMPTY, TEAM_RETROS_TITLE } from "@/convex/retroCopy";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
 import { toast } from "@/lib/toast";
 import { runAct } from "@/lib/run-act";
@@ -47,8 +49,9 @@ function Centered({ title, body }: { title: string; body: string }) {
 /**
  * The team page (spec §5, §18.1), members only: the Team's retros in
  * creation order, members with roles, the invite link, the retro-defaults
- * panel, New retro, and admin-only Delete team. The history row, action
- * items and export arrive with #299.
+ * panel, New retro, and admin-only Delete team; the open action items
+ * across its retros with done, drop, edit and reassign in place for
+ * whoever attended (spec §13). The history row and export arrive with #299.
  */
 export function TeamContent() {
   const params = useParams();
@@ -58,6 +61,8 @@ export function TeamContent() {
 
   const team = useQuery(api.teams.get, isAuthenticated ? { teamId } : "skip");
   const retros = useQuery(api.retro.listForTeam, isAuthenticated ? { teamId } : "skip");
+  const openActions = useQuery(api.teams.openActions, isAuthenticated ? { teamId } : "skip");
+  const actionItems = useActionActions();
 
   const rename = useMutation(api.teams.rename);
   const rotateInvite = useMutation(api.teams.rotateInvite);
@@ -193,6 +198,16 @@ export function TeamContent() {
               ) : (
                 <RetroRows rows={retros} />
               )}
+            </CardContent>
+          </Card>
+
+          {/* Open action items (spec §5, §13): the cross-retro door to completion */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{OPEN_ACTIONS_TITLE}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ActionList read={openActions} empty={OPEN_ACTIONS_EMPTY} showRoom actions={actionItems} testId="team-open-actions" />
             </CardContent>
           </Card>
 

--- a/src/components/retro/action-composer.tsx
+++ b/src/components/retro/action-composer.tsx
@@ -16,7 +16,8 @@ import {
   ACTION_SUBMIT,
   ACTION_TEXT_LABEL,
   ACTION_TEXT_PLACEHOLDER,
-  NO_OWNER_OPTION,
+  CLEAR_SOURCE,
+  UNOWNED_ACTION,
 } from "@/convex/retroCopy";
 import type { ActionMember } from "./action-row";
 import { parseDueDate } from "./actions";
@@ -84,7 +85,7 @@ export function ActionComposer({ members, source, onClearSource, onSubmit }: Act
             {ACTION_SOURCE_LABEL}: {source.label}
           </span>
           {onClearSource && (
-            <Button type="button" variant="ghost" size="icon-xs" aria-label="Clear" onClick={onClearSource}>
+            <Button type="button" variant="ghost" size="icon-xs" aria-label={CLEAR_SOURCE} onClick={onClearSource}>
               <X className="size-3" />
             </Button>
           )}
@@ -116,7 +117,7 @@ export function ActionComposer({ members, source, onClearSource, onSubmit }: Act
             onChange={(e) => setOwnerId(e.target.value)}
             className="h-8 rounded-md border border-input bg-transparent px-1.5 text-xs dark:bg-input/30"
           >
-            <option value="">{NO_OWNER_OPTION}</option>
+            <option value="">{UNOWNED_ACTION}</option>
             {members.map((member) => (
               <option key={member.userId} value={member.userId}>
                 {member.name}

--- a/src/components/retro/action-composer.tsx
+++ b/src/components/retro/action-composer.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { TopicRef } from "@/convex/model/walk";
+import { MAX_ACTION_TEXT } from "@/convex/model/retroActions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  ACTION_DUE_LABEL,
+  ACTION_OWNER_LABEL,
+  ACTION_SOURCE_LABEL,
+  ACTION_SUBMIT,
+  ACTION_TEXT_LABEL,
+  ACTION_TEXT_PLACEHOLDER,
+  NO_OWNER_OPTION,
+} from "@/convex/retroCopy";
+import type { ActionMember } from "./action-row";
+import { parseDueDate } from "./actions";
+import type { CreateActionInput } from "./use-action-actions";
+
+/** The topic an item is written against (spec §13): the walk's current topic, with its label. */
+export interface ActionSource {
+  ref: TopicRef;
+  label: string;
+}
+
+export interface ActionComposerProps {
+  members: readonly ActionMember[];
+  /** Pre-filled by "Add action" on the walk's topic; cleared by the person. */
+  source?: ActionSource;
+  onClearSource?: () => void;
+  /** Resolves to whether the item was written; the form clears on success. */
+  onSubmit: (input: CreateActionInput) => Promise<boolean>;
+}
+
+/**
+ * The inline composer (spec §13): text, zero or one owner among the
+ * attendees, an optional date, and the source it answers when it came from
+ * the walk. Never refused by a stage; the panel decides where it is
+ * offered. Unowned is a fine way to save.
+ */
+export function ActionComposer({ members, source, onClearSource, onSubmit }: ActionComposerProps) {
+  const [text, setText] = useState("");
+  const [ownerId, setOwnerId] = useState("");
+  const [due, setDue] = useState("");
+  const [posting, setPosting] = useState(false);
+
+  const post = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || posting) return;
+    setPosting(true);
+    const dueAt = parseDueDate(due);
+    const written = await onSubmit({
+      text: trimmed,
+      ...(ownerId ? { ownerId: ownerId as Id<"users"> } : {}),
+      ...(dueAt !== undefined ? { dueAt } : {}),
+      ...(source ? { source: source.ref } : {}),
+    });
+    setPosting(false);
+    if (written) {
+      setText("");
+      setOwnerId("");
+      setDue("");
+      onClearSource?.();
+    }
+  };
+
+  return (
+    <form
+      data-testid="action-composer"
+      className="grid gap-2 rounded-md border p-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void post();
+      }}
+    >
+      {source && (
+        <p data-testid="action-source" className="flex items-center gap-1 text-xs text-muted-foreground">
+          <span className="min-w-0 flex-1 truncate">
+            {ACTION_SOURCE_LABEL}: {source.label}
+          </span>
+          {onClearSource && (
+            <Button type="button" variant="ghost" size="icon-xs" aria-label="Clear" onClick={onClearSource}>
+              <X className="size-3" />
+            </Button>
+          )}
+        </p>
+      )}
+      <div className="grid gap-1">
+        <Label htmlFor="action-composer-text">{ACTION_TEXT_LABEL}</Label>
+        <Textarea
+          id="action-composer-text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={ACTION_TEXT_PLACEHOLDER}
+          maxLength={MAX_ACTION_TEXT}
+          rows={2}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              void post();
+            }
+          }}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="grid gap-1">
+          <Label htmlFor="action-composer-owner">{ACTION_OWNER_LABEL}</Label>
+          <select
+            id="action-composer-owner"
+            value={ownerId}
+            onChange={(e) => setOwnerId(e.target.value)}
+            className="h-8 rounded-md border border-input bg-transparent px-1.5 text-xs dark:bg-input/30"
+          >
+            <option value="">{NO_OWNER_OPTION}</option>
+            {members.map((member) => (
+              <option key={member.userId} value={member.userId}>
+                {member.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="action-composer-due">{ACTION_DUE_LABEL}</Label>
+          <Input id="action-composer-due" type="date" value={due} onChange={(e) => setDue(e.target.value)} className="h-8 text-xs" />
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Button type="submit" size="xs" disabled={!text.trim() || posting}>
+          {ACTION_SUBMIT}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/retro/action-list.tsx
+++ b/src/components/retro/action-list.tsx
@@ -25,10 +25,7 @@ export interface ActionListProps {
  * room, so one list serves the retro's panel, the review and the team page.
  */
 export function ActionList({ read, empty, showRoom, actions, now, testId = "action-list" }: ActionListProps) {
-  const membersByRoom = useMemo(
-    () => new Map((read?.rooms ?? []).map((room) => [room.roomId, room.members])),
-    [read]
-  );
+  const roomsById = useMemo(() => new Map((read?.rooms ?? []).map((room) => [room.roomId, room])), [read]);
   const bound = useMemo<((roomId: Id<"rooms">) => ActionRowActions) | undefined>(
     () =>
       actions &&
@@ -52,16 +49,20 @@ export function ActionList({ read, empty, showRoom, actions, now, testId = "acti
   }
   return (
     <ul data-testid={testId} data-count={read.items.length} className="flex flex-col gap-1.5">
-      {read.items.map((item) => (
-        <ActionRow
-          key={item._id}
-          item={item}
-          members={membersByRoom.get(item.roomId) ?? []}
-          now={now}
-          showRoom={showRoom}
-          actions={bound?.(item.roomId)}
-        />
-      ))}
+      {read.items.map((item) => {
+        const room = roomsById.get(item.roomId);
+        return (
+          <ActionRow
+            key={item._id}
+            item={item}
+            members={room?.members ?? []}
+            attending={room?.attending ?? true}
+            now={now}
+            showRoom={showRoom}
+            actions={bound?.(item.roomId)}
+          />
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/retro/action-list.tsx
+++ b/src/components/retro/action-list.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import { ActionRow, type ActionRowActions } from "./action-row";
+import type { ActionActions } from "./use-action-actions";
+
+export interface ActionListProps {
+  /** Undefined while loading. */
+  read: ActionsRead | undefined;
+  /** The line for no items. */
+  empty: string;
+  /** Name each item's retro: the review and the team page. */
+  showRoom?: boolean;
+  /** The writes, bound here to each item's room; absent for a Team reader. */
+  actions?: ActionActions;
+  now?: number;
+  testId?: string;
+}
+
+/**
+ * A list of action items over one read (spec §13): each row's owner picker
+ * draws on its own retro's attendees, and each act is bound to the row's
+ * room, so one list serves the retro's panel, the review and the team page.
+ */
+export function ActionList({ read, empty, showRoom, actions, now, testId = "action-list" }: ActionListProps) {
+  const membersByRoom = useMemo(
+    () => new Map((read?.rooms ?? []).map((room) => [room.roomId, room.members])),
+    [read]
+  );
+  const bound = useMemo<((roomId: Id<"rooms">) => ActionRowActions) | undefined>(
+    () =>
+      actions &&
+      ((roomId) => ({
+        onSetStatus: (actionId, status, note) => actions.setStatus(roomId, actionId, status, note),
+        onEdit: (actionId, text, dueAt) => actions.edit(roomId, actionId, text, dueAt),
+        onAssign: (actionId, ownerId) => actions.assign(roomId, actionId, ownerId),
+        onDelete: (actionId) => actions.remove(roomId, actionId),
+      })),
+    [actions]
+  );
+  if (read === undefined) {
+    return <div data-testid={testId} className="h-10 animate-pulse rounded-lg bg-muted" />;
+  }
+  if (read.items.length === 0) {
+    return (
+      <p data-testid={testId} data-count="0" className="text-sm text-muted-foreground">
+        {empty}
+      </p>
+    );
+  }
+  return (
+    <ul data-testid={testId} data-count={read.items.length} className="flex flex-col gap-1.5">
+      {read.items.map((item) => (
+        <ActionRow
+          key={item._id}
+          item={item}
+          members={membersByRoom.get(item.roomId) ?? []}
+          now={now}
+          showRoom={showRoom}
+          actions={bound?.(item.roomId)}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/retro/action-row.test.tsx
+++ b/src/components/retro/action-row.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { ActionRead } from "@/convex/model/retroActions";
-import { FORMER_MEMBER, OVERDUE, UNOWNED_ACTION } from "@/convex/retroCopy";
+import { FORMER_MEMBER, NOT_ATTENDING, OVERDUE, UNOWNED_ACTION } from "@/convex/retroCopy";
 import { ActionRow, type ActionRowActions } from "./action-row";
 
 afterEach(cleanup);
@@ -91,6 +91,17 @@ describe("ActionRow", () => {
     render(<ActionRow item={base} members={members} now={NOW} actions={actions()} />);
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.queryByText(NOT_ATTENDING)).toBeNull();
+  });
+
+  it("tells a viewer who never attended the item's retro why there is nothing to press", () => {
+    render(<ActionRow item={base} members={members} now={NOW} attending={false} actions={actions()} showRoom />);
+    expect(screen.getByTestId("not-attending").textContent).toBe(NOT_ATTENDING);
+    expect(screen.queryByRole("button")).toBeNull();
+    cleanup();
+    // Without the acts at all (a reader's surface) the line is not needed.
+    render(<ActionRow item={base} members={members} now={NOW} attending={false} showRoom />);
+    expect(screen.queryByText(NOT_ATTENDING)).toBeNull();
   });
 
   it("with edit rights: done and drop invite a note and reopen does not", () => {

--- a/src/components/retro/action-row.test.tsx
+++ b/src/components/retro/action-row.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * One action item as the board, the review and the team page render it
+ * (spec §13, §19): its text, owner or the unowned line, the due date with
+ * the overdue state, the source's label, and the in-place acts the
+ * viewer's rights allow.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionRead } from "@/convex/model/retroActions";
+import { FORMER_MEMBER, OVERDUE, UNOWNED_ACTION } from "@/convex/retroCopy";
+import { ActionRow, type ActionRowActions } from "./action-row";
+
+afterEach(cleanup);
+
+const NOW = Date.UTC(2026, 8, 5, 12);
+
+const base: ActionRead = {
+  _id: "a1" as Id<"retroActions">,
+  roomId: "r1" as Id<"rooms">,
+  roomName: "Sprint 12",
+  text: "Fix the flaky build",
+  status: "open",
+  createdBy: "u1" as Id<"users">,
+  creatorName: "Ada",
+  createdAt: NOW - 1000,
+  updatedAt: NOW - 1000,
+  rights: { edit: false, manage: false },
+};
+
+const members = [
+  { userId: "u1" as Id<"users">, name: "Ada" },
+  { userId: "u2" as Id<"users">, name: "Grace" },
+];
+
+function actions(): ActionRowActions {
+  return { onSetStatus: vi.fn(), onEdit: vi.fn(), onAssign: vi.fn(), onDelete: vi.fn() };
+}
+
+describe("ActionRow", () => {
+  it("renders an unowned item as a state, never an error", () => {
+    render(<ActionRow item={base} members={members} now={NOW} />);
+    const row = screen.getByTestId("action-item");
+    expect(row.getAttribute("data-owned")).toBe("false");
+    expect(row.getAttribute("data-overdue")).toBe("false");
+    expect(row.getAttribute("data-status")).toBe("open");
+    expect(screen.getByText(UNOWNED_ACTION)).toBeTruthy();
+    expect(screen.getByText("Fix the flaky build")).toBeTruthy();
+  });
+
+  it("names the owner, and a missing one as the register's former member", () => {
+    const { rerender } = render(
+      <ActionRow item={{ ...base, ownerId: "u2" as Id<"users">, ownerName: "Grace" }} members={members} now={NOW} />
+    );
+    expect(screen.getByTestId("action-item").getAttribute("data-owned")).toBe("true");
+    expect(screen.getByText(/Grace/)).toBeTruthy();
+    rerender(
+      <ActionRow item={{ ...base, ownerId: "u9" as Id<"users">, ownerName: FORMER_MEMBER }} members={members} now={NOW} />
+    );
+    expect(screen.getByText(new RegExp(FORMER_MEMBER))).toBeTruthy();
+  });
+
+  it("is overdue only while open with a due date in the past", () => {
+    const past = NOW - 86_400_000;
+    const { rerender } = render(<ActionRow item={{ ...base, dueAt: past }} members={members} now={NOW} />);
+    expect(screen.getByTestId("action-item").getAttribute("data-overdue")).toBe("true");
+    expect(screen.getByText(OVERDUE)).toBeTruthy();
+
+    rerender(<ActionRow item={{ ...base, dueAt: past, status: "done" }} members={members} now={NOW} />);
+    expect(screen.getByTestId("action-item").getAttribute("data-overdue")).toBe("false");
+    expect(screen.queryByText(OVERDUE)).toBeNull();
+
+    rerender(<ActionRow item={{ ...base, dueAt: NOW + 86_400_000 }} members={members} now={NOW} />);
+    expect(screen.getByTestId("action-item").getAttribute("data-overdue")).toBe("false");
+  });
+
+  it("shows the source's label and, when asked, the retro it came from", () => {
+    render(
+      <ActionRow
+        item={{ ...base, source: { kind: "card", id: "c1" as Id<"retroCards">, label: "CI is red every morning" } }}
+        members={members}
+        now={NOW}
+        showRoom
+      />
+    );
+    expect(screen.getByText(/CI is red every morning/)).toBeTruthy();
+    expect(screen.getByText(/Sprint 12/)).toBeTruthy();
+  });
+
+  it("offers no act without rights, and a Team reader sees none either", () => {
+    render(<ActionRow item={base} members={members} now={NOW} actions={actions()} />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("with edit rights: done and drop invite a note and reopen does not", () => {
+    const acts = actions();
+    render(<ActionRow item={{ ...base, rights: { edit: true, manage: false } }} members={members} now={NOW} actions={acts} />);
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    const note = screen.getByLabelText("Note");
+    fireEvent.change(note, { target: { value: "Shipped" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(acts.onSetStatus).toHaveBeenCalledWith("a1", "done", "Shipped");
+    // No owner picker and no delete without the category.
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete action" })).toBeNull();
+
+    cleanup();
+    render(
+      <ActionRow item={{ ...base, status: "dropped", note: "Not worth it", rights: { edit: true, manage: false } }} members={members} now={NOW} actions={acts} />
+    );
+    expect(screen.getByText(/Not worth it/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Reopen" }));
+    expect(acts.onSetStatus).toHaveBeenCalledWith("a1", "open", undefined);
+  });
+
+  it("with the category: the owner picker reassigns in place among the retro's attendees, and delete asks first", () => {
+    const acts = actions();
+    render(<ActionRow item={{ ...base, rights: { edit: true, manage: true } }} members={members} now={NOW} actions={acts} />);
+    const picker = screen.getByRole("combobox", { name: "Owner" });
+    expect(within(picker).getAllByRole("option").map((o) => o.textContent)).toEqual([UNOWNED_ACTION, "Ada", "Grace"]);
+    fireEvent.change(picker, { target: { value: "u2" } });
+    expect(acts.onAssign).toHaveBeenCalledWith("a1", "u2");
+    fireEvent.change(picker, { target: { value: "" } });
+    expect(acts.onAssign).toHaveBeenCalledWith("a1", undefined);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete action" }));
+    expect(acts.onDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(acts.onDelete).toHaveBeenCalledWith("a1");
+  });
+
+  it("edits text and due date in place", () => {
+    const acts = actions();
+    render(<ActionRow item={{ ...base, rights: { edit: true, manage: false } }} members={members} now={NOW} actions={acts} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("Action"), { target: { value: "Fix the build for good" } });
+    fireEvent.change(screen.getByLabelText("Due"), { target: { value: "2026-09-10" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(acts.onEdit).toHaveBeenCalledWith("a1", "Fix the build for good", new Date(2026, 8, 10, 23, 59, 59).getTime());
+  });
+});

--- a/src/components/retro/action-row.tsx
+++ b/src/components/retro/action-row.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import {
   ACTION_DELETE,
+  ACTION_DELETE_CONFIRM,
+  ACTION_DELETE_TITLE,
   ACTION_DONE,
   ACTION_DROP,
   ACTION_DUE_LABEL,
@@ -35,7 +37,7 @@ import {
   ACTION_STATUS_LABELS,
   ACTION_TEXT_LABEL,
   CANCEL_BUTTON,
-  NO_OWNER_OPTION,
+  NOT_ATTENDING,
   OVERDUE,
   UNOWNED_ACTION,
   dueOn,
@@ -62,6 +64,8 @@ export interface ActionRowProps {
   item: ActionRead;
   /** The item's retro's attendees: an owner must attend (spec §13). */
   members: readonly ActionMember[];
+  /** Whether the viewer attends the item's retro; a Team reader who does not is told so. */
+  attending?: boolean;
   /** The clock the overdue state reads; defaults to now. */
   now?: number;
   /** Name the retro the item lives in: the review and the team page. */
@@ -70,7 +74,8 @@ export interface ActionRowProps {
   actions?: ActionRowActions;
 }
 
-type Pending = { status: "done" | "dropped" } | { edit: true } | null;
+/** The inline form the row is showing, if any. */
+type Pending = { kind: "note"; status: "done" | "dropped" } | { kind: "edit" } | null;
 
 /**
  * One action item (spec §13, §19; ADR-0017): text; the owner by name or
@@ -81,7 +86,7 @@ type Pending = { status: "done" | "dropped" } | { edit: true } | null;
  * the category: the owner picker among the retro's attendees, and delete
  * behind a confirmation. No priority, no comments, no count copy.
  */
-export function ActionRow({ item, members, now, showRoom = false, actions }: ActionRowProps) {
+export function ActionRow({ item, members, attending = true, now, showRoom = false, actions }: ActionRowProps) {
   // The clock is read once per mount when the caller passes none; overdue is a
   // rendering state and a re-read every render would be an impure render.
   const [mountedAt] = useState(() => Date.now());
@@ -91,23 +96,24 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
   const [due, setDue] = useState(toDateInput(item.dueAt));
   const [confirmDelete, setConfirmDelete] = useState(false);
   const overdue = isOverdue(item, now ?? mountedAt);
-  const canEdit = actions !== undefined && item.rights.edit;
-  const canManage = actions !== undefined && item.rights.manage;
+  const editing = actions !== undefined && item.rights.edit ? actions : undefined;
+  const managing = actions !== undefined && item.rights.manage ? actions : undefined;
 
   const openEdit = () => {
     setText(item.text);
     setDue(toDateInput(item.dueAt));
-    setPending({ edit: true });
+    setPending({ kind: "edit" });
   };
   const saveEdit = () => {
     const trimmed = text.trim();
-    if (!trimmed) return;
-    actions!.onEdit(item._id, trimmed, parseDueDate(due) ?? null);
+    if (!trimmed || !editing) return;
+    editing.onEdit(item._id, trimmed, parseDueDate(due) ?? null);
     setPending(null);
   };
   const saveStatus = (status: "done" | "dropped") => {
+    if (!editing) return;
     const trimmed = note.trim();
-    actions!.onSetStatus(item._id, status, trimmed === "" ? undefined : trimmed);
+    editing.onSetStatus(item._id, status, trimmed === "" ? undefined : trimmed);
     setNote("");
     setPending(null);
   };
@@ -124,14 +130,8 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
         item.status !== "open" && "bg-gray-50 text-muted-foreground dark:bg-surface-2"
       )}
     >
-      {pending && "edit" in pending ? (
-        <form
-          className="grid gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            saveEdit();
-          }}
-        >
+      {pending?.kind === "edit" ? (
+        <RowForm onSubmit={saveEdit} onCancel={() => setPending(null)} disabled={!text.trim()}>
           <div className="grid gap-1">
             <Label htmlFor={`action-text-${item._id}`}>{ACTION_TEXT_LABEL}</Label>
             <Textarea
@@ -147,15 +147,7 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
             <Label htmlFor={`action-due-${item._id}`}>{ACTION_DUE_LABEL}</Label>
             <Input id={`action-due-${item._id}`} type="date" value={due} onChange={(e) => setDue(e.target.value)} />
           </div>
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" size="xs" onClick={() => setPending(null)}>
-              {CANCEL_BUTTON}
-            </Button>
-            <Button type="submit" size="xs" disabled={!text.trim()}>
-              {ACTION_SAVE}
-            </Button>
-          </div>
-        </form>
+        </RowForm>
       ) : (
         <>
           <div className="flex items-start gap-2">
@@ -170,7 +162,7 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
                 {OVERDUE}
               </span>
             )}
-            {canManage && (
+            {managing && (
               <Button
                 type="button"
                 variant="ghost"
@@ -183,18 +175,18 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
             )}
           </div>
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-            {canManage ? (
+            {managing ? (
               <label className="flex items-center gap-1">
                 <span>{ACTION_OWNER_LABEL}</span>
                 <select
                   aria-label={ACTION_OWNER_LABEL}
                   value={item.ownerId ?? ""}
                   onChange={(e) =>
-                    actions!.onAssign(item._id, e.target.value === "" ? undefined : (e.target.value as Id<"users">))
+                    managing.onAssign(item._id, e.target.value === "" ? undefined : (e.target.value as Id<"users">))
                   }
                   className="h-6 rounded-md border border-input bg-transparent px-1 text-xs dark:bg-input/30"
                 >
-                  <option value="">{NO_OWNER_OPTION}</option>
+                  <option value="">{UNOWNED_ACTION}</option>
                   {members.map((member) => (
                     <option key={member.userId} value={member.userId}>
                       {member.name}
@@ -222,14 +214,8 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
           {item.note !== undefined && item.status !== "open" && (
             <p className="text-xs italic text-muted-foreground">{item.note}</p>
           )}
-          {pending && "status" in pending ? (
-            <form
-              className="grid gap-2"
-              onSubmit={(e) => {
-                e.preventDefault();
-                saveStatus(pending.status);
-              }}
-            >
+          {pending?.kind === "note" ? (
+            <RowForm onSubmit={() => saveStatus(pending.status)} onCancel={() => setPending(null)}>
               <div className="grid gap-1">
                 <Label htmlFor={`action-note-${item._id}`}>{ACTION_NOTE_LABEL}</Label>
                 <Textarea
@@ -242,50 +228,57 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
                   autoFocus
                 />
               </div>
-              <div className="flex justify-end gap-2">
-                <Button type="button" variant="ghost" size="xs" onClick={() => setPending(null)}>
-                  {CANCEL_BUTTON}
-                </Button>
-                <Button type="submit" size="xs">
-                  {ACTION_SAVE}
-                </Button>
-              </div>
-            </form>
-          ) : (
-            canEdit && (
-              <div className="flex flex-wrap gap-1">
-                {item.status === "open" ? (
-                  <>
-                    <Button type="button" variant="outline" size="xs" onClick={() => setPending({ status: "done" })}>
-                      {ACTION_DONE}
-                    </Button>
-                    <Button type="button" variant="outline" size="xs" onClick={() => setPending({ status: "dropped" })}>
-                      {ACTION_DROP}
-                    </Button>
-                  </>
-                ) : (
+            </RowForm>
+          ) : editing ? (
+            <div className="flex flex-wrap gap-1">
+              {item.status === "open" ? (
+                <>
                   <Button
                     type="button"
                     variant="outline"
                     size="xs"
-                    onClick={() => actions!.onSetStatus(item._id, "open", undefined)}
+                    onClick={() => setPending({ kind: "note", status: "done" })}
                   >
-                    {ACTION_REOPEN}
+                    {ACTION_DONE}
                   </Button>
-                )}
-                <Button type="button" variant="ghost" size="xs" onClick={openEdit}>
-                  {ACTION_EDIT}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => setPending({ kind: "note", status: "dropped" })}
+                  >
+                    {ACTION_DROP}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  onClick={() => editing.onSetStatus(item._id, "open", undefined)}
+                >
+                  {ACTION_REOPEN}
                 </Button>
-              </div>
+              )}
+              <Button type="button" variant="ghost" size="xs" onClick={openEdit}>
+                {ACTION_EDIT}
+              </Button>
+            </div>
+          ) : (
+            actions !== undefined &&
+            !attending && (
+              <p data-testid="not-attending" className="text-xs text-muted-foreground">
+                {NOT_ATTENDING}
+              </p>
             )
           )}
         </>
       )}
-      {canManage && (
+      {managing && (
         <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
           <AlertDialogContent size="sm">
             <AlertDialogHeader>
-              <AlertDialogTitle>{ACTION_DELETE}?</AlertDialogTitle>
+              <AlertDialogTitle>{ACTION_DELETE_TITLE}</AlertDialogTitle>
               <AlertDialogDescription>{item.text}</AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -294,15 +287,48 @@ export function ActionRow({ item, members, now, showRoom = false, actions }: Act
                 variant="destructive"
                 onClick={() => {
                   setConfirmDelete(false);
-                  actions!.onDelete(item._id);
+                  managing.onDelete(item._id);
                 }}
               >
-                Delete
+                {ACTION_DELETE_CONFIRM}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
       )}
     </li>
+  );
+}
+
+/** The row's inline form shell: its fields, then Cancel and Save. */
+function RowForm({
+  children,
+  onSubmit,
+  onCancel,
+  disabled = false,
+}: {
+  children: React.ReactNode;
+  onSubmit: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <form
+      className="grid gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      {children}
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" size="xs" onClick={onCancel}>
+          {CANCEL_BUTTON}
+        </Button>
+        <Button type="submit" size="xs" disabled={disabled}>
+          {ACTION_SAVE}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/src/components/retro/action-row.tsx
+++ b/src/components/retro/action-row.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionRead, ActionStatus } from "@/convex/model/retroActions";
+import { MAX_ACTION_NOTE, MAX_ACTION_TEXT } from "@/convex/model/retroActions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  ACTION_DELETE,
+  ACTION_DONE,
+  ACTION_DROP,
+  ACTION_DUE_LABEL,
+  ACTION_EDIT,
+  ACTION_NOTE_LABEL,
+  ACTION_NOTE_PLACEHOLDER,
+  ACTION_OWNER_LABEL,
+  ACTION_REOPEN,
+  ACTION_SAVE,
+  ACTION_SOURCE_LABEL,
+  ACTION_STATUS_LABELS,
+  ACTION_TEXT_LABEL,
+  CANCEL_BUTTON,
+  NO_OWNER_OPTION,
+  OVERDUE,
+  UNOWNED_ACTION,
+  dueOn,
+  fromRetro,
+  ownedBy,
+} from "@/convex/retroCopy";
+import { formatDue, isOverdue, parseDueDate, toDateInput } from "./actions";
+
+/** An attendee of the item's retro, as the owner picker lists them. */
+export interface ActionMember {
+  userId: Id<"users">;
+  name: string;
+}
+
+/** The in-place acts, bound to the item's room by whoever renders the list. */
+export interface ActionRowActions {
+  onSetStatus: (actionId: Id<"retroActions">, status: ActionStatus, note?: string) => void;
+  onEdit: (actionId: Id<"retroActions">, text: string, dueAt: number | null) => void;
+  onAssign: (actionId: Id<"retroActions">, ownerId: Id<"users"> | undefined) => void;
+  onDelete: (actionId: Id<"retroActions">) => void;
+}
+
+export interface ActionRowProps {
+  item: ActionRead;
+  /** The item's retro's attendees: an owner must attend (spec §13). */
+  members: readonly ActionMember[];
+  /** The clock the overdue state reads; defaults to now. */
+  now?: number;
+  /** Name the retro the item lives in: the review and the team page. */
+  showRoom?: boolean;
+  /** Absent for a Team reader; present acts still show only under the item's rights. */
+  actions?: ActionRowActions;
+}
+
+type Pending = { status: "done" | "dropped" } | { edit: true } | null;
+
+/**
+ * One action item (spec §13, §19; ADR-0017): text; the owner by name or
+ * "Nobody owns this yet", a state and never an error; the due date, with
+ * Overdue while open and past; the source's label, never an author; the
+ * note once the item left open. With edit rights: done and drop, each
+ * inviting a note, reopen, and an in-place edit of text and date. With
+ * the category: the owner picker among the retro's attendees, and delete
+ * behind a confirmation. No priority, no comments, no count copy.
+ */
+export function ActionRow({ item, members, now, showRoom = false, actions }: ActionRowProps) {
+  // The clock is read once per mount when the caller passes none; overdue is a
+  // rendering state and a re-read every render would be an impure render.
+  const [mountedAt] = useState(() => Date.now());
+  const [pending, setPending] = useState<Pending>(null);
+  const [note, setNote] = useState("");
+  const [text, setText] = useState(item.text);
+  const [due, setDue] = useState(toDateInput(item.dueAt));
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const overdue = isOverdue(item, now ?? mountedAt);
+  const canEdit = actions !== undefined && item.rights.edit;
+  const canManage = actions !== undefined && item.rights.manage;
+
+  const openEdit = () => {
+    setText(item.text);
+    setDue(toDateInput(item.dueAt));
+    setPending({ edit: true });
+  };
+  const saveEdit = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    actions!.onEdit(item._id, trimmed, parseDueDate(due) ?? null);
+    setPending(null);
+  };
+  const saveStatus = (status: "done" | "dropped") => {
+    const trimmed = note.trim();
+    actions!.onSetStatus(item._id, status, trimmed === "" ? undefined : trimmed);
+    setNote("");
+    setPending(null);
+  };
+
+  return (
+    <li
+      data-testid="action-item"
+      data-action-id={item._id}
+      data-status={item.status}
+      data-owned={String(item.ownerId !== undefined)}
+      data-overdue={String(overdue)}
+      className={cn(
+        "flex flex-col gap-1.5 rounded-md border px-3 py-2 text-sm",
+        item.status !== "open" && "bg-gray-50 text-muted-foreground dark:bg-surface-2"
+      )}
+    >
+      {pending && "edit" in pending ? (
+        <form
+          className="grid gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            saveEdit();
+          }}
+        >
+          <div className="grid gap-1">
+            <Label htmlFor={`action-text-${item._id}`}>{ACTION_TEXT_LABEL}</Label>
+            <Textarea
+              id={`action-text-${item._id}`}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              maxLength={MAX_ACTION_TEXT}
+              rows={2}
+              autoFocus
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor={`action-due-${item._id}`}>{ACTION_DUE_LABEL}</Label>
+            <Input id={`action-due-${item._id}`} type="date" value={due} onChange={(e) => setDue(e.target.value)} />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="xs" onClick={() => setPending(null)}>
+              {CANCEL_BUTTON}
+            </Button>
+            <Button type="submit" size="xs" disabled={!text.trim()}>
+              {ACTION_SAVE}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <>
+          <div className="flex items-start gap-2">
+            <p className={cn("min-w-0 flex-1", item.status !== "open" && "line-through")}>{item.text}</p>
+            {item.status !== "open" && (
+              <span className="shrink-0 rounded-full border px-1.5 text-[10px] font-semibold uppercase">
+                {ACTION_STATUS_LABELS[item.status]}
+              </span>
+            )}
+            {overdue && (
+              <span className="shrink-0 rounded-full bg-amber-100 px-1.5 text-[10px] font-semibold text-amber-800 uppercase dark:bg-status-warning-bg dark:text-status-warning-fg">
+                {OVERDUE}
+              </span>
+            )}
+            {canManage && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={ACTION_DELETE}
+                onClick={() => setConfirmDelete(true)}
+              >
+                <Trash2 className="size-3.5 text-destructive" />
+              </Button>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {canManage ? (
+              <label className="flex items-center gap-1">
+                <span>{ACTION_OWNER_LABEL}</span>
+                <select
+                  aria-label={ACTION_OWNER_LABEL}
+                  value={item.ownerId ?? ""}
+                  onChange={(e) =>
+                    actions!.onAssign(item._id, e.target.value === "" ? undefined : (e.target.value as Id<"users">))
+                  }
+                  className="h-6 rounded-md border border-input bg-transparent px-1 text-xs dark:bg-input/30"
+                >
+                  <option value="">{NO_OWNER_OPTION}</option>
+                  {members.map((member) => (
+                    <option key={member.userId} value={member.userId}>
+                      {member.name}
+                    </option>
+                  ))}
+                  {/* An owner no longer attending, or gone: keep the stored value selectable. */}
+                  {item.ownerId !== undefined && !members.some((m) => m.userId === item.ownerId) && (
+                    <option value={item.ownerId}>{item.ownerName}</option>
+                  )}
+                </select>
+              </label>
+            ) : (
+              <span data-testid="action-owner">
+                {item.ownerId !== undefined ? ownedBy(item.ownerName ?? "") : UNOWNED_ACTION}
+              </span>
+            )}
+            {item.dueAt !== undefined && <span>{dueOn(formatDue(item.dueAt))}</span>}
+            {item.source && (
+              <span className="min-w-0 truncate" title={item.source.label}>
+                {ACTION_SOURCE_LABEL}: {item.source.label}
+              </span>
+            )}
+            {showRoom && <span>{fromRetro(item.roomName)}</span>}
+          </div>
+          {item.note !== undefined && item.status !== "open" && (
+            <p className="text-xs italic text-muted-foreground">{item.note}</p>
+          )}
+          {pending && "status" in pending ? (
+            <form
+              className="grid gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                saveStatus(pending.status);
+              }}
+            >
+              <div className="grid gap-1">
+                <Label htmlFor={`action-note-${item._id}`}>{ACTION_NOTE_LABEL}</Label>
+                <Textarea
+                  id={`action-note-${item._id}`}
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder={ACTION_NOTE_PLACEHOLDER}
+                  maxLength={MAX_ACTION_NOTE}
+                  rows={2}
+                  autoFocus
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="ghost" size="xs" onClick={() => setPending(null)}>
+                  {CANCEL_BUTTON}
+                </Button>
+                <Button type="submit" size="xs">
+                  {ACTION_SAVE}
+                </Button>
+              </div>
+            </form>
+          ) : (
+            canEdit && (
+              <div className="flex flex-wrap gap-1">
+                {item.status === "open" ? (
+                  <>
+                    <Button type="button" variant="outline" size="xs" onClick={() => setPending({ status: "done" })}>
+                      {ACTION_DONE}
+                    </Button>
+                    <Button type="button" variant="outline" size="xs" onClick={() => setPending({ status: "dropped" })}>
+                      {ACTION_DROP}
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => actions!.onSetStatus(item._id, "open", undefined)}
+                  >
+                    {ACTION_REOPEN}
+                  </Button>
+                )}
+                <Button type="button" variant="ghost" size="xs" onClick={openEdit}>
+                  {ACTION_EDIT}
+                </Button>
+              </div>
+            )
+          )}
+        </>
+      )}
+      {canManage && (
+        <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+          <AlertDialogContent size="sm">
+            <AlertDialogHeader>
+              <AlertDialogTitle>{ACTION_DELETE}?</AlertDialogTitle>
+              <AlertDialogDescription>{item.text}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{CANCEL_BUTTON}</AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                onClick={() => {
+                  setConfirmDelete(false);
+                  actions!.onDelete(item._id);
+                }}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </li>
+  );
+}

--- a/src/components/retro/actions-panel.test.tsx
+++ b/src/components/retro/actions-panel.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * The retro's actions panel (spec §7, §13, ADR-0017): reachable at every
+ * stage, with the composer for attendees at every stage but `collect`,
+ * the roster to own the first item, and at `close` the facts line.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import type { StageKind } from "@/convex/model/retroFormats";
+import { ACTIONS_EMPTY, UNOWNED_ACTION, closeFacts } from "@/convex/retroCopy";
+import { ActionsPanel } from "./actions-panel";
+import type { ActionActions } from "./use-action-actions";
+
+afterEach(cleanup);
+
+const roomId = "r1" as Id<"rooms">;
+
+/** An empty retro's read: no items, its own roster all the same. */
+const empty: ActionsRead = {
+  items: [],
+  rooms: [
+    {
+      roomId,
+      name: "Sprint 12",
+      members: [
+        { userId: "u1" as Id<"users">, name: "Ada" },
+        { userId: "u2" as Id<"users">, name: "Grace" },
+      ],
+      attending: true,
+    },
+  ],
+};
+
+const item = (id: string, ownerId?: string): ActionsRead["items"][number] => ({
+  _id: id as Id<"retroActions">,
+  roomId,
+  roomName: "Sprint 12",
+  text: `Action ${id}`,
+  status: "open",
+  createdBy: "u1" as Id<"users">,
+  creatorName: "Ada",
+  createdAt: 1,
+  updatedAt: 1,
+  ...(ownerId ? { ownerId: ownerId as Id<"users">, ownerName: "Grace" } : {}),
+  rights: { edit: false, manage: false },
+});
+
+function acts(): ActionActions {
+  return { create: vi.fn(), edit: vi.fn(), setStatus: vi.fn(), assign: vi.fn(), remove: vi.fn() };
+}
+
+const panel = (stageKind: StageKind, read: ActionsRead = empty, actions: ActionActions | "reader" = acts()) =>
+  render(
+    <ActionsPanel roomId={roomId} read={read} stageKind={stageKind} actions={actions === "reader" ? undefined : actions} />
+  );
+
+describe("ActionsPanel", () => {
+  it.each<StageKind>(["review", "group", "vote", "discuss", "close"])(
+    "offers the composer to an attendee in %s",
+    (kind) => {
+      panel(kind);
+      expect(screen.getByTestId("action-composer")).toBeTruthy();
+    }
+  );
+
+  it("offers nothing that invites an action during collect (ADR-0017)", () => {
+    panel("collect");
+    expect(screen.queryByTestId("action-composer")).toBeNull();
+    expect(screen.getByTestId("actions-list").textContent).toBe(ACTIONS_EMPTY);
+  });
+
+  it("offers no composer to a Team reader", () => {
+    panel("close", empty, "reader");
+    expect(screen.queryByTestId("action-composer")).toBeNull();
+  });
+
+  it("lets the first item of a retro be owned: the roster is there before any item is", () => {
+    panel("discuss");
+    const picker = screen.getByRole("combobox", { name: "Owner" });
+    expect(within(picker).getAllByRole("option").map((o) => o.textContent)).toEqual([UNOWNED_ACTION, "Ada", "Grace"]);
+  });
+
+  it("at close states the facts: the count and the unowned, never a judgement", () => {
+    const read: ActionsRead = { ...empty, items: [item("a1"), item("a2", "u2"), item("a3")] };
+    panel("close", read);
+    const section = screen.getByTestId("actions-panel");
+    expect(section.getAttribute("data-count")).toBe("3");
+    expect(section.getAttribute("data-unowned")).toBe("2");
+    expect(screen.getByTestId("close-facts").textContent).toBe(closeFacts(3, 2));
+    expect(closeFacts(3, 2)).toBe("3 actions, 2 unowned");
+    cleanup();
+    panel("discuss", read);
+    expect(screen.queryByTestId("close-facts")).toBeNull();
+  });
+});

--- a/src/components/retro/actions-panel.tsx
+++ b/src/components/retro/actions-panel.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import { ACTIONS_EMPTY, ACTIONS_TITLE, closeFacts } from "@/convex/retroCopy";
+import { ActionList } from "./action-list";
+import { ActionComposer, type ActionSource } from "./action-composer";
+import { factsOf } from "./actions";
+import type { ActionActions, CreateActionInput } from "./use-action-actions";
+
+export interface ActionsPanelProps {
+  roomId: Id<"rooms">;
+  /** `retro.actions`; undefined while loading. */
+  read: ActionsRead | undefined;
+  /** Whether the shared pointer is in `close`: the facts line shows there (spec §7). */
+  atClose: boolean;
+  /** The writes; absent for a Team reader, who reads and never writes. */
+  actions?: ActionActions;
+  /** The composer's pre-filled source, from "Add action" on the walk's topic. */
+  source?: ActionSource;
+  onClearSource?: () => void;
+  className?: string;
+}
+
+/**
+ * The retro's actions panel (spec §13, ADR-0017): this retro's items at
+ * every stage, the composer for attendees, and at `close` the facts line
+ * "{n} actions, {m} unowned" and nothing about too many or too few. Counts
+ * come from the bounded read, never a stored counter (ADR-0024).
+ */
+export function ActionsPanel({ roomId, read, atClose, actions, source, onClearSource, className }: ActionsPanelProps) {
+  const facts = read ? factsOf(read.items) : undefined;
+  const members = read?.rooms.find((room) => room.roomId === roomId)?.members ?? [];
+  const onSubmit = actions ? (input: CreateActionInput) => actions.create(roomId, input) : undefined;
+  return (
+    <section
+      data-testid="actions-panel"
+      data-count={facts?.count ?? ""}
+      data-unowned={facts?.unowned ?? ""}
+      aria-label={ACTIONS_TITLE}
+      className={cn("flex flex-col gap-3 text-sm", className)}
+    >
+      <header className="flex flex-col gap-0.5">
+        <h2 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">{ACTIONS_TITLE}</h2>
+        {atClose && facts && (
+          <p data-testid="close-facts" className="font-medium tabular-nums">
+            {closeFacts(facts.count, facts.unowned)}
+          </p>
+        )}
+      </header>
+      {onSubmit && <ActionComposer members={members} source={source} onClearSource={onClearSource} onSubmit={onSubmit} />}
+      <ActionList read={read} empty={ACTIONS_EMPTY} actions={actions} testId="actions-list" />
+    </section>
+  );
+}

--- a/src/components/retro/actions-panel.tsx
+++ b/src/components/retro/actions-panel.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { ActionsRead } from "@/convex/model/retroActions";
+import type { StageKind } from "@/convex/model/retroFormats";
 import { ACTIONS_EMPTY, ACTIONS_TITLE, closeFacts } from "@/convex/retroCopy";
 import { ActionList } from "./action-list";
 import { ActionComposer, type ActionSource } from "./action-composer";
@@ -13,8 +14,8 @@ export interface ActionsPanelProps {
   roomId: Id<"rooms">;
   /** `retro.actions`; undefined while loading. */
   read: ActionsRead | undefined;
-  /** Whether the shared pointer is in `close`: the facts line shows there (spec §7). */
-  atClose: boolean;
+  /** The shared pointer's stage: the facts line shows at `close`, and `collect` offers no composer (spec §7, §13). */
+  stageKind: StageKind;
   /** The writes; absent for a Team reader, who reads and never writes. */
   actions?: ActionActions;
   /** The composer's pre-filled source, from "Add action" on the walk's topic. */
@@ -25,14 +26,18 @@ export interface ActionsPanelProps {
 
 /**
  * The retro's actions panel (spec §13, ADR-0017): this retro's items at
- * every stage, the composer for attendees, and at `close` the facts line
- * "{n} actions, {m} unowned" and nothing about too many or too few. Counts
- * come from the bounded read, never a stored counter (ADR-0024).
+ * every stage; the composer for attendees at every stage but `collect`,
+ * where nothing on the board invites an action though creation is never
+ * refused; and at `close` the facts line "{n} actions, {m} unowned" and
+ * nothing about too many or too few. Counts come from the bounded read,
+ * never a stored counter (ADR-0024).
  */
-export function ActionsPanel({ roomId, read, atClose, actions, source, onClearSource, className }: ActionsPanelProps) {
+export function ActionsPanel({ roomId, read, stageKind, actions, source, onClearSource, className }: ActionsPanelProps) {
+  const atClose = stageKind === "close";
   const facts = read ? factsOf(read.items) : undefined;
   const members = read?.rooms.find((room) => room.roomId === roomId)?.members ?? [];
-  const onSubmit = actions ? (input: CreateActionInput) => actions.create(roomId, input) : undefined;
+  const onSubmit =
+    actions && stageKind !== "collect" ? (input: CreateActionInput) => actions.create(roomId, input) : undefined;
   return (
     <section
       data-testid="actions-panel"

--- a/src/components/retro/actions.ts
+++ b/src/components/retro/actions.ts
@@ -1,0 +1,32 @@
+import { format } from "date-fns";
+import type { ActionRead } from "@/convex/model/retroActions";
+import { parseCollectUntil } from "./collect-until";
+
+/**
+ * The action item's rendering arithmetic (spec §13, ADR-0017), pure so the
+ * row, the panel and a node test share one rule.
+ */
+
+/** Overdue is a rendering state, not a status: `dueAt` past and still `open`. */
+export function isOverdue(item: Pick<ActionRead, "status" | "dueAt">, now: number): boolean {
+  return item.status === "open" && item.dueAt !== undefined && item.dueAt < now;
+}
+
+/** The close panel's facts (spec §19): how many, and how many unowned. Counts, never a judgement. */
+export function factsOf(items: readonly Pick<ActionRead, "ownerId">[]): { count: number; unowned: number } {
+  return {
+    count: items.length,
+    unowned: items.filter((item) => item.ownerId === undefined).length,
+  };
+}
+
+/** A due date as the `<input type="date">` holds it. */
+export function toDateInput(ms: number | undefined): string {
+  return ms === undefined ? "" : format(ms, "yyyy-MM-dd");
+}
+
+/** The date field's value as the end of that local day, the one reading the collect date uses too. */
+export const parseDueDate = parseCollectUntil;
+
+/** A due date as the row shows it. */
+export const formatDue = (ms: number) => format(ms, "d MMM");

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -3,13 +3,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ReactFlow, ReactFlowProvider, useStore, type Node, type NodeTypes, type ReactFlowInstance } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Plus, Users } from "lucide-react";
+import { ListChecks, Plus, Users } from "lucide-react";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import type { ResolvedDecision } from "@/convex/permissions";
 import type { UserWithPresence } from "@/hooks/useRoomPresence";
 import { CanvasDotsBackground } from "@/components/canvas-dots-background";
 import { Button } from "@/components/ui/button";
-import { ADD_CARD, FORMER_MEMBER, HIDDEN_CARD_LABEL, ROSTER_TITLE } from "@/convex/retroCopy";
+import { ACTIONS_TITLE, ADD_CARD, FORMER_MEMBER, HIDDEN_CARD_LABEL, ROSTER_TITLE } from "@/convex/retroCopy";
 import { currentStageOf } from "@/convex/model/retroFormats";
 import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
@@ -40,6 +40,11 @@ import { VoteBudget } from "./vote-budget";
 import type { TopicRef as WalkTopicRef, WalkRead } from "@/convex/model/walk";
 import type { WalkActions } from "./use-walk-actions";
 import { WalkPanel, type WalkPanelActions } from "./walk-panel";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import type { ActionActions } from "./use-action-actions";
+import { ActionsPanel } from "./actions-panel";
+import { ReviewPanel } from "./review-panel";
+import type { ActionSource } from "./action-composer";
 
 /** What an attendee brings to the board that a Team reader does not. */
 export interface BoardViewer {
@@ -56,6 +61,8 @@ export interface BoardViewer {
   dots?: DotActions;
   /** The walk's `stageFlow` acts (spec §12.2). */
   walk?: WalkActions;
+  /** The action item writes (spec §13); absent for a Team reader. */
+  actionItems?: ActionActions;
   /** Another person's card, and a cluster's rename, merge, tidy and dissolve, only under this decision (spec §4.2). */
   cardManagement: ResolvedDecision;
 }
@@ -80,6 +87,10 @@ interface RetroBoardProps {
   tally?: TallyRead;
   /** The walk as the board read projects it (spec §12.3), once one exists. */
   walk?: WalkRead;
+  /** This retro's action items (spec §13); undefined while loading. */
+  actions?: ActionsRead;
+  /** The carryover (spec §13): the Team's open items from other retros; undefined while loading or without a review entry. */
+  review?: ActionsRead;
   /** The header's menu, for attendees. */
   menu?: ReactNode;
   /** A line under the header: the non-attending Team reader's (ADR-0009). */
@@ -137,6 +148,12 @@ const noMoves = () => {};
  * entry it is keyed to: the panel beside the canvas, coverage on the
  * chips, Raise on any topic outside it, and a pan for whoever follows the
  * cursor. Go is `setCenter` on the topic's derived position.
+ *
+ * Action items (spec §13): one panel reachable at every stage, opened by
+ * itself when the shared pointer reaches `close`; "Add action" on the
+ * walk's current topic opens it with the source filled. The review panel
+ * foregrounds the Team's older open items while the viewed entry is
+ * `review`.
  */
 export function RetroBoard({
   name,
@@ -151,11 +168,15 @@ export function RetroBoard({
   banner,
   tally,
   walk,
+  actions,
+  review,
 }: RetroBoardProps) {
   const currentStage = currentStageOf(retro);
   /** The viewer's own view; null follows the shared pointer. */
   const [viewStageId, setViewStageId] = useState<string | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [pendingSource, setPendingSource] = useState<ActionSource | undefined>(undefined);
   const [composing, setComposing] = useState(false);
   const [level, setLevel] = useState<ZoomLevel>("detail");
   const isMobile = useIsMobile();
@@ -167,6 +188,13 @@ export function RetroBoard({
   useEffect(() => {
     document.title = `${name} | AgileKit`;
   }, [name]);
+
+  // The close entry foregrounds the actions panel (spec §7); a person may
+  // close it again, and it stays reachable from the header at any stage.
+  const atClose = currentStage.kind === "close";
+  useEffect(() => {
+    if (atClose) setActionsOpen(true);
+  }, [atClose]);
 
   const zones = useMemo(() => layoutZones(retro.format.prompts), [retro.format.prompts]);
 
@@ -443,8 +471,46 @@ export function RetroBoard({
         : undefined,
     [walkActions, stageFlow]
   );
+  const actionItems = viewer?.actionItems;
+  // "Add action" on the walk's current topic (spec §13): the panel opens
+  // with the source filled; the composer writes it.
+  const onAddAction = useMemo(
+    () =>
+      actionItems
+        ? (ref: WalkTopicRef) => {
+            setPendingSource({ ref, label: labelOf(ref) });
+            setActionsOpen(true);
+          }
+        : undefined,
+    [actionItems, labelOf]
+  );
+  const clearSource = useCallback(() => setPendingSource(undefined), []);
   const walkPanel = walkShown && (
-    <WalkPanel walk={walk} labelOf={labelOf} onGo={panTo} actions={walkPanelActions} />
+    <WalkPanel walk={walk} labelOf={labelOf} onGo={panTo} actions={walkPanelActions} onAddAction={onAddAction} />
+  );
+  const actionsPanel = actionsOpen && (
+    <ActionsPanel
+      roomId={retro.roomId}
+      read={actions}
+      atClose={atClose}
+      actions={actionItems}
+      source={pendingSource}
+      onClearSource={clearSource}
+    />
+  );
+  const reviewPanel = viewStage.kind === "review" && <ReviewPanel read={review} actions={actionItems} />;
+  const actionsToggle = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label={ACTIONS_TITLE}
+      aria-pressed={actionsOpen}
+      onClick={() => setActionsOpen((open) => !open)}
+    >
+      <ListChecks className="size-4" />
+      {actions !== undefined ? actions.items.length : ""}
+    </Button>
   );
 
   // Zones, then hulls (same z, later in order so they draw above), cards, chips.
@@ -607,8 +673,13 @@ export function RetroBoard({
         >
           {banner}
           {stageNav}
+          {reviewPanel && <div className="border-t pt-3">{reviewPanel}</div>}
           {walkPanel && <div className="border-t pt-3">{walkPanel}</div>}
-          {menu && <div className="flex justify-end">{menu}</div>}
+          <div className="flex justify-end gap-1">
+            {actionsToggle}
+            {menu}
+          </div>
+          {actionsPanel && <div className="border-t pt-3">{actionsPanel}</div>}
           {roster}
         </MobileChrome>
         {composer}
@@ -645,6 +716,7 @@ export function RetroBoard({
               <Users className="size-4" />
               {onlineCount !== undefined ? `${onlineCount}/${users.length}` : users.length}
             </Button>
+            {actionsToggle}
             {menu}
           </>
         }
@@ -675,8 +747,14 @@ export function RetroBoard({
             </Button>
           )}
         </div>
+        {reviewPanel && (
+          <aside className="w-80 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{reviewPanel}</aside>
+        )}
         {walkPanel && (
           <aside className="w-72 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{walkPanel}</aside>
+        )}
+        {actionsPanel && (
+          <aside className="w-80 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{actionsPanel}</aside>
         )}
         {rosterOpen && (
           <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{roster}</aside>

--- a/src/components/retro/retro-board.tsx
+++ b/src/components/retro/retro-board.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { ReactFlow, ReactFlowProvider, useStore, type Node, type NodeTypes, type ReactFlowInstance } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { ListChecks, Plus, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import type { ResolvedDecision } from "@/convex/permissions";
 import type { UserWithPresence } from "@/hooks/useRoomPresence";
@@ -15,7 +16,7 @@ import { RetroHeader, type RetroTeam } from "./retro-header";
 import { PromptZoneNodeView, type PromptZoneNode } from "./prompt-zone-node";
 import { layoutZones } from "./zones";
 import { StageNav, type StageControls } from "./stage-nav";
-import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
+import { StageEmptyState, emptyStageOf } from "./stage-empty-state";
 import { RetroRoster } from "./retro-roster";
 import { CardNodeView, type CardNode } from "./card-node";
 import { ClusterNodeView, type ClusterNode, type ClusterChipActions, type ClusterTarget } from "./cluster-node";
@@ -492,7 +493,7 @@ export function RetroBoard({
     <ActionsPanel
       roomId={retro.roomId}
       read={actions}
-      atClose={atClose}
+      stageKind={currentStage.kind}
       actions={actionItems}
       source={pendingSource}
       onClearSource={clearSource}
@@ -509,7 +510,6 @@ export function RetroBoard({
       onClick={() => setActionsOpen((open) => !open)}
     >
       <ListChecks className="size-4" />
-      {actions !== undefined ? actions.items.length : ""}
     </Button>
   );
 
@@ -639,6 +639,7 @@ export function RetroBoard({
     />
   );
 
+  const emptyStage = emptyStageOf(viewStage.kind, cards.length);
   const stageNav = (
     <StageNav
       stages={retro.stages}
@@ -659,7 +660,7 @@ export function RetroBoard({
         data-zoom-level={level}
         data-chrome="mobile"
       >
-        {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
+        {emptyStage && <StageEmptyState kind={emptyStage} />}
         {canvas}
         <MobileChrome
           name={name}
@@ -673,13 +674,13 @@ export function RetroBoard({
         >
           {banner}
           {stageNav}
-          {reviewPanel && <div className="border-t pt-3">{reviewPanel}</div>}
-          {walkPanel && <div className="border-t pt-3">{walkPanel}</div>}
+          {reviewPanel && <SheetSection>{reviewPanel}</SheetSection>}
+          {walkPanel && <SheetSection>{walkPanel}</SheetSection>}
           <div className="flex justify-end gap-1">
             {actionsToggle}
             {menu}
           </div>
-          {actionsPanel && <div className="border-t pt-3">{actionsPanel}</div>}
+          {actionsPanel && <SheetSection>{actionsPanel}</SheetSection>}
           {roster}
         </MobileChrome>
         {composer}
@@ -725,7 +726,7 @@ export function RetroBoard({
       {stageNav}
       <div className="relative flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1">
-          {isStageEmpty(viewStage.kind, cards.length) && <StageEmptyState kind={viewStage.kind} />}
+          {emptyStage && <StageEmptyState kind={emptyStage} />}
           {canvas}
           <div className="absolute top-3 left-3 flex flex-col items-start gap-2">
             {budget && <div className="rounded-lg border bg-white/95 px-2.5 py-1.5 shadow-md dark:bg-surface-2/95">{budget}</div>}
@@ -747,20 +748,26 @@ export function RetroBoard({
             </Button>
           )}
         </div>
-        {reviewPanel && (
-          <aside className="w-80 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{reviewPanel}</aside>
-        )}
-        {walkPanel && (
-          <aside className="w-72 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{walkPanel}</aside>
-        )}
-        {actionsPanel && (
-          <aside className="w-80 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{actionsPanel}</aside>
-        )}
-        {rosterOpen && (
-          <aside className="w-64 shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1">{roster}</aside>
-        )}
+        {reviewPanel && <BoardAside className="w-80">{reviewPanel}</BoardAside>}
+        {walkPanel && <BoardAside className="w-72">{walkPanel}</BoardAside>}
+        {actionsPanel && <BoardAside className="w-80">{actionsPanel}</BoardAside>}
+        {rosterOpen && <BoardAside className="w-64">{roster}</BoardAside>}
       </div>
       {composer}
     </div>
   );
+}
+
+/** One of the desktop chrome's side panels, right of the canvas. */
+function BoardAside({ className, children }: { className: string; children: React.ReactNode }) {
+  return (
+    <aside className={cn("shrink-0 overflow-y-auto border-l bg-white p-4 dark:bg-surface-1", className)}>
+      {children}
+    </aside>
+  );
+}
+
+/** One panel inside the phone's sheet, ruled off from the one above. */
+function SheetSection({ children }: { children: React.ReactNode }) {
+  return <div className="border-t pt-3">{children}</div>;
 }

--- a/src/components/retro/review-panel.test.tsx
+++ b/src/components/retro/review-panel.test.tsx
@@ -27,7 +27,7 @@ const read: ActionsRead = {
       rights: { edit: false, manage: false },
     },
   ],
-  rooms: [{ roomId: "r1" as Id<"rooms">, name: "Sprint 11", members: [] }],
+  rooms: [{ roomId: "r1" as Id<"rooms">, name: "Sprint 11", members: [], attending: false }],
 };
 
 describe("ReviewPanel", () => {

--- a/src/components/retro/review-panel.test.tsx
+++ b/src/components/retro/review-panel.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * The review stage's foreground (spec §7, §13, ADR-0017): the Team's open
+ * action items from earlier retros, each with the retro it came from, and
+ * the register's empty state when there are none.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import { REVIEW_EMPTY } from "@/convex/retroCopy";
+import { ReviewPanel } from "./review-panel";
+
+afterEach(cleanup);
+
+const read: ActionsRead = {
+  items: [
+    {
+      _id: "a1" as Id<"retroActions">,
+      roomId: "r1" as Id<"rooms">,
+      roomName: "Sprint 11",
+      text: "Write the runbook",
+      status: "open",
+      createdBy: "u1" as Id<"users">,
+      creatorName: "Ada",
+      createdAt: 1,
+      updatedAt: 1,
+      rights: { edit: false, manage: false },
+    },
+  ],
+  rooms: [{ roomId: "r1" as Id<"rooms">, name: "Sprint 11", members: [] }],
+};
+
+describe("ReviewPanel", () => {
+  it("reads the register's empty state with no open actions from earlier retros", () => {
+    render(<ReviewPanel read={{ items: [], rooms: [] }} />);
+    const panel = screen.getByTestId("review-panel");
+    expect(panel.getAttribute("data-count")).toBe("0");
+    expect(screen.getByText(REVIEW_EMPTY)).toBeTruthy();
+    expect(REVIEW_EMPTY).toBe("No open actions from earlier retros");
+  });
+
+  it("lists the items with the retro each came from", () => {
+    render(<ReviewPanel read={read} />);
+    expect(screen.getByTestId("review-panel").getAttribute("data-count")).toBe("1");
+    expect(screen.getByText("Write the runbook")).toBeTruthy();
+    expect(screen.getByText(/Sprint 11/)).toBeTruthy();
+    expect(screen.queryByText(REVIEW_EMPTY)).toBeNull();
+  });
+
+  it("shows nothing but a placeholder while loading", () => {
+    render(<ReviewPanel read={undefined} />);
+    expect(screen.getByTestId("review-panel").getAttribute("data-count")).toBe("");
+    expect(screen.queryByText(REVIEW_EMPTY)).toBeNull();
+  });
+});

--- a/src/components/retro/review-panel.tsx
+++ b/src/components/retro/review-panel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { ActionsRead } from "@/convex/model/retroActions";
+import { REVIEW_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
+import { ActionList } from "./action-list";
+import type { ActionActions } from "./use-action-actions";
+
+export interface ReviewPanelProps {
+  /** `retro.reviewActions`; undefined while loading. */
+  read: ActionsRead | undefined;
+  /** The writes; absent for a Team reader. */
+  actions?: ActionActions;
+  className?: string;
+}
+
+/**
+ * The review stage's foreground (spec §7, §13; ADR-0017): the Team's open
+ * action items from earlier retros, oldest first, each naming the retro it
+ * came from, with done, drop, edit and reassign in place for whoever may.
+ * Nothing is copied; an item has one home. Empty for a teamless retro.
+ */
+export function ReviewPanel({ read, actions, className }: ReviewPanelProps) {
+  return (
+    <section
+      data-testid="review-panel"
+      data-count={read === undefined ? "" : String(read.items.length)}
+      aria-label={STAGE_LABELS.review}
+      className={cn("flex flex-col gap-3 text-sm", className)}
+    >
+      <h2 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">{STAGE_LABELS.review}</h2>
+      <ActionList read={read} empty={REVIEW_EMPTY} showRoom actions={actions} testId="review-list" />
+    </section>
+  );
+}

--- a/src/components/retro/stage-empty-state.test.tsx
+++ b/src/components/retro/stage-empty-state.test.tsx
@@ -27,11 +27,11 @@ describe("StageEmptyState", () => {
     expect(STAGE_EMPTY.review).toBe("No open actions from earlier retros");
   });
 
-  it("a card stage is empty only with no cards; review and close read empty until action items land (spec §7)", () => {
+  it("a card stage is empty only with no cards; review and close speak through their panels (spec §7, §13)", () => {
     expect(isStageEmpty("collect", 0)).toBe(true);
     expect(isStageEmpty("collect", 1)).toBe(false);
     expect(isStageEmpty("group", 2)).toBe(false);
-    expect(isStageEmpty("review", 5)).toBe(true);
-    expect(isStageEmpty("close", 5)).toBe(true);
+    expect(isStageEmpty("review", 0)).toBe(false);
+    expect(isStageEmpty("close", 0)).toBe(false);
   });
 });

--- a/src/components/retro/stage-empty-state.test.tsx
+++ b/src/components/retro/stage-empty-state.test.tsx
@@ -1,17 +1,16 @@
 /**
- * Every stage kind renders an empty state, never a lock (ADR-0010): a
- * line naming the stage and explaining what is not there yet, with the
- * review line from the copy register.
+ * Every card stage renders an empty state, never a lock (ADR-0010): a line
+ * naming the stage and explaining what is not there yet. Review and close
+ * speak through their panels (spec §13).
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
-import { StageEmptyState, isStageEmpty } from "./stage-empty-state";
-import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
-import type { StageKind } from "@/convex/model/retroFormats";
+import { StageEmptyState, emptyStageOf } from "./stage-empty-state";
+import { STAGE_EMPTY, STAGE_LABELS, type CardStageKind } from "@/convex/retroCopy";
 
 afterEach(cleanup);
 
-const KINDS: StageKind[] = ["collect", "review", "group", "vote", "discuss", "close"];
+const KINDS: CardStageKind[] = ["collect", "group", "vote", "discuss"];
 
 describe("StageEmptyState", () => {
   it.each(KINDS)("%s reads its label and its line", (kind) => {
@@ -23,15 +22,11 @@ describe("StageEmptyState", () => {
     expect(state.textContent?.toLowerCase()).not.toMatch(/lock/);
   });
 
-  it("the review line is the register's", () => {
-    expect(STAGE_EMPTY.review).toBe("No open actions from earlier retros");
-  });
-
   it("a card stage is empty only with no cards; review and close speak through their panels (spec §7, §13)", () => {
-    expect(isStageEmpty("collect", 0)).toBe(true);
-    expect(isStageEmpty("collect", 1)).toBe(false);
-    expect(isStageEmpty("group", 2)).toBe(false);
-    expect(isStageEmpty("review", 0)).toBe(false);
-    expect(isStageEmpty("close", 0)).toBe(false);
+    expect(emptyStageOf("collect", 0)).toBe("collect");
+    expect(emptyStageOf("collect", 1)).toBeUndefined();
+    expect(emptyStageOf("group", 2)).toBeUndefined();
+    expect(emptyStageOf("review", 0)).toBeUndefined();
+    expect(emptyStageOf("close", 0)).toBeUndefined();
   });
 });

--- a/src/components/retro/stage-empty-state.tsx
+++ b/src/components/retro/stage-empty-state.tsx
@@ -1,17 +1,16 @@
 import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
 
-/** The kinds whose line is about cards; the others speak of action items. */
+/** The kinds whose line is about cards; `review` and `close` speak through their panels. */
 const CARD_KINDS: ReadonlySet<StageKind> = new Set(["collect", "group", "vote", "discuss"]);
 
 /**
  * Whether the viewed entry has nothing in it (spec §7): no cards for a
- * card stage; for `review` and `close` the line is about action items,
- * which arrive with their own ticket, so until then those entries always
- * read empty.
+ * card stage. `review` and `close` never read empty here: their panels
+ * carry the register's line for no action items (spec §13).
  */
 export function isStageEmpty(kind: StageKind, cardCount: number): boolean {
-  return CARD_KINDS.has(kind) ? cardCount === 0 : true;
+  return CARD_KINDS.has(kind) && cardCount === 0;
 }
 
 /**

--- a/src/components/retro/stage-empty-state.tsx
+++ b/src/components/retro/stage-empty-state.tsx
@@ -1,23 +1,22 @@
-import { STAGE_EMPTY, STAGE_LABELS } from "@/convex/retroCopy";
+import { STAGE_EMPTY, STAGE_LABELS, type CardStageKind } from "@/convex/retroCopy";
 import type { StageKind } from "@/convex/model/retroFormats";
 
-/** The kinds whose line is about cards; `review` and `close` speak through their panels. */
-const CARD_KINDS: ReadonlySet<StageKind> = new Set(["collect", "group", "vote", "discuss"]);
+const isCardStage = (kind: StageKind): kind is CardStageKind => kind in STAGE_EMPTY;
 
 /**
- * Whether the viewed entry has nothing in it (spec §7): no cards for a
- * card stage. `review` and `close` never read empty here: their panels
- * carry the register's line for no action items (spec §13).
+ * The card stage the viewed entry is empty in (spec §7): a card stage with
+ * no cards. `review` and `close` never read empty here: their panels carry
+ * the register's line for no action items (spec §13).
  */
-export function isStageEmpty(kind: StageKind, cardCount: number): boolean {
-  return CARD_KINDS.has(kind) && cardCount === 0;
+export function emptyStageOf(kind: StageKind, cardCount: number): CardStageKind | undefined {
+  return isCardStage(kind) && cardCount === 0 ? kind : undefined;
 }
 
 /**
  * A stage with nothing in it (ADR-0010): an explanation over the canvas,
  * never a lock.
  */
-export function StageEmptyState({ kind }: { kind: StageKind }) {
+export function StageEmptyState({ kind }: { kind: CardStageKind }) {
   return (
     <div
       data-testid="stage-empty-state"

--- a/src/components/retro/use-action-actions.ts
+++ b/src/components/retro/use-action-actions.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { ActionStatus } from "@/convex/model/retroActions";
+import type { TopicRef } from "@/convex/model/walk";
+import { failureCopy } from "@/lib/write-retry";
+import { toast } from "@/lib/toast";
+import { ACTION_ACT_FAILED } from "@/convex/retroCopy";
+
+export interface CreateActionInput {
+  text: string;
+  ownerId?: Id<"users">;
+  dueAt?: number;
+  source?: TopicRef;
+}
+
+/**
+ * The action item writes (spec §13), each bound to a room per call so one
+ * hook serves the retro's panel, the review (other rooms' items) and the
+ * team page. None is optimistic: the list settles on the server's answer,
+ * and a refusal surfaces as its copy.
+ */
+export interface ActionActions {
+  /** Resolves to whether the item was written. */
+  create: (roomId: Id<"rooms">, input: CreateActionInput) => Promise<boolean>;
+  edit: (roomId: Id<"rooms">, actionId: Id<"retroActions">, text: string, dueAt: number | null) => void;
+  setStatus: (roomId: Id<"rooms">, actionId: Id<"retroActions">, status: ActionStatus, note?: string) => void;
+  assign: (roomId: Id<"rooms">, actionId: Id<"retroActions">, ownerId: Id<"users"> | undefined) => void;
+  remove: (roomId: Id<"rooms">, actionId: Id<"retroActions">) => void;
+}
+
+async function act(write: Promise<unknown>): Promise<boolean> {
+  try {
+    await write;
+    return true;
+  } catch (error) {
+    toast.error(failureCopy(error, ACTION_ACT_FAILED));
+    return false;
+  }
+}
+
+export function useActionActions(): ActionActions {
+  const createAction = useMutation(api.retro.createAction);
+  const updateAction = useMutation(api.retro.updateAction);
+  const setActionStatus = useMutation(api.retro.setActionStatus);
+  const assignAction = useMutation(api.retro.assignAction);
+  const deleteAction = useMutation(api.retro.deleteAction);
+
+  const create = useCallback<ActionActions["create"]>(
+    (roomId, input) => act(createAction({ roomId, ...input })),
+    [createAction]
+  );
+  const edit = useCallback<ActionActions["edit"]>(
+    (roomId, actionId, text, dueAt) => void act(updateAction({ roomId, actionId, text, dueAt })),
+    [updateAction]
+  );
+  const setStatus = useCallback<ActionActions["setStatus"]>(
+    (roomId, actionId, status, note) =>
+      void act(setActionStatus({ roomId, actionId, status, ...(note !== undefined ? { note } : {}) })),
+    [setActionStatus]
+  );
+  const assign = useCallback<ActionActions["assign"]>(
+    (roomId, actionId, ownerId) =>
+      void act(assignAction({ roomId, actionId, ...(ownerId !== undefined ? { ownerId } : {}) })),
+    [assignAction]
+  );
+  const remove = useCallback<ActionActions["remove"]>(
+    (roomId, actionId) => void act(deleteAction({ roomId, actionId })),
+    [deleteAction]
+  );
+
+  return useMemo(() => ({ create, edit, setStatus, assign, remove }), [create, edit, setStatus, assign, remove]);
+}

--- a/src/components/retro/walk-panel.tsx
+++ b/src/components/retro/walk-panel.tsx
@@ -8,6 +8,7 @@ import type { ResolvedDecision } from "@/convex/permissions";
 import { permissionProps } from "@/hooks/usePermissions";
 import type { OutsideTopic, TopicRef, WalkRead } from "@/convex/model/walk";
 import {
+  ADD_ACTION,
   COVERED_LABEL,
   CURRENT_TOPIC,
   GO_TO_TOPIC,
@@ -35,6 +36,8 @@ export interface WalkPanelProps {
   /** Pan this viewer to the topic; open to everyone. */
   onGo: (ref: TopicRef) => void;
   actions?: WalkPanelActions;
+  /** "Add action" on the current topic (spec §13): opens the composer with the source filled; absent for a Team reader. */
+  onAddAction?: (ref: TopicRef) => void;
   className?: string;
 }
 
@@ -47,7 +50,7 @@ export interface WalkPanelProps {
  * Raise. Go on an order row moves the shared cursor for a `stageFlow`
  * holder and pans for anyone else; nothing here is optimistic.
  */
-export function WalkPanel({ walk, labelOf, onGo, actions, className }: WalkPanelProps) {
+export function WalkPanel({ walk, labelOf, onGo, actions, onAddAction, className }: WalkPanelProps) {
   const allowed = actions?.decision.allowed === true;
   const deny = actions ? permissionProps(actions.decision) : {};
   const late = walk.outside.filter((topic) => topic.late);
@@ -106,6 +109,11 @@ export function WalkPanel({ walk, labelOf, onGo, actions, className }: WalkPanel
                   <span className="rounded-full bg-blue-100 px-1.5 text-[10px] font-semibold text-blue-800 uppercase dark:bg-status-info-bg dark:text-status-info-fg">
                     {CURRENT_TOPIC}
                   </span>
+                )}
+                {current && onAddAction && (
+                  <Button type="button" variant="outline" size="xs" onClick={() => onAddAction(entry.ref)}>
+                    {ADD_ACTION}
+                  </Button>
                 )}
                 <Button
                   type="button"


### PR DESCRIPTION
Closes #296.

## What

- `convex/model/retroActions.ts`: create (never refused, any stage), edit, done/dropped/open with a note only when leaving open, assign and delete under `actionManagement`, the owner's own rights, source re-pointing; reads for the retro's panel, `retro.reviewActions` (the Team's open items from other retros, oldest first, bounded, empty when teamless) and `teams.openActions`.
- Cluster dissolve and card delete null `source`, merge re-points it to the survivor, `linkAnonymousToPermanent` re-points `ownerId`/`createdBy`, adoption stamps `teamId`, every mutation goes through the activity chokepoint.
- Client: actions panel reachable at every stage (no composer during `collect`), "Add action" on the walk's current topic prefilling the source, the review panel, the team page's open-actions list with done/drop/edit/reassign in place, "Nobody owns this yet", Overdue, "Former member", the close facts line "{n} actions, {m} unowned".
- Copy in `convex/retroCopy.ts` (spec §19).

## Tests

- convex-test: `convex/retroActions.test.ts` (23) plus the activity chokepoint proof.
- jsdom: action row, actions panel (collect rule, first-item roster, close facts), review panel empty state, team page list.
- Full suite 1020 passing, `ts:check` and `lint` clean.
- Hand-verified the round trip in the browser: discuss → add action with source → team page → done with note → retro panel and close facts → reopen → next retro's review lists it.

Playwright scenario 8 belongs to #301.

https://claude.ai/code/session_01V4jznJuY1icau3JpaYv5xd
