### PR TITLE
feat(retro): Markdown and JSON exports, delete account (#299)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as model_retro from "../model/retro.js";
 import type * as model_retroActions from "../model/retroActions.js";
 import type * as model_retroCards from "../model/retroCards.js";
 import type * as model_retroClusters from "../model/retroClusters.js";
+import type * as model_retroExport from "../model/retroExport.js";
 import type * as model_retroFormats from "../model/retroFormats.js";
 import type * as model_retroNudge from "../model/retroNudge.js";
 import type * as model_retroReminders from "../model/retroReminders.js";
@@ -122,6 +123,7 @@ declare const fullApi: ApiFromModules<{
   "model/retroActions": typeof model_retroActions;
   "model/retroCards": typeof model_retroCards;
   "model/retroClusters": typeof model_retroClusters;
+  "model/retroExport": typeof model_retroExport;
   "model/retroFormats": typeof model_retroFormats;
   "model/retroNudge": typeof model_retroNudge;
   "model/retroReminders": typeof model_retroReminders;

--- a/convex/accountDeletion.test.ts
+++ b/convex/accountDeletion.test.ts
@@ -1,0 +1,119 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+import { FORMER_MEMBER } from "./retroCopy";
+
+// Account deletion (spec §15.2, ADR-0019): the user row goes and the
+// content stays. `authorId`, `voterId`, `ownerId` and `createdBy` dangle
+// and render "Former member"; a team retro whose owner deletes their
+// account enters lockdown and is recovered by `claim`. The auth provider's
+// record is not this module's to touch.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string, accountType?: "anonymous" | "permanent") =>
+  seedNamedUser(t, authUserId, authUserId, accountType);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+const joinRoom = (t: T, roomId: Id<"rooms">, subject: string) =>
+  as(t, subject).mutation(api.users.join, { roomId, name: subject, authUserId: subject });
+
+/**
+ * A Team with two admins ("admin" and "leaver", so the leaver's deletion
+ * is not refused by the last-admin rule) and a team retro the leaver owns,
+ * with a card, a dot and an action item of theirs in it; the admin attends.
+ */
+async function seedLeaverRetro(t: T) {
+  await seedUser(t, "admin", "permanent");
+  const leaverId = await seedUser(t, "leaver", "permanent");
+  const teamId = await as(t, "leaver").mutation(api.teams.create, { name: "Acme" });
+  const team = (await t.run((ctx) => ctx.db.get(teamId)))!;
+  await as(t, "admin").mutation(api.teams.joinByInvite, { inviteToken: team.inviteToken });
+  await as(t, "leaver").mutation(api.teams.promote, { teamId, targetUserId: (await t.run((ctx) => ctx.db.query("users").withIndex("by_auth_user", (q) => q.eq("authUserId", "admin")).unique()))!._id });
+  const roomId = await as(t, "leaver").mutation(api.retro.create, { name: "R", formatName: DEFAULT_RETRO_FORMAT.name, teamId });
+  await joinRoom(t, roomId, "admin");
+  const retro = await retroRow(t, roomId);
+  const byKind = (kind: string) => retro.stages.find((s) => s.kind === kind)!;
+  const { cardId } = await as(t, "leaver").mutation(api.retro.createCard, {
+    roomId,
+    clientId: "c1",
+    text: "Mine",
+    promptId: retro.format.prompts[0].id,
+    position: { x: 0, y: 0 },
+  });
+  await as(t, "leaver").mutation(api.retro.advance, { roomId, toStageId: byKind("vote").id });
+  await as(t, "leaver").mutation(api.retro.placeDot, { roomId, target: { kind: "card", id: cardId } });
+  await as(t, "leaver").mutation(api.retro.advance, { roomId, toStageId: byKind("close").id });
+  const actionId = await as(t, "leaver").mutation(api.retro.createAction, { roomId, text: "Do it", ownerId: leaverId });
+  return { teamId, roomId, leaverId, cardId, actionId };
+}
+
+describe("deleting a permanent account (spec §15.2)", () => {
+  it("removes the user row and their memberships, and leaves cards, dots and action items in place with dangling references", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, roomId, leaverId, cardId, actionId } = await seedLeaverRetro(t);
+
+    await as(t, "leaver").mutation(api.users.deleteUser, {});
+
+    expect(await t.run((ctx) => ctx.db.get(leaverId))).toBeNull();
+    const card = (await t.run((ctx) => ctx.db.get(cardId)))!;
+    expect(card.text).toBe("Mine");
+    expect(card.authorId).toBe(leaverId);
+    const dots = await t.run((ctx) => ctx.db.query("retroVotes").withIndex("by_voter", (q) => q.eq("voterId", leaverId)).collect());
+    expect(dots).toHaveLength(1);
+    const action = (await t.run((ctx) => ctx.db.get(actionId)))!;
+    expect(action.ownerId).toBe(leaverId);
+    expect(action.createdBy).toBe(leaverId);
+    const room = (await t.run((ctx) => ctx.db.get(roomId)))!;
+    expect(room.ownerId).toBe(leaverId);
+    expect(room.teamId).toBe(teamId);
+    expect(
+      await t.run((ctx) => ctx.db.query("roomMemberships").withIndex("by_user", (q) => q.eq("userId", leaverId)).collect())
+    ).toEqual([]);
+    expect(
+      await t.run((ctx) => ctx.db.query("teamMemberships").withIndex("by_user", (q) => q.eq("userId", leaverId)).collect())
+    ).toEqual([]);
+  });
+
+  it("the reads render the dangling references as Former member: the action's owner and creator, the export's author", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId, leaverId } = await seedLeaverRetro(t);
+    await as(t, "leaver").mutation(api.users.deleteUser, {});
+
+    const actions = await as(t, "admin").query(api.retro.actions, { roomId });
+    expect(actions.items[0]).toMatchObject({ ownerId: leaverId, ownerName: FORMER_MEMBER, creatorName: FORMER_MEMBER });
+    const board = await as(t, "admin").query(api.retro.board, { roomId });
+    expect(board.cards[0]).toMatchObject({ text: "Mine", authorId: leaverId });
+    const exported = await as(t, "admin").query(api.retro.exportMarkdown, { roomId });
+    expect(exported.content).toContain(`- Mine — ${FORMER_MEMBER}`);
+    expect(exported.content).toContain(`Owner: ${FORMER_MEMBER}`);
+  });
+
+  it("a team retro whose owner deleted their account is in lockdown and a team admin recovers it by claim", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedLeaverRetro(t);
+    await as(t, "leaver").mutation(api.users.deleteUser, {});
+
+    const shell = await t.query(api.rooms.get, { roomId });
+    expect(shell?.isOwnerAbsent).toBe(true);
+
+    await as(t, "admin").mutation(api.retro.claim, { roomId });
+    const adminId = (await t.run((ctx) => ctx.db.query("users").withIndex("by_auth_user", (q) => q.eq("authUserId", "admin")).unique()))!._id;
+    expect((await t.run((ctx) => ctx.db.get(roomId)))!.ownerId).toBe(adminId);
+    expect((await t.query(api.rooms.get, { roomId }))?.isOwnerAbsent).toBe(false);
+  });
+});

--- a/convex/model/retro.ts
+++ b/convex/model/retro.ts
@@ -1104,7 +1104,7 @@ export interface HistoryRow {
 const MAX_COUNTED_ACTIONS = 500;
 
 /** Count a bounded read of action rows by status. */
-export function countByStatus(rows: readonly Pick<Doc<"retroActions">, "status">[]): ActionCounts {
+function countByStatus(rows: readonly Pick<Doc<"retroActions">, "status">[]): ActionCounts {
   const counts: ActionCounts = { open: 0, done: 0, dropped: 0 };
   for (const row of rows) counts[row.status] += 1;
   return counts;

--- a/convex/model/retroExport.ts
+++ b/convex/model/retroExport.ts
@@ -125,11 +125,12 @@ async function dotCounts(
 
 /** The display names of the referenced people, one read each; a missing row renders by the register. */
 async function namesOf(ctx: QueryCtx, ids: Iterable<Id<"users">>): Promise<Map<Id<"users">, string>> {
+  const unique = [...new Set(ids)];
+  const users = await Promise.all(unique.map((id) => ctx.db.get(id)));
   const names = new Map<Id<"users">, string>();
-  for (const id of new Set(ids)) {
-    const user = await ctx.db.get(id);
-    if (user) names.set(id, user.name);
-  }
+  users.forEach((user, i) => {
+    if (user) names.set(unique[i], user.name);
+  });
   return names;
 }
 

--- a/convex/model/retroExport.ts
+++ b/convex/model/retroExport.ts
@@ -12,7 +12,7 @@ import {
   type Reader,
 } from "./retro";
 import { MAX_ACTION_ROWS, projectActions, type ActionRead } from "./retroActions";
-import { MAX_VOTE_ROWS, tally, tallyEntryOf, topicKey } from "./retroVotes";
+import { MAX_VOTE_ROWS, countDots, tally, tallyEntryOf } from "./retroVotes";
 import { currentStageOf, type StageEntry } from "./retroFormats";
 import { liveTopics, projectWalk, topicId, type TopicRef } from "./walk";
 import {
@@ -104,15 +104,15 @@ function actionLine(action: Doc<"retroActions">, names: Map<Id<"users">, string>
 
 /**
  * The dots the export counts (spec §15.3): the entry the board's tally
- * reads (`tallyEntryOf`), and only while the current entry shows its
- * tally, so a hidden vote round exports no counts. A dot on a member card
- * counts for its cluster (ADR-0016). Voters never leave this function.
+ * reads (`tallyEntryOf`), through the tally's own `countDots`, and only
+ * while the current entry shows its tally, so a hidden vote round exports
+ * no counts. Null when the retro has had no vote round to count.
  */
 async function dotCounts(
   ctx: QueryCtx,
   retro: Doc<"retros">,
   cards: readonly Doc<"retroCards">[]
-): Promise<Map<string, number> | null> {
+): Promise<Record<string, number> | null> {
   if (currentStageOf(retro).tallyVisible !== "visible") return null;
   const entry = tallyEntryOf(retro);
   if (entry.voteBudget === undefined) return null;
@@ -120,18 +120,7 @@ async function dotCounts(
     .query("retroVotes")
     .withIndex("by_room_entry", (q) => q.eq("roomId", retro.roomId).eq("stageEntryId", entry.id))
     .take(MAX_VOTE_ROWS);
-  const clusterOf = new Map<string, Id<"retroClusters">>();
-  for (const card of cards) {
-    if (card.clusterId !== undefined) clusterOf.set(card._id, card.clusterId);
-  }
-  const counts = new Map<string, number>();
-  const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1);
-  for (const row of rows) {
-    bump(topicKey(row.target));
-    const clusterId = row.target.kind === "card" ? clusterOf.get(row.target.id) : undefined;
-    if (clusterId !== undefined) bump(clusterId);
-  }
-  return counts;
+  return countDots(rows, cards);
 }
 
 /** The display names of the referenced people, one read each; a missing row renders by the register. */
@@ -190,7 +179,7 @@ export async function exportMarkdown(
       : sortedCards.filter((card) => card._id === ref.id);
 
   const topicSection = (ref: TopicRef, tags: string[]): string[] => {
-    const votes = counts ? [votesCount(counts.get(topicId(ref)) ?? 0)] : [];
+    const votes = counts ? [votesCount(counts[topicId(ref)] ?? 0)] : [];
     const lines = [`### ${[topicTitle(ref, clusters, projected), ...tags, ...votes].join(" · ")}`, ""];
     for (const prompt of retro.format.prompts) {
       const answers = cardsOf(ref).filter((card) => card.promptId === prompt.id);
@@ -255,7 +244,10 @@ export interface RetroExport {
 /**
  * `retro.exportBoard` (spec §15.4): the same shape `retro.board` returns
  * for that reader, with the tally's counts and the names beside it. The
- * guard (`requireRoomReader`) has passed.
+ * board read is the identity-free one (spec §9): the reader's own hidden
+ * text travels in `retro.mine` on the board and in the Markdown export,
+ * not here, so the file is what the board shows the Team. The guard
+ * (`requireRoomReader`) has passed.
  */
 export async function exportBoard(ctx: QueryCtx, room: Doc<"rooms">, readerId: Id<"users">): Promise<RetroExport> {
   const [read, counts] = await Promise.all([board(ctx, room._id), tally(ctx, { roomId: room._id, viewerId: readerId })]);

--- a/convex/model/retroExport.ts
+++ b/convex/model/retroExport.ts
@@ -1,0 +1,315 @@
+import { QueryCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import {
+  MAX_BOARD_ROWS,
+  board,
+  policyOf,
+  projectCard,
+  requireRetro,
+  type BoardRead,
+  type ProjectedCard,
+  type ProjectionPolicy,
+  type Reader,
+} from "./retro";
+import { MAX_ACTION_ROWS, projectActions, type ActionRead } from "./retroActions";
+import { MAX_VOTE_ROWS, tally, tallyEntryOf, topicKey } from "./retroVotes";
+import { currentStageOf, type StageEntry } from "./retroFormats";
+import { liveTopics, projectWalk, topicId, type TopicRef } from "./walk";
+import {
+  ACTION_STATUS_LABELS,
+  ACTIONS_TITLE,
+  COVERED_LABEL,
+  EXPORT_CREATED,
+  EXPORT_DISCUSSION,
+  EXPORT_FORMAT,
+  EXPORT_NEW,
+  EXPORT_NO_TEAM,
+  EXPORT_NOT_COVERED,
+  EXPORT_OUTSIDE,
+  EXPORT_STAGES_WALKED,
+  EXPORT_TEAM,
+  EXPORT_TOPICS,
+  FORMER_MEMBER,
+  HIDDEN_CARD_EXPORT,
+  STAGE_LABELS,
+  UNOWNED_ACTION,
+  dueOn,
+  noteLine,
+  ownedBy,
+  votesCount,
+} from "../retroCopy";
+
+/**
+ * Export (spec §15.3, §15.4; ADR-0019): a projection of read access and
+ * never more. One retro as Markdown, for the people who were not there;
+ * the JSON history is assembled by `teams.exportHistory` from the board
+ * read itself. Everything here runs through `projectCard` with the
+ * requester as reader (own cards in full in a named retro, silhouettes for
+ * the rest while the entry hides cards), the attribution projection (no
+ * author in an anonymous retro) and never names a voter: dots are counts,
+ * and only while the board shows its tally.
+ */
+
+export interface MarkdownExport {
+  filename: string;
+  content: string;
+}
+
+/** A file name the browser will take: the room's name with path and shell characters replaced. */
+export function exportFilename(name: string, extension: string): string {
+  const safe = name.replace(/[\\/:*?"<>|]/g, "-").trim();
+  return `${safe || "retro"}.${extension}`;
+}
+
+const isoDate = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+const isFullCard = (card: ProjectedCard): card is ProjectedCard & { text: string; authorId?: Id<"users"> } =>
+  "text" in card;
+
+/** A card's line: its text and, in a named retro, its author; a silhouette has neither (ADR-0015). */
+function cardLine(card: ProjectedCard, names: Map<Id<"users">, string>): string {
+  if (!isFullCard(card)) return `- ${HIDDEN_CARD_EXPORT}`;
+  const author = card.authorId !== undefined ? ` — ${names.get(card.authorId) ?? FORMER_MEMBER}` : "";
+  return `- ${card.text}${author}`;
+}
+
+/** A topic's title: a cluster's name, a lone card's text through the projection. */
+function topicTitle(
+  ref: TopicRef,
+  clusters: Map<Id<"retroClusters">, Doc<"retroClusters">>,
+  projected: Map<Id<"retroCards">, ProjectedCard>
+): string {
+  if (ref.kind === "cluster") return clusters.get(ref.id)?.name ?? "";
+  const card = projected.get(ref.id);
+  return card && isFullCard(card) ? card.text : HIDDEN_CARD_EXPORT;
+}
+
+/** The stages the shared pointer has passed, in list order up to and including the current entry. */
+export function stagesWalked(stages: readonly StageEntry[], currentStageId: string): string[] {
+  const index = stages.findIndex((stage) => stage.id === currentStageId);
+  return stages.slice(0, index + 1).map((stage) => STAGE_LABELS[stage.kind]);
+}
+
+const STATUS_MARK: Record<Doc<"retroActions">["status"], string> = { open: "[ ]", done: "[x]", dropped: "[-]" };
+
+function actionLine(action: Doc<"retroActions">, names: Map<Id<"users">, string>): string {
+  const parts = [
+    action.ownerId !== undefined ? ownedBy(names.get(action.ownerId) ?? FORMER_MEMBER) : UNOWNED_ACTION,
+    ...(action.dueAt !== undefined ? [dueOn(isoDate(action.dueAt))] : []),
+    ACTION_STATUS_LABELS[action.status],
+    ...(action.note ? [noteLine(action.note)] : []),
+  ];
+  return `- ${STATUS_MARK[action.status]} ${action.text} — ${parts.join(" · ")}`;
+}
+
+/**
+ * The dots the export counts (spec §15.3): the entry the board's tally
+ * reads (`tallyEntryOf`), and only while the current entry shows its
+ * tally, so a hidden vote round exports no counts. A dot on a member card
+ * counts for its cluster (ADR-0016). Voters never leave this function.
+ */
+async function dotCounts(
+  ctx: QueryCtx,
+  retro: Doc<"retros">,
+  cards: readonly Doc<"retroCards">[]
+): Promise<Map<string, number> | null> {
+  if (currentStageOf(retro).tallyVisible !== "visible") return null;
+  const entry = tallyEntryOf(retro);
+  if (entry.voteBudget === undefined) return null;
+  const rows = await ctx.db
+    .query("retroVotes")
+    .withIndex("by_room_entry", (q) => q.eq("roomId", retro.roomId).eq("stageEntryId", entry.id))
+    .take(MAX_VOTE_ROWS);
+  const clusterOf = new Map<string, Id<"retroClusters">>();
+  for (const card of cards) {
+    if (card.clusterId !== undefined) clusterOf.set(card._id, card.clusterId);
+  }
+  const counts = new Map<string, number>();
+  const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1);
+  for (const row of rows) {
+    bump(topicKey(row.target));
+    const clusterId = row.target.kind === "card" ? clusterOf.get(row.target.id) : undefined;
+    if (clusterId !== undefined) bump(clusterId);
+  }
+  return counts;
+}
+
+/** The display names of the referenced people, one read each; a missing row renders by the register. */
+async function namesOf(ctx: QueryCtx, ids: Iterable<Id<"users">>): Promise<Map<Id<"users">, string>> {
+  const names = new Map<Id<"users">, string>();
+  for (const id of new Set(ids)) {
+    const user = await ctx.db.get(id);
+    if (user) names.set(id, user.name);
+  }
+  return names;
+}
+
+const byCreation = <T extends { createdAt: number }>(a: T, b: T) => a.createdAt - b.createdAt;
+
+/**
+ * `retro.exportMarkdown` (spec §15.3): the retro's facts, then each topic
+ * with its cards under their prompts and its dot count — the walk as
+ * covered / not covered over the order, then topics outside it, or every
+ * topic in creation order when no walk exists — then the action items.
+ * The guard (`requireRoomReader`) has passed; `readerId` is who reads.
+ */
+export async function exportMarkdown(
+  ctx: QueryCtx,
+  room: Doc<"rooms">,
+  readerId: Id<"users">
+): Promise<MarkdownExport> {
+  const retro = await requireRetro(ctx, room._id);
+  const policy: ProjectionPolicy = policyOf(retro);
+  const reader: Reader = { userId: readerId };
+  const [cards, clusterRows, actions, team] = await Promise.all([
+    ctx.db
+      .query("retroCards")
+      .withIndex("by_room", (q) => q.eq("roomId", room._id))
+      .take(MAX_BOARD_ROWS),
+    ctx.db
+      .query("retroClusters")
+      .withIndex("by_room", (q) => q.eq("roomId", room._id))
+      .take(MAX_BOARD_ROWS),
+    ctx.db
+      .query("retroActions")
+      .withIndex("by_room", (q) => q.eq("roomId", room._id))
+      .take(MAX_ACTION_ROWS),
+    room.teamId ? ctx.db.get(room.teamId) : Promise.resolve(null),
+  ]);
+  const counts = await dotCounts(ctx, retro, cards);
+  const projected = new Map(cards.map((card) => [card._id, projectCard(policy, reader, card)]));
+  const names = await namesOf(ctx, [
+    ...[...projected.values()].flatMap((card) => (isFullCard(card) && card.authorId !== undefined ? [card.authorId] : [])),
+    ...actions.flatMap((action) => (action.ownerId !== undefined ? [action.ownerId] : [])),
+  ]);
+  const clusters = new Map(clusterRows.map((cluster) => [cluster._id, cluster]));
+  const sortedCards = [...cards].sort(byCreation);
+  const cardsOf = (ref: TopicRef) =>
+    ref.kind === "cluster"
+      ? sortedCards.filter((card) => card.clusterId === ref.id)
+      : sortedCards.filter((card) => card._id === ref.id);
+
+  const topicSection = (ref: TopicRef, tags: string[]): string[] => {
+    const votes = counts ? [votesCount(counts.get(topicId(ref)) ?? 0)] : [];
+    const lines = [`### ${[topicTitle(ref, clusters, projected), ...tags, ...votes].join(" · ")}`, ""];
+    for (const prompt of retro.format.prompts) {
+      const answers = cardsOf(ref).filter((card) => card.promptId === prompt.id);
+      if (answers.length === 0) continue;
+      lines.push(`**${prompt.label}**`, "", ...answers.map((card) => cardLine(projected.get(card._id)!, names)), "");
+    }
+    return lines;
+  };
+
+  const lines: string[] = [
+    `# ${room.name}`,
+    "",
+    team ? `- ${EXPORT_TEAM}: ${team.name}` : `- ${EXPORT_NO_TEAM}`,
+    `- ${EXPORT_CREATED}: ${isoDate(room.createdAt)}`,
+    `- ${EXPORT_FORMAT}: ${retro.format.name}`,
+    `- ${EXPORT_STAGES_WALKED}: ${stagesWalked(retro.stages, retro.currentStageId).join(", ")}`,
+    "",
+  ];
+
+  if (retro.walk) {
+    const walk = projectWalk(retro.walk, cards, clusterRows);
+    lines.push(`## ${EXPORT_DISCUSSION}`, "");
+    for (const entry of walk.entries) {
+      lines.push(...topicSection(entry.ref, [(entry.covered ? COVERED_LABEL : EXPORT_NOT_COVERED).toLowerCase()]));
+    }
+    if (walk.outside.length > 0) {
+      lines.push(`## ${EXPORT_OUTSIDE}`, "");
+      for (const topic of walk.outside) {
+        lines.push(...topicSection(topic.ref, topic.late ? [EXPORT_NEW.toLowerCase()] : []));
+      }
+    }
+  } else {
+    lines.push(`## ${EXPORT_TOPICS}`, "");
+    for (const topic of liveTopics(cards, clusterRows).sort(byCreation)) {
+      lines.push(...topicSection(topic.ref, []));
+    }
+  }
+
+  lines.push(`## ${ACTIONS_TITLE}`, "");
+  for (const action of [...actions].sort(byCreation)) {
+    lines.push(actionLine(action, names));
+  }
+  if (actions.length > 0) lines.push("");
+
+  return { filename: exportFilename(room.name, "md"), content: lines.join("\n") };
+}
+
+// --- The JSON history (spec §15.4) ---
+
+/** One retro of the JSON history: the board read for that reader, the tally's counts and the names the ids point at. */
+export interface RetroExport {
+  roomId: Id<"rooms">;
+  name: string;
+  createdAt: number;
+  board: BoardRead;
+  /** The tally as the board shows it: counts, never a voter (spec §9). */
+  tally: { stageEntryId: string; visible: boolean; counts: Record<string, number> };
+  /** Display names for the ids the board carries; a deleted account is absent and renders by the register. */
+  people: Record<Id<"users">, string>;
+}
+
+/**
+ * `retro.exportBoard` (spec §15.4): the same shape `retro.board` returns
+ * for that reader, with the tally's counts and the names beside it. The
+ * guard (`requireRoomReader`) has passed.
+ */
+export async function exportBoard(ctx: QueryCtx, room: Doc<"rooms">, readerId: Id<"users">): Promise<RetroExport> {
+  const [read, counts] = await Promise.all([board(ctx, room._id), tally(ctx, { roomId: room._id, viewerId: readerId })]);
+  const names = await namesOf(ctx, [
+    ...read.cards.flatMap((card) => (isFullCard(card) && card.authorId !== undefined ? [card.authorId] : [])),
+    ...read.writers,
+  ]);
+  return {
+    roomId: room._id,
+    name: room.name,
+    createdAt: room.createdAt,
+    board: read,
+    tally: { stageEntryId: counts.stageEntryId, visible: counts.visible, counts: counts.counts },
+    people: Object.fromEntries(names) as Record<Id<"users">, string>,
+  };
+}
+
+/** An action item in the history file: the projected read without the reader's rights. */
+export type ExportedAction = Omit<ActionRead, "rights">;
+
+/**
+ * `teams.exportActions` (spec §15.4): every action item across the Team's
+ * retros, every status, oldest first, through the one action projection
+ * (names by reference, sources through the room's card projection).
+ */
+export async function exportActions(ctx: QueryCtx, viewer: Doc<"users">, teamId: Id<"teams">): Promise<ExportedAction[]> {
+  const statuses: Doc<"retroActions">["status"][] = ["open", "done", "dropped"];
+  const rows = (
+    await Promise.all(
+      statuses.map((status) =>
+        ctx.db
+          .query("retroActions")
+          .withIndex("by_team_status", (q) => q.eq("teamId", teamId).eq("status", status))
+          .take(MAX_ACTION_ROWS)
+      )
+    )
+  )
+    .flat()
+    .sort(byCreation);
+  const { items } = await projectActions(ctx, viewer, rows);
+  return items.map(({ rights: _rights, ...item }) => item);
+}
+
+/** One page of a Team's rooms for the history export, in creation order, with the Team's name. */
+export interface ExportRoomsPage {
+  team: { name: string };
+  page: Id<"rooms">[];
+  isDone: boolean;
+  continueCursor: string;
+}
+
+/** The whole file as the action assembles it. */
+export interface HistoryExport {
+  team: { name: string; exportedAt: string };
+  retros: RetroExport[];
+  actions: ExportedAction[];
+}

--- a/convex/model/retroVotes.ts
+++ b/convex/model/retroVotes.ts
@@ -126,6 +126,32 @@ export function tallyEntryOf(retro: { stages: readonly StageEntry[]; currentStag
 }
 
 /**
+ * The one dot-count rule (spec §9, §15.3), pure over loaded rows: dots per
+ * topic key, a dot on a member card carrying into its cluster's count
+ * (ADR-0016). The tally and the export both count this way, and neither
+ * lets a voter out.
+ */
+export function countDots(
+  rows: readonly Pick<Doc<"retroVotes">, "target">[],
+  cards: readonly Pick<Doc<"retroCards">, "_id" | "clusterId">[]
+): Record<string, number> {
+  const clusterOf = new Map<string, Id<"retroClusters">>();
+  for (const card of cards) {
+    if (card.clusterId !== undefined) clusterOf.set(card._id, card.clusterId);
+  }
+  const counts: Record<string, number> = {};
+  const bump = (key: string) => {
+    counts[key] = (counts[key] ?? 0) + 1;
+  };
+  for (const row of rows) {
+    bump(topicKey(row.target));
+    const clusterId = row.target.kind === "card" ? clusterOf.get(row.target.id) : undefined;
+    if (clusterId !== undefined) bump(clusterId);
+  }
+  return counts;
+}
+
+/**
  * `retro.tally` (spec §9, §8.2): per viewer and small. Counts are
  * aggregate and carry no voter in either attribution mode; the viewer's
  * own dots are theirs to see whatever the entry shows.
@@ -144,34 +170,19 @@ export async function tally(ctx: QueryCtx, args: { roomId: Id<"rooms">; viewerId
       .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
       .take(MAX_BOARD_ROWS),
   ]);
-  const clusterOf = new Map<string, Id<"retroClusters">>();
-  for (const card of cards) {
-    if (card.clusterId !== undefined) clusterOf.set(card._id, card.clusterId);
-  }
   const visible = current.tallyVisible === "visible";
-  const counts: Record<string, number> = {};
   const mine: Record<string, number> = {};
   let spent = 0;
-  const bump = (record: Record<string, number>, key: string) => {
-    record[key] = (record[key] ?? 0) + 1;
-  };
   for (const row of rows) {
+    if (row.voterId !== args.viewerId) continue;
+    spent += 1;
     const key = topicKey(row.target);
-    const own = row.voterId === args.viewerId;
-    if (own) {
-      spent += 1;
-      bump(mine, key);
-    }
-    if (!visible) continue;
-    bump(counts, key);
-    // A dot on a member card carries into its cluster's tally (ADR-0016).
-    const clusterId = row.target.kind === "card" ? clusterOf.get(row.target.id) : undefined;
-    if (clusterId !== undefined) bump(counts, clusterId);
+    mine[key] = (mine[key] ?? 0) + 1;
   }
   return {
     stageEntryId: entry.id,
     visible,
-    counts,
+    counts: visible ? countDots(rows, cards) : {},
     mine,
     spent: current.id === entry.id ? spent : 0,
     ...(current.voteBudget !== undefined ? { budget: current.voteBudget } : {}),

--- a/convex/model/teams.ts
+++ b/convex/model/teams.ts
@@ -1,4 +1,5 @@
 import { MutationCtx, QueryCtx } from "../_generated/server";
+import type { PaginationOptions } from "convex/server";
 import { Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import {
@@ -494,4 +495,26 @@ export async function teamFacts(ctx: QueryCtx, teamId: Id<"teams">): Promise<Tea
       .take(MAX_COUNTED_ROOMS),
   ]);
   return { open, done, dropped, retros: rooms.length };
+}
+
+/**
+ * One page of the Team's rooms for the history export (spec §15.4), in
+ * creation order through `by_team`; the action pages until done and reads
+ * each room's board through its own guard.
+ */
+export async function exportRoomsPage(
+  ctx: QueryCtx,
+  team: Doc<"teams">,
+  paginationOpts: PaginationOptions
+): Promise<{ team: { name: string }; page: Id<"rooms">[]; isDone: boolean; continueCursor: string }> {
+  const result = await ctx.db
+    .query("rooms")
+    .withIndex("by_team", (q) => q.eq("teamId", team._id))
+    .paginate(paginationOpts);
+  return {
+    team: { name: team.name },
+    page: result.page.map((room) => room._id),
+    isDone: result.isDone,
+    continueCursor: result.continueCursor,
+  };
 }

--- a/convex/model/teams.ts
+++ b/convex/model/teams.ts
@@ -1,5 +1,7 @@
 import { MutationCtx, QueryCtx } from "../_generated/server";
 import type { PaginationOptions } from "convex/server";
+import type { ActionCounts } from "./retro";
+import type { ExportRoomsPage } from "./retroExport";
 import { Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import {
@@ -464,15 +466,10 @@ export async function releaseMembershipsOfDeletedUser(
 }
 
 /** The team count line (spec §17, ADR-0024): three sums over `by_team_status` and a count of `by_team`. */
-export interface TeamFacts {
-  open: number;
-  done: number;
-  dropped: number;
-  retros: number;
-}
+export type TeamFacts = ActionCounts & { retros: number };
 
-/** How many action rows one status's sum reads; a Team's history never approaches it. */
-const MAX_COUNTED_ACTIONS = 5000;
+/** How many action rows one status's sum reads across the Team; its history never approaches it. */
+const MAX_TEAM_ACTION_ROWS = 5000;
 
 /**
  * `teams.facts`: counts, never a rate. The same for admin and member; the
@@ -483,7 +480,7 @@ export async function teamFacts(ctx: QueryCtx, teamId: Id<"teams">): Promise<Tea
     ctx.db
       .query("retroActions")
       .withIndex("by_team_status", (q) => q.eq("teamId", teamId).eq("status", status))
-      .take(MAX_COUNTED_ACTIONS)
+      .take(MAX_TEAM_ACTION_ROWS)
       .then((rows) => rows.length);
   const [open, done, dropped, rooms] = await Promise.all([
     countStatus("open"),
@@ -506,7 +503,7 @@ export async function exportRoomsPage(
   ctx: QueryCtx,
   team: Doc<"teams">,
   paginationOpts: PaginationOptions
-): Promise<{ team: { name: string }; page: Id<"rooms">[]; isDone: boolean; continueCursor: string }> {
+): Promise<ExportRoomsPage> {
   const result = await ctx.db
     .query("rooms")
     .withIndex("by_team", (q) => q.eq("teamId", team._id))

--- a/convex/model/walk.ts
+++ b/convex/model/walk.ts
@@ -26,13 +26,13 @@ export function topicOf(card: Pick<Doc<"retroCards">, "_id" | "clusterId">): Top
 /** A topic's bare id, as `covered` stores it. */
 export const topicId = (ref: TopicRef): string => ref.id;
 
-interface Topic {
+export interface Topic {
   ref: TopicRef;
   createdAt: number;
 }
 
 /** Every live topic on the board: clusters with members, loose cards. */
-function liveTopics(cards: readonly CardRow[], clusters: readonly ClusterRow[]): Topic[] {
+export function liveTopics(cards: readonly CardRow[], clusters: readonly ClusterRow[]): Topic[] {
   const populated = new Set<Id<"retroClusters">>();
   const topics: Topic[] = [];
   for (const card of cards) {

--- a/convex/retro.ts
+++ b/convex/retro.ts
@@ -8,6 +8,7 @@ import * as RetroVotes from "./model/retroVotes";
 import * as RetroWalk from "./model/retroWalk";
 import * as RetroActions from "./model/retroActions";
 import * as RetroNudge from "./model/retroNudge";
+import * as RetroExport from "./model/retroExport";
 import {
   joinPolicyValidator,
   retroFormatValidator,
@@ -323,6 +324,31 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const { room } = await requireCan(ctx, args.roomId, { kind: "relationship", verb: "delete" });
     await Retro.deleteRetro(ctx, room);
+  },
+});
+
+/**
+ * One retro as Markdown (spec §15.3, ADR-0019): room access, and never more
+ * than the board shows the requester: silhouettes, no author in an
+ * anonymous retro, no voter in any.
+ */
+export const exportMarkdown = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user, room } = await requireRoomReader(ctx, args.roomId);
+    return await RetroExport.exportMarkdown(ctx, room, user._id);
+  },
+});
+
+/**
+ * One retro for the JSON history (spec §15.4): the board read for this
+ * reader with the tally's counts and the names beside it. Room access.
+ */
+export const exportBoard = query({
+  args: { roomId: v.id("rooms") },
+  handler: async (ctx, args) => {
+    const { user, room } = await requireRoomReader(ctx, args.roomId);
+    return await RetroExport.exportBoard(ctx, room, user._id);
   },
 });
 

--- a/convex/retroCopy.ts
+++ b/convex/retroCopy.ts
@@ -328,6 +328,8 @@ export const DELETE_CARD = "Delete card";
 export const UNSAVED_CHIP = "Unsaved";
 export const EDITING_CHIP = "Editing";
 export const HIDDEN_CARD_LABEL = "Hidden card";
+/** A silhouette in the Markdown export (spec §15.3). */
+export const HIDDEN_CARD_EXPORT = "(hidden card)";
 export const HAS_WRITTEN = "Has written";
 export const cardsCount = (n: number) => `${n} ${n === 1 ? "card" : "cards"}`;
 /** Missing user (spec §19). */
@@ -468,6 +470,7 @@ export const ACTIONS_EMPTY = "No action items yet.";
 export const ownedBy = (name: string) => `Owner: ${name}`;
 export const dueOn = (date: string) => `Due ${date}`;
 export const fromRetro = (name: string) => `From ${name}`;
+export const noteLine = (note: string) => `Note: ${note}`;
 export const ACTION_SOURCE_LABEL = "About";
 export const OPEN_ACTIONS_TITLE = "Open action items";
 export const OPEN_ACTIONS_EMPTY = "No open action items across this team's retros.";
@@ -499,6 +502,25 @@ export const ATTRIBUTION_LABELS: Record<"named" | "anonymous", string> = {
   anonymous: "Anonymous",
 };
 export const createdOn = (date: string) => `Created ${date}`;
+
+// --- Export (spec §15.3, §15.4; ADR-0019) ---
+
+export const EXPORT_MARKDOWN_MENU_ITEM = "Export as Markdown";
+export const EXPORT_MARKDOWN_FAILED = "Failed to export this retro";
+export const EXPORT_HISTORY_BUTTON = "Export history";
+export const EXPORTING_HISTORY_BUTTON = "Exporting…";
+export const EXPORT_HISTORY_FAILED = "Failed to export the team's history";
+/** The Markdown export's header line for a teamless retro. */
+export const EXPORT_NO_TEAM = "Not kept by a team";
+export const EXPORT_TEAM = "Team";
+export const EXPORT_CREATED = "Created";
+export const EXPORT_FORMAT = "Format";
+export const EXPORT_STAGES_WALKED = "Stages walked";
+export const EXPORT_DISCUSSION = "Discussion";
+export const EXPORT_OUTSIDE = "Outside the discussion";
+export const EXPORT_TOPICS = "Topics";
+export const EXPORT_NOT_COVERED = "Not covered";
+export const EXPORT_NEW = "New";
 
 // --- Account deletion (spec §15.2, §19; ADR-0019) ---
 

--- a/convex/retroExport.test.ts
+++ b/convex/retroExport.test.ts
@@ -1,0 +1,286 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { DEFAULT_RETRO_FORMAT } from "./model/retroFormats";
+import { type T, seedUser as seedNamedUser } from "./analytics.seeds";
+import { FORMER_MEMBER, HIDDEN_CARD_LABEL, UNOWNED_ACTION } from "./retroCopy";
+
+// Export (spec §15.3, §15.4, ADR-0019): a projection of read access and
+// never more. Both exports run through `projectCard`, the attribution
+// projection and the guards, so a hidden entry exports silhouettes, an
+// anonymous retro has no authors, no export has voters, and only a reader
+// (a room member or a Team member) gets one.
+
+const modules = import.meta.glob("./**/*.*s");
+
+const seedUser = (t: T, authUserId: string, accountType?: "anonymous" | "permanent") =>
+  seedNamedUser(t, authUserId, authUserId, accountType);
+const as = (t: T, subject: string) => t.withIdentity({ subject });
+
+async function retroRow(t: T, roomId: Id<"rooms">) {
+  return (await t.run((ctx) =>
+    ctx.db
+      .query("retros")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .unique()
+  ))!;
+}
+
+/** A Team with an admin and a member (permanent), and a stranger outside it. */
+async function seedTeam(t: T) {
+  const adminId = await seedUser(t, "admin", "permanent");
+  const memberId = await seedUser(t, "member", "permanent");
+  await seedUser(t, "stranger", "permanent");
+  const teamId = await as(t, "admin").mutation(api.teams.create, { name: "Acme Squad" });
+  const team = (await t.run((ctx) => ctx.db.get(teamId)))!;
+  await as(t, "member").mutation(api.teams.joinByInvite, { inviteToken: team.inviteToken });
+  return { teamId, adminId, memberId };
+}
+
+const joinRoom = (t: T, roomId: Id<"rooms">, subject: string) =>
+  as(t, subject).mutation(api.users.join, { roomId, name: subject, authUserId: subject });
+
+/**
+ * A team retro created by the admin with a guest (anonymous account)
+ * attending; the member of the Team never joins, so they read without
+ * attendance (ADR-0009). Helpers write cards, group, dot, act and advance.
+ */
+async function seedRetro(t: T, teamId: Id<"teams">, name = "Sprint 42") {
+  const roomId = await as(t, "admin").mutation(api.retro.create, {
+    name,
+    formatName: DEFAULT_RETRO_FORMAT.name,
+    teamId,
+  });
+  await seedUser(t, "guest", "anonymous");
+  await joinRoom(t, roomId, "guest");
+  const retro = await retroRow(t, roomId);
+  const byKind = (kind: string) => retro.stages.find((s) => s.kind === kind)!;
+  const advance = (kind: string) => as(t, "admin").mutation(api.retro.advance, { roomId, toStageId: byKind(kind).id });
+  const write = (who: string, clientId: string, promptIndex = 0) =>
+    as(t, who).mutation(api.retro.createCard, {
+      roomId,
+      clientId,
+      text: `Card ${clientId}`,
+      promptId: retro.format.prompts[promptIndex].id,
+      position: { x: 0, y: 0 },
+    });
+  const group = (clientIds: string[]) => as(t, "admin").mutation(api.retro.formCluster, { roomId, clientIds });
+  const dot = (who: string, target: { kind: "card"; id: Id<"retroCards"> } | { kind: "cluster"; id: Id<"retroClusters"> }) =>
+    as(t, who).mutation(api.retro.placeDot, { roomId, target });
+  const action = (who: string, text: string, extra: Record<string, unknown> = {}) =>
+    as(t, who).mutation(api.retro.createAction, { roomId, text, ...extra });
+  return { roomId, retro, byKind, advance, write, group, dot, action };
+}
+
+const exportMd = (t: T, who: string, roomId: Id<"rooms">) => as(t, who).query(api.retro.exportMarkdown, { roomId });
+
+describe("retro.exportMarkdown (spec §15.3)", () => {
+  it("in collect, a non-author reads silhouettes as hidden cards and their own card in full; nothing else leaks", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const { roomId, write } = await seedRetro(t, teamId);
+    await write("admin", "a1");
+    await write("guest", "g1");
+
+    const asGuest = await exportMd(t, "guest", roomId);
+    expect(asGuest.filename).toBe("Sprint 42.md");
+    expect(asGuest.content).toContain("# Sprint 42");
+    expect(asGuest.content).toContain("Card g1");
+    expect(asGuest.content).not.toContain("Card a1");
+    expect(asGuest.content).toContain(`(${HIDDEN_CARD_LABEL.toLowerCase()})`);
+
+    // A Team member who never attended reads it too (ADR-0009): every card a silhouette.
+    const asMember = await exportMd(t, "member", roomId);
+    expect(asMember.content).not.toContain("Card a1");
+    expect(asMember.content).not.toContain("Card g1");
+    // Two card lines, each a silhouette; a hidden lone card's topic title is one too.
+    expect(asMember.content.match(/^- \(hidden card\)$/gm)).toHaveLength(2);
+  });
+
+  it("names the retro's facts, the team, the format, the stages walked, each topic with its cards under their prompts and its dot count, then the action items", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    const { roomId, write, group, dot, advance, action } = await seedRetro(t, teamId);
+    const { cardId: a1 } = await write("admin", "a1", 0);
+    await write("guest", "g1", 1);
+    await write("guest", "g2", 1);
+    const k = await group(["g1", "g2"]);
+    await as(t, "admin").mutation(api.retro.renameCluster, { roomId, clusterId: k, name: "Flaky CI" });
+    await advance("vote");
+    await dot("admin", { kind: "cluster", id: k });
+    await dot("guest", { kind: "cluster", id: k });
+    await dot("guest", { kind: "card", id: a1 });
+    await advance("discuss");
+    const walk = (await retroRow(t, roomId)).walk!;
+    await as(t, "admin").mutation(api.retro.markCovered, { roomId, topicId: walk.order[0].id, covered: true });
+    await write("guest", "late", 0);
+    await action("admin", "Fix the flaky test", { ownerId: adminId, dueAt: Date.UTC(2026, 8, 12) });
+    const dropped = await action("guest", "Buy a bigger monitor");
+    await as(t, "guest").mutation(api.retro.setActionStatus, { roomId, actionId: dropped, status: "dropped", note: "Not ours to fix" });
+    await advance("close");
+
+    const { content } = await exportMd(t, "admin", roomId);
+    const [prompt0, prompt1] = DEFAULT_RETRO_FORMAT.prompts.map((p) => p.label);
+    expect(content).toMatch(/^# Sprint 42\n/);
+    expect(content).toContain("Team: Acme Squad");
+    expect(content).toMatch(/Created: \d{4}-\d{2}-\d{2}/);
+    expect(content).toContain(`Format: ${DEFAULT_RETRO_FORMAT.name}`);
+    expect(content).toContain("Stages walked: Collect, Review, Group, Vote, Discuss, Close");
+
+    // The walk: covered then not covered over the order, then the late topic outside it.
+    const discussion = content.slice(content.indexOf("## Discussion"), content.indexOf("## Action items"));
+    expect(discussion.indexOf("Flaky CI")).toBeLessThan(discussion.indexOf("Card a1"));
+    expect(discussion).toContain("### Flaky CI · covered · 2 votes");
+    expect(discussion).toContain("### Card a1 · not covered · 1 vote");
+    expect(discussion).toContain(`**${prompt1}**\n\n- Card g1 — guest\n- Card g2 — guest`);
+    expect(discussion).toContain(`**${prompt0}**\n\n- Card a1 — admin`);
+    expect(discussion.indexOf("## Outside the discussion")).toBeGreaterThan(discussion.indexOf("### Card a1"));
+    expect(discussion).toContain("### Card late · new");
+
+    const actions = content.slice(content.indexOf("## Action items"));
+    expect(actions).toContain("- [ ] Fix the flaky test — Owner: admin · Due 2026-09-12 · Open");
+    expect(actions).toContain(`- [-] Buy a bigger monitor — ${UNOWNED_ACTION} · Dropped · Note: Not ours to fix`);
+  });
+
+  it("an anonymous retro exports no author anywhere, and no export names a voter", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    await as(t, "admin").mutation(api.teams.updateRetroDefaults, {
+      teamId,
+      retroDefaults: { attribution: "anonymous", joinPolicy: "anyone", permissions: (await t.run((ctx) => ctx.db.get(teamId)))!.retroDefaults.permissions },
+    });
+    const { roomId, write, dot, advance } = await seedRetro(t, teamId);
+    const { cardId } = await write("admin", "a1");
+    await write("guest", "g1");
+    await advance("vote");
+    await dot("admin", { kind: "card", id: cardId });
+    await advance("close");
+
+    const { content } = await exportMd(t, "member", roomId);
+    expect(content).toContain("- Card a1\n");
+    expect(content).toContain("- Card g1\n");
+    expect(content).not.toMatch(/— (admin|guest|member)/);
+    expect(content).toContain("· 1 vote");
+    // Ids never appear: not a voter's, not an author's.
+    expect(content).not.toContain(adminId);
+    expect(content).not.toMatch(/[a-z0-9]{32}/);
+  });
+
+  it("without a walk, lists topics in creation order under Topics; a dangling author reads as a former member", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const { roomId, write, advance } = await seedRetro(t, teamId);
+    await write("guest", "g1");
+    await write("admin", "a1");
+    await advance("group");
+    await as(t, "guest").mutation(api.users.deleteUser, {});
+
+    const { content } = await exportMd(t, "admin", roomId);
+    expect(content).toContain("## Topics");
+    expect(content).not.toContain("## Discussion");
+    expect(content.indexOf("### Card g1")).toBeLessThan(content.indexOf("### Card a1"));
+    expect(content).toContain(`- Card g1 — ${FORMER_MEMBER}`);
+    expect(content).not.toContain("votes");
+  });
+
+  it("is refused to a non-reader and to an unauthenticated caller; a teamless retro names no team", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    const { roomId } = await seedRetro(t, teamId);
+    await expect(exportMd(t, "stranger", roomId)).rejects.toThrow("You don't have access to this room");
+    await expect(t.query(api.retro.exportMarkdown, { roomId })).rejects.toThrow("Not authenticated");
+
+    const loose = await as(t, "admin").mutation(api.retro.create, { name: "Loose", formatName: DEFAULT_RETRO_FORMAT.name });
+    const { content } = await exportMd(t, "admin", loose);
+    expect(content).toContain("Not kept by a team");
+    expect(content).not.toContain("Team: ");
+  });
+});
+
+describe("teams.exportHistory (spec §15.4)", () => {
+  it("returns one JSON file of every retro in creation order in the board's shape for that reader, plus the Team's action items", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    const first = await seedRetro(t, teamId, "First");
+    const { cardId } = await first.write("admin", "f1");
+    await first.write("guest", "f2");
+    await first.advance("vote");
+    await first.dot("admin", { kind: "card", id: cardId });
+    await first.advance("discuss");
+    await first.advance("close");
+    await first.action("admin", "Ship it", { ownerId: adminId });
+    const second = await seedRetro(t, teamId, "Second");
+    await second.write("admin", "s1");
+    const done = await second.action("guest", "Write it up");
+    await as(t, "guest").mutation(api.retro.setActionStatus, { roomId: second.roomId, actionId: done, status: "done" });
+    // A teamless retro and another Team's retro are not in this file.
+    await as(t, "admin").mutation(api.retro.create, { name: "Loose", formatName: DEFAULT_RETRO_FORMAT.name });
+
+    const file = await as(t, "member").action(api.teams.exportHistory, { teamId });
+    expect(file.filename).toBe("Acme Squad.json");
+    const json = JSON.parse(file.content);
+    expect(json.team).toEqual({ name: "Acme Squad", exportedAt: expect.any(String) });
+    expect(json.retros.map((r: { name: string }) => r.name)).toEqual(["First", "Second"]);
+
+    // First is closed: every card in full, the vote as a count on the tally, the walk.
+    const closed = json.retros[0];
+    expect(closed.roomId).toBe(first.roomId);
+    expect(closed.createdAt).toEqual(expect.any(Number));
+    expect(closed.board.cards.map((c: { text?: string }) => c.text).sort()).toEqual(["Card f1", "Card f2"]);
+    expect(closed.board.cards.every((c: { authorId?: string }) => c.authorId !== undefined)).toBe(true);
+    expect(closed.board.walk).toBeDefined();
+    expect(closed.tally.counts[cardId]).toBe(1);
+    expect(JSON.stringify(closed)).not.toContain("voterId");
+    expect(closed.people[adminId]).toBe("admin");
+
+    // Second is collecting: silhouettes for the member, who wrote nothing.
+    const collecting = json.retros[1];
+    expect(collecting.board.cards).toHaveLength(1);
+    expect(collecting.board.cards[0].text).toBeUndefined();
+    expect(collecting.board.cards[0].authorId).toBeUndefined();
+
+    // The Team's action items, every status, oldest first, names by reference.
+    expect(json.actions.map((a: { text: string; status: string; roomName: string }) => [a.text, a.status, a.roomName])).toEqual([
+      ["Ship it", "open", "First"],
+      ["Write it up", "done", "Second"],
+    ]);
+    expect(json.actions[0].ownerName).toBe("admin");
+    expect(json.actions[0].rights).toBeUndefined();
+  });
+
+  it("an anonymous retro's cards carry no authorId, and the file names no voter", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, adminId } = await seedTeam(t);
+    await as(t, "admin").mutation(api.teams.updateRetroDefaults, {
+      teamId,
+      retroDefaults: { attribution: "anonymous", joinPolicy: "anyone", permissions: (await t.run((ctx) => ctx.db.get(teamId)))!.retroDefaults.permissions },
+    });
+    const { roomId, write, dot, advance } = await seedRetro(t, teamId);
+    const { cardId } = await write("admin", "a1");
+    await advance("vote");
+    await dot("admin", { kind: "card", id: cardId });
+    await advance("close");
+
+    const file = await as(t, "admin").action(api.teams.exportHistory, { teamId });
+    const json = JSON.parse(file.content);
+    expect(json.retros[0].roomId).toBe(roomId);
+    expect(json.retros[0].board.cards[0].text).toBe("Card a1");
+    expect(json.retros[0].board.cards[0].authorId).toBeUndefined();
+    expect(json.retros[0].tally.counts[cardId]).toBe(1);
+    expect(file.content).not.toContain("voterId");
+    expect(file.content).not.toContain(adminId);
+  });
+
+  it("is refused to anyone outside the Team and to an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId } = await seedTeam(t);
+    await seedRetro(t, teamId);
+    await expect(as(t, "stranger").action(api.teams.exportHistory, { teamId })).rejects.toThrow(
+      "You are not a member of this team"
+    );
+    await expect(t.action(api.teams.exportHistory, { teamId })).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -199,10 +199,11 @@ export const exportHistory = action({
         paginationOpts: { numItems: EXPORT_PAGE_SIZE, cursor },
       });
       teamName = page.team.name;
-      for (const roomId of page.page) {
-        const retro: RetroExport.RetroExport = await ctx.runQuery(api.retro.exportBoard, { roomId });
-        retros.push(retro);
-      }
+      // One page's boards read together; each read still runs its own guard.
+      const boards: RetroExport.RetroExport[] = await Promise.all(
+        page.page.map((roomId) => ctx.runQuery(api.retro.exportBoard, { roomId }))
+      );
+      retros.push(...boards);
       cursor = page.isDone ? null : page.continueCursor;
     } while (cursor !== null);
     const actions: RetroExport.ExportedAction[] = await ctx.runQuery(api.teams.exportActions, { teamId: args.teamId });

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -1,7 +1,10 @@
-import { mutation, query } from "./_generated/server";
+import { action, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
+import { api } from "./_generated/api";
 import * as Teams from "./model/teams";
 import * as RetroActions from "./model/retroActions";
+import * as RetroExport from "./model/retroExport";
 import { retroDefaultsValidator } from "./schema";
 import { getOptionalAuthUser, requireAuthUser, requireTeamRole } from "./model/auth";
 
@@ -150,5 +153,64 @@ export const facts = query({
   handler: async (ctx, args) => {
     await requireTeamRole(ctx, args.teamId, "member");
     return await Teams.teamFacts(ctx, args.teamId);
+  },
+});
+
+// --- The history export (spec §15.4, ADR-0019) ---
+
+/** One page of the Team's rooms in creation order, for the export action (members only). */
+export const exportRooms = query({
+  args: { teamId: v.id("teams"), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const { team } = await requireTeamRole(ctx, args.teamId, "member");
+    return await Teams.exportRoomsPage(ctx, team, args.paginationOpts);
+  },
+});
+
+/** Every action item across the Team's retros, every status, oldest first (members only). */
+export const exportActions = query({
+  args: { teamId: v.id("teams") },
+  handler: async (ctx, args) => {
+    const { user } = await requireTeamRole(ctx, args.teamId, "member");
+    return await RetroExport.exportActions(ctx, user, args.teamId);
+  },
+});
+
+/** How many rooms one page of the history export reads. */
+const EXPORT_PAGE_SIZE = 50;
+
+/**
+ * A Team's history as one JSON file (spec §15.4): every retro in creation
+ * order in the shape `retro.board` returns for that reader, plus the Team's
+ * action items. Every read runs under its own guard as the caller: the
+ * rooms page and the actions under `requireTeamRole`, each board under
+ * `requireRoomReader`, so the file holds nothing the team page and the
+ * boards would not show this member. No share page.
+ */
+export const exportHistory = action({
+  args: { teamId: v.id("teams") },
+  handler: async (ctx, args): Promise<{ filename: string; content: string }> => {
+    const retros: RetroExport.RetroExport[] = [];
+    let teamName = "";
+    let cursor: string | null = null;
+    do {
+      const page: RetroExport.ExportRoomsPage = await ctx.runQuery(api.teams.exportRooms, {
+        teamId: args.teamId,
+        paginationOpts: { numItems: EXPORT_PAGE_SIZE, cursor },
+      });
+      teamName = page.team.name;
+      for (const roomId of page.page) {
+        const retro: RetroExport.RetroExport = await ctx.runQuery(api.retro.exportBoard, { roomId });
+        retros.push(retro);
+      }
+      cursor = page.isDone ? null : page.continueCursor;
+    } while (cursor !== null);
+    const actions: RetroExport.ExportedAction[] = await ctx.runQuery(api.teams.exportActions, { teamId: args.teamId });
+    const file: RetroExport.HistoryExport = {
+      team: { name: teamName, exportedAt: new Date().toISOString() },
+      retros,
+      actions,
+    };
+    return { filename: RetroExport.exportFilename(teamName, "json"), content: JSON.stringify(file, null, 2) };
   },
 });

--- a/src/app/room/[roomId]/retro-room-content.test.tsx
+++ b/src/app/room/[roomId]/retro-room-content.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
+  exports: 0,
   queries: {} as Record<string, unknown>,
   join: vi.fn(),
   mutations: [] as { fn: string; args: unknown }[],
@@ -74,6 +75,11 @@ vi.mock("@/components/retro/retro-board", () => ({
     </div>
   ),
 }));
+vi.mock("@/components/retro/use-export-markdown", () => ({
+  useExportMarkdown: () => async () => {
+    mocks.exports += 1;
+  },
+}));
 vi.mock("@/components/retro/retro-menu", () => ({
   RetroMenu: ({ role, settings }: { role: string; settings?: { name: string; decision: { allowed: boolean } } }) => (
     <div data-testid="menu" data-settings={settings?.name} data-settings-allowed={String(settings?.decision.allowed)}>{role}</div>
@@ -99,6 +105,7 @@ const teamed = {
 } as never;
 
 beforeEach(() => {
+  mocks.exports = 0;
   mocks.join.mockReset();
   mocks.mutations = [];
   mocks.presenceCalls = [];
@@ -221,6 +228,11 @@ describe("RetroRoomContent", () => {
     expect(board.getAttribute("data-viewer")).toBeNull();
     await new Promise((r) => setTimeout(r, 0));
     expect(mocks.join).not.toHaveBeenCalled();
+
+    // A reader may export (spec §15.3): the banner carries the door the menu would.
+    fireEvent.click(screen.getByRole("button", { name: "Export as Markdown" }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.exports).toBe(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Join retro" }));
     expect(screen.getByTestId("join-form").getAttribute("data-team-member")).toBe("true");

--- a/src/app/room/[roomId]/retro-room-content.tsx
+++ b/src/app/room/[roomId]/retro-room-content.tsx
@@ -21,6 +21,7 @@ import type { TallyRead } from "@/convex/model/retroVotes";
 import { useEditKeys, type EditKeyStore } from "@/components/retro/use-edit-keys";
 import { useSingleFlightMutation } from "@/hooks/useSingleFlightMutation";
 import { RetroMenu, type MyTeam } from "@/components/retro/retro-menu";
+import { useExportMarkdown } from "@/components/retro/use-export-markdown";
 import type { RetroTeam } from "@/components/retro/retro-header";
 import type { StageControls } from "@/components/retro/stage-nav";
 import { currentStageOf } from "@/convex/model/retroFormats";
@@ -31,6 +32,7 @@ import { useRoomPresence, type UserWithPresence } from "@/hooks/useRoomPresence"
 import { runAct } from "@/lib/run-act";
 import {
   CHECKING_SESSION,
+  EXPORT_MARKDOWN_MENU_ITEM,
   JOIN_RETRO_BUTTON,
   LOADING_BOARD,
   LOADING_TITLE,
@@ -54,7 +56,8 @@ interface RetroRoomContentProps {
  * visitor with neither attendance nor Team access sees the join form, with
  * the join decision resolved first. A Team member who never joined reads
  * the board (ADR-0009) with a line offering to join, and no membership is
- * written until they take it. An attendee gets the board and its menu.
+ * written until they take it, and the export (spec §15.3) since they may
+ * read. An attendee gets the board and its menu.
  */
 export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomContentProps) {
   const { isLoading: authLoading, isAuthenticated, accountType } = useAuth();
@@ -64,6 +67,7 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
   const isPermanent = accountType === "permanent";
   const myTeams = useQuery(api.teams.listMine, isPermanent ? {} : "skip");
   const [wantsToJoin, setWantsToJoin] = useState(false);
+  const exportMarkdown = useExportMarkdown(roomId);
 
   const { room } = roomData;
   const team: RetroTeam | undefined =
@@ -150,9 +154,14 @@ export function RetroRoomContent({ roomId, roomData, membership }: RetroRoomCont
             <span className="text-blue-800 dark:text-status-info-fg">
               {readingAsTeamMember(team.name)}
             </span>
-            <Button size="sm" onClick={() => setWantsToJoin(true)}>
-              {JOIN_RETRO_BUTTON}
-            </Button>
+            <span className="flex items-center gap-2">
+              <Button size="sm" variant="outline" onClick={() => void exportMarkdown()}>
+                {EXPORT_MARKDOWN_MENU_ITEM}
+              </Button>
+              <Button size="sm" onClick={() => setWantsToJoin(true)}>
+                {JOIN_RETRO_BUTTON}
+              </Button>
+            </span>
           </div>
         }
       />

--- a/src/app/team/[teamId]/team-content.test.tsx
+++ b/src/app/team/[teamId]/team-content.test.tsx
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   facts: undefined as { open: number; done: number; dropped: number; retros: number } | undefined,
   calls: [] as { fn: string; args: unknown }[],
   fail: {} as Record<string, string>,
+  downloads: [] as unknown[][],
   push: vi.fn(),
   toasts: [] as { kind: "success" | "error"; message: string }[],
 }));
@@ -53,8 +54,19 @@ vi.mock("convex/react", async () => {
         if (mocks.fail[fn]) throw new Error(mocks.fail[fn]);
       };
     },
+    useAction: (ref: unknown) => {
+      const fn = getFunctionName(ref as never);
+      return async (args: unknown) => {
+        mocks.calls.push({ fn, args });
+        if (mocks.fail[fn]) throw new Error(mocks.fail[fn]);
+        return { filename: "Acme.json", content: "{}" };
+      };
+    },
   };
 });
+vi.mock("@/utils/download-file", () => ({
+  downloadFile: (...args: unknown[]) => mocks.downloads.push(args),
+}));
 vi.mock("next/navigation", () => {
   const router = { push: (href: string) => mocks.push(href), replace: vi.fn() };
   return { useParams: () => ({ teamId: "team-1" }), useRouter: () => router };
@@ -141,6 +153,7 @@ beforeEach(() => {
   mocks.retros = [];
   mocks.calls = [];
   mocks.fail = {};
+  mocks.downloads = [];
   mocks.toasts = [];
   mocks.push.mockReset();
 });
@@ -258,6 +271,25 @@ describe("TeamContent — the Team's retros", () => {
     render(<TeamContent />);
     expect(screen.getByText("No retros yet. Start one and this team keeps it.")).toBeTruthy();
     expect(screen.queryByTestId("retro-rows")).toBeNull();
+  });
+});
+
+describe("TeamContent — export history (spec §15.4)", () => {
+  it("any member takes the Team's history as one JSON file under the server's name", async () => {
+    mocks.team = team("member");
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Export history" }));
+    await waitFor(() => expect(calledWith("teams:exportHistory")).toEqual([{ teamId: "team-1" }]));
+    await waitFor(() => expect(mocks.downloads).toEqual([["{}", "Acme.json", "application/json"]]));
+    expect(mocks.toasts).toEqual([]);
+  });
+
+  it("a refused export surfaces the server's copy and downloads nothing", async () => {
+    mocks.fail["teams:exportHistory"] = "You are not a member of this team";
+    render(<TeamContent />);
+    fireEvent.click(screen.getByRole("button", { name: "Export history" }));
+    await waitFor(() => expect(mocks.toasts).toContainEqual({ kind: "error", message: "You are not a member of this team" }));
+    expect(mocks.downloads).toEqual([]);
   });
 });
 

--- a/src/app/team/[teamId]/team-content.tsx
+++ b/src/app/team/[teamId]/team-content.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useMutation, useQuery } from "convex/react";
-import { Copy, Crown, RefreshCw, ShieldMinus, ShieldPlus, UserMinus, LogOut, Trash2, Plus } from "lucide-react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { Copy, Crown, Download, RefreshCw, ShieldMinus, ShieldPlus, UserMinus, LogOut, Trash2, Plus } from "lucide-react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useAuth } from "@/components/auth/auth-provider";
@@ -31,6 +31,9 @@ import { HistoryRows } from "@/components/retro/history-row";
 import { ActionList } from "@/components/retro/action-list";
 import { useActionActions } from "@/components/retro/use-action-actions";
 import {
+  EXPORT_HISTORY_BUTTON,
+  EXPORT_HISTORY_FAILED,
+  EXPORTING_HISTORY_BUTTON,
   OPEN_ACTIONS_EMPTY,
   OPEN_ACTIONS_TITLE,
   TEAM_RETROS_EMPTY,
@@ -40,6 +43,7 @@ import {
   teamCountLine,
 } from "@/convex/retroCopy";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
+import { downloadFile } from "@/utils/download-file";
 import { toast } from "@/lib/toast";
 import { runAct } from "@/lib/run-act";
 
@@ -59,8 +63,8 @@ function Centered({ title, body }: { title: string; body: string }) {
  * creation order, members with roles, the invite link, the retro-defaults
  * panel, New retro, and admin-only Delete team; the open action items
  * across its retros with done, drop, edit and reassign in place for
- * whoever attended (spec §13), under one count line (spec §17). Export
- * arrives with the second half of #299.
+ * whoever attended (spec §13), under one count line (spec §17); Export
+ * history as one JSON file for any member (spec §15.4).
  */
 export function TeamContent() {
   const params = useParams();
@@ -82,6 +86,7 @@ export function TeamContent() {
   const leave = useMutation(api.teams.leave);
   const updateRetroDefaults = useMutation(api.teams.updateRetroDefaults);
   const deleteTeam = useMutation(api.teams.remove);
+  const exportHistory = useAction(api.teams.exportHistory);
 
   // The rename draft, keyed to the stored name it was typed over: a query
   // update that changes the stored name discards the draft, and no effect
@@ -91,6 +96,7 @@ export function TeamContent() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmLeave, setConfirmLeave] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   if (authLoading || !isAuthenticated || team === undefined) {
     return <Centered title="Loading…" body="Fetching the team" />;
@@ -155,6 +161,20 @@ export function TeamContent() {
   const handleRetroDefaults = (next: RetroDefaults) =>
     runAct(updateRetroDefaults({ teamId, retroDefaults: next }), "Failed to update retro defaults");
 
+  // The export is an action that pages the Team's rooms (spec §15.4); the
+  // button waits for the file rather than offering a second press.
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const file = await exportHistory({ teamId });
+      downloadFile(file.content, file.filename, "application/json");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : EXPORT_HISTORY_FAILED);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const handleDelete = async () => {
     setIsDeleting(true);
     if (await runAct(deleteTeam({ teamId }), "Failed to delete team")) {
@@ -197,8 +217,12 @@ export function TeamContent() {
 
           {/* Retros (spec §5, §17): the Team's history in creation order */}
           <Card>
-            <CardHeader>
+            <CardHeader className="flex flex-row items-center justify-between gap-3">
               <CardTitle>{TEAM_RETROS_TITLE}</CardTitle>
+              <Button variant="outline" size="sm" onClick={handleExport} disabled={isExporting}>
+                <Download className="size-4" />
+                {isExporting ? EXPORTING_HISTORY_BUTTON : EXPORT_HISTORY_BUTTON}
+              </Button>
             </CardHeader>
             <CardContent>
               {retros === undefined ? (

--- a/src/components/dashboard/account-settings.test.tsx
+++ b/src/components/dashboard/account-settings.test.tsx
@@ -1,15 +1,41 @@
 /**
- * The Account tab's email toggle (spec §16.4): "Email me about retros and
- * action items", on unless the account opted out, writing the flag on
- * every flip. #299 adds Delete account beside it.
+ * The Account tab (spec §16.4, §15.2): the email toggle "Email me about
+ * retros and action items", on unless the account opted out, writing the
+ * flag on every flip; and Delete account for a permanent account only,
+ * behind a confirmation carrying the register's line, which stays open
+ * when the deletion is refused.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
 
 const mocks = vi.hoisted(() => ({
   user: undefined as undefined | null | { _id: string; emailOptOut?: boolean },
   setEmailOptOut: vi.fn(async () => null),
+  accountType: "permanent" as "permanent" | "anonymous" | null,
+  deleteAccount: vi.fn(async () => true),
 }));
+
+vi.mock("@/components/auth/auth-provider", () => ({ useAuth: () => ({ accountType: mocks.accountType }) }));
+vi.mock("@/hooks/useDeleteAccount", () => ({ useDeleteAccount: () => mocks.deleteAccount }));
+vi.mock("@/components/ui/alert-dialog", () => {
+  const pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    AlertDialog: ({ children, open }: { children?: ReactNode; open: boolean }) =>
+      open ? <div role="alertdialog">{children}</div> : null,
+    AlertDialogContent: pass,
+    AlertDialogHeader: pass,
+    AlertDialogFooter: pass,
+    AlertDialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    AlertDialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    AlertDialogCancel: ({ children, disabled }: { children?: ReactNode; disabled?: boolean }) => (
+      <button disabled={disabled}>{children}</button>
+    ),
+    AlertDialogAction: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+      <button onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+  };
+});
 
 vi.mock("@/convex/_generated/api", () => ({
   api: { users: { getGlobalUser: "users.getGlobalUser", setEmailOptOut: "users.setEmailOptOut" } },
@@ -25,6 +51,9 @@ import { AccountSettings } from "./account-settings";
 beforeEach(() => {
   mocks.user = { _id: "u1" };
   mocks.setEmailOptOut.mockClear();
+  mocks.accountType = "permanent";
+  mocks.deleteAccount.mockReset();
+  mocks.deleteAccount.mockResolvedValue(true);
 });
 afterEach(cleanup);
 
@@ -50,5 +79,38 @@ describe("AccountSettings", () => {
     mocks.user = undefined;
     render(<AccountSettings />);
     expect(screen.queryByRole("switch")).toBeNull();
+  });
+});
+
+describe("AccountSettings — Delete account (spec §15.2)", () => {
+  it("a permanent account confirms with the register's line and deletes", async () => {
+    render(<AccountSettings />);
+    fireEvent.click(within(screen.getByTestId("delete-account")).getByRole("button", { name: "Delete account" }));
+    const dialog = within(screen.getByRole("alertdialog"));
+    expect(dialog.getByText("Delete your account?")).toBeTruthy();
+    expect(
+      dialog.getByText(
+        "Your account is removed. Cards and action items you wrote in team retros stay with those teams, without your name."
+      )
+    ).toBeTruthy();
+    fireEvent.click(dialog.getByRole("button", { name: "Delete account" }));
+    await waitFor(() => expect(mocks.deleteAccount).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+  });
+
+  it("a refused deletion keeps the confirmation open for another try", async () => {
+    mocks.deleteAccount.mockResolvedValue(false);
+    render(<AccountSettings />);
+    fireEvent.click(within(screen.getByTestId("delete-account")).getByRole("button", { name: "Delete account" }));
+    fireEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Delete account" }));
+    await waitFor(() => expect(mocks.deleteAccount).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  it("an anonymous account has no Delete account: signing out already deletes it", () => {
+    mocks.accountType = "anonymous";
+    render(<AccountSettings />);
+    expect(screen.queryByTestId("delete-account")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete account" })).toBeNull();
   });
 });

--- a/src/components/dashboard/account-settings.tsx
+++ b/src/components/dashboard/account-settings.tsx
@@ -1,13 +1,35 @@
 "use client";
 
+import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
+import { Trash2 } from "lucide-react";
 import { api } from "@/convex/_generated/api";
+import { useAuth } from "@/components/auth/auth-provider";
+import { useDeleteAccount } from "@/hooks/useDeleteAccount";
+import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { toast } from "@/lib/toast";
 import {
+  ACCOUNT_DELETED,
+  CANCEL_BUTTON,
+  DELETE_ACCOUNT_BUTTON,
+  DELETE_ACCOUNT_SECTION_DESCRIPTION,
+  DELETE_ACCOUNT_SECTION_TITLE,
+  DELETE_ACCOUNT_TITLE,
+  DELETING_ACCOUNT_BUTTON,
   EMAIL_OPT_IN_DESCRIPTION,
   EMAIL_OPT_IN_FAILED,
   EMAIL_OPT_IN_LABEL,
@@ -15,13 +37,19 @@ import {
 } from "@/convex/retroCopy";
 
 /**
- * The Account tab (spec §16.4, §18.1): the one email switch covering
- * every nudge and reminder, on unless the account opted out. Sign-in
- * emails are never covered. #299 adds Delete account here.
+ * The Account tab (spec §16.4, §15.2, §18.1): the one email switch covering
+ * every nudge and reminder, on unless the account opted out (sign-in
+ * emails are never covered); and, for a permanent account, Delete account
+ * behind a confirmation that says what stays (ADR-0019). An anonymous
+ * account is deleted by signing out, so it has no button here.
  */
 export function AccountSettings() {
   const user = useQuery(api.users.getGlobalUser);
   const setEmailOptOut = useMutation(api.users.setEmailOptOut);
+  const { accountType } = useAuth();
+  const deleteAccount = useDeleteAccount();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const toggle = async (checked: boolean) => {
     try {
@@ -31,27 +59,69 @@ export function AccountSettings() {
     }
   };
 
+  // The confirmation stays open on a refusal (the last-admin rule), so the
+  // next attempt is one click away once the Team is sorted out.
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    if (await deleteAccount()) {
+      setConfirmDelete(false);
+    }
+    setIsDeleting(false);
+  };
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{EMAIL_SECTION_TITLE}</CardTitle>
-        <CardDescription>{EMAIL_OPT_IN_DESCRIPTION}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        {user === undefined ? (
-          <Skeleton className="h-6 w-64" />
-        ) : (
-          <div className="flex items-center gap-3">
-            <Switch
-              id="email-opt-in"
-              checked={user?.emailOptOut !== true}
-              onCheckedChange={(checked) => void toggle(checked)}
-              disabled={user === null}
-            />
-            <Label htmlFor="email-opt-in">{EMAIL_OPT_IN_LABEL}</Label>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{EMAIL_SECTION_TITLE}</CardTitle>
+          <CardDescription>{EMAIL_OPT_IN_DESCRIPTION}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {user === undefined ? (
+            <Skeleton className="h-6 w-64" />
+          ) : (
+            <div className="flex items-center gap-3">
+              <Switch
+                id="email-opt-in"
+                checked={user?.emailOptOut !== true}
+                onCheckedChange={(checked) => void toggle(checked)}
+                disabled={user === null}
+              />
+              <Label htmlFor="email-opt-in">{EMAIL_OPT_IN_LABEL}</Label>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {accountType === "permanent" && (
+        <Card data-testid="delete-account">
+          <CardHeader>
+            <CardTitle>{DELETE_ACCOUNT_SECTION_TITLE}</CardTitle>
+            <CardDescription>{DELETE_ACCOUNT_SECTION_DESCRIPTION}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
+              <Trash2 className="size-4" />
+              {DELETE_ACCOUNT_BUTTON}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      <AlertDialog open={confirmDelete} onOpenChange={(open) => !isDeleting && setConfirmDelete(open)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{DELETE_ACCOUNT_TITLE}</AlertDialogTitle>
+            <AlertDialogDescription>{ACCOUNT_DELETED}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>{CANCEL_BUTTON}</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting ? DELETING_ACCOUNT_BUTTON : DELETE_ACCOUNT_BUTTON}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   );
 }

--- a/src/components/retro/retro-menu.test.tsx
+++ b/src/components/retro/retro-menu.test.tsx
@@ -10,6 +10,7 @@ import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-li
 import { cloneElement, type ReactElement, type ReactNode } from "react";
 
 const mocks = vi.hoisted(() => ({
+  exports: 0,
   calls: [] as { fn: string; args: unknown }[],
   fail: {} as Record<string, string>,
   counts: { cards: 47, openActions: 3 } as { cards: number; openActions: number } | undefined,
@@ -77,6 +78,11 @@ vi.mock("@/components/ui/dialog", () => {
   };
 });
 
+vi.mock("./use-export-markdown", () => ({
+  useExportMarkdown: () => async () => {
+    mocks.exports += 1;
+  },
+}));
 vi.mock("./retro-settings-dialog", () => ({
   RetroSettingsDialog: ({ open, name, hasTeam, decision }: { open: boolean; name: string; hasTeam: boolean; decision: { allowed: boolean } }) =>
     open ? <div data-testid="settings" data-team={String(hasTeam)} data-allowed={String(decision.allowed)}>{name}</div> : null,
@@ -90,6 +96,7 @@ const acme = { _id: "team-1" as never, name: "Acme Squad" };
 const calledWith = (fn: string) => mocks.calls.filter((c) => c.fn === fn).map((c) => c.args);
 
 beforeEach(() => {
+  mocks.exports = 0;
   mocks.calls = [];
   mocks.fail = {};
   mocks.toasts = [];
@@ -97,6 +104,17 @@ beforeEach(() => {
   mocks.push.mockReset();
 });
 afterEach(cleanup);
+
+describe("RetroMenu — export (spec §15.3)", () => {
+  it("every attendee, whatever their role, exports the retro as Markdown from the menu", async () => {
+    render(<RetroMenu roomId={roomId} role="participant" isOwnerAbsent={false} myTeams={[]} />);
+    const item = screen.getByRole("menuitem", { name: "Export as Markdown" }) as HTMLButtonElement;
+    expect(item.disabled).toBe(false);
+    fireEvent.click(item);
+    await waitFor(() => expect(mocks.exports).toBe(1));
+    expect(mocks.calls).toEqual([]);
+  });
+});
 
 describe("RetroMenu — delete", () => {
   it("the owner sees the counted confirmation, deletes, and leaves for the team page", async () => {

--- a/src/components/retro/retro-menu.tsx
+++ b/src/components/retro/retro-menu.tsx
@@ -30,6 +30,7 @@ import {
   DELETE_MENU_ITEM,
   DELETE_TITLE,
   DELETING_BUTTON,
+  EXPORT_MARKDOWN_MENU_ITEM,
   RATCHET_BUTTON,
   RATCHET_DESCRIPTION,
   RATCHET_FAILED,
@@ -73,6 +74,7 @@ import { toast } from "@/lib/toast";
 import type { Attribution } from "@/convex/model/retro";
 import type { RetroTeam } from "./retro-header";
 import { RetroSettingsDialog } from "./retro-settings-dialog";
+import { useExportMarkdown } from "./use-export-markdown";
 
 /** One of the viewer's Teams, as `teams.listMine` returns it. */
 export interface MyTeam {
@@ -102,14 +104,16 @@ interface RetroMenuProps {
 }
 
 /**
- * The board header's menu (spec §4.3, §5, §15.2): the owner's *Delete
- * retro* behind the counted confirmation; the owner's *Make anonymous…*
+ * The board header's menu (spec §4.3, §5, §15.2, §15.3): *Export as
+ * Markdown* for anyone here (spec §15.3; a Team reader without attendance
+ * takes theirs from the banner); the owner's *Delete retro* behind the
+ * counted confirmation; the owner's *Make anonymous…*
  * behind the irreversibility confirmation, gone once pressed (ADR-0012);
  * *Claim ownership* for a team admin who is not the owner (the server
  * decides `owner-present`); *Keep with a team…* for the owner of a
  * teamless retro who has a Team to give it to; *Retro settings…* opens the
  * settings dialog (spec §6.4), where a denied viewer reads the denial
- * rather than finding the door gone. Every item is a mutation on
+ * rather than finding the door gone. Every other item is a mutation on
  * room-owned state, so the menu renders only for an attendee.
  */
 export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, attribution, settings }: RetroMenuProps) {
@@ -118,6 +122,7 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, attribut
   const ratchet = useMutation(api.retro.ratchet);
   const claim = useMutation(api.retro.claim);
   const adopt = useMutation(api.retro.adoptIntoTeam);
+  const exportMarkdown = useExportMarkdown(roomId);
 
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -206,6 +211,7 @@ export function RetroMenu({ roomId, team, role, isOwnerAbsent, myTeams, attribut
           <MoreHorizontal className="size-4" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => void exportMarkdown()}>{EXPORT_MARKDOWN_MENU_ITEM}</DropdownMenuItem>
           {settings && (
             <DropdownMenuItem onClick={() => setSettingsOpen(true)}>{SETTINGS_MENU_ITEM}</DropdownMenuItem>
           )}

--- a/src/components/retro/use-export-markdown.test.tsx
+++ b/src/components/retro/use-export-markdown.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * useExportMarkdown — one retro as a Markdown file (spec §15.3): reads the
+ * export once through the client, hands the browser the file under the
+ * name the server chose, and raises the failure copy when the read is
+ * refused.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const spy = vi.hoisted(() => ({
+  queries: [] as unknown[],
+  fail: null as string | null,
+  downloads: [] as unknown[][],
+  toasts: [] as { kind: string; message: string }[],
+}));
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({
+    query: async (_ref: unknown, args: unknown) => {
+      spy.queries.push(args);
+      if (spy.fail) throw new Error(spy.fail);
+      return { filename: "Sprint 42.md", content: "# Sprint 42" };
+    },
+  }),
+}));
+vi.mock("@/utils/download-file", () => ({
+  downloadFile: (...args: unknown[]) => spy.downloads.push(args),
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (message: string) => spy.toasts.push({ kind: "success", message }),
+    error: (message: string) => spy.toasts.push({ kind: "error", message }),
+  },
+}));
+
+import { useExportMarkdown } from "./use-export-markdown";
+
+beforeEach(() => {
+  spy.queries = [];
+  spy.fail = null;
+  spy.downloads = [];
+  spy.toasts = [];
+});
+
+describe("useExportMarkdown", () => {
+  it("reads the export for the room and downloads it as Markdown under the server's file name", async () => {
+    const { result } = renderHook(() => useExportMarkdown("room-1" as never));
+    await result.current();
+    expect(spy.queries).toEqual([{ roomId: "room-1" }]);
+    expect(spy.downloads).toEqual([["# Sprint 42", "Sprint 42.md", "text/markdown;charset=utf-8"]]);
+    expect(spy.toasts).toEqual([]);
+  });
+
+  it("a refused read raises the server's copy and downloads nothing", async () => {
+    spy.fail = "You don't have access to this room";
+    const { result } = renderHook(() => useExportMarkdown("room-1" as never));
+    await result.current();
+    expect(spy.downloads).toEqual([]);
+    expect(spy.toasts).toEqual([{ kind: "error", message: "You don't have access to this room" }]);
+  });
+});

--- a/src/components/retro/use-export-markdown.ts
+++ b/src/components/retro/use-export-markdown.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+import { useConvex } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { downloadFile } from "@/utils/download-file";
+import { toast } from "@/lib/toast";
+import { EXPORT_MARKDOWN_FAILED } from "@/convex/retroCopy";
+
+/**
+ * One retro as Markdown (spec §15.3): a one-shot read of `retro.exportMarkdown`
+ * (no subscription: the file is a moment, not a view) handed to the
+ * browser as a download under the name the server chose. Anyone with room
+ * access may take one; the server's projections decide what is in it.
+ */
+export function useExportMarkdown(roomId: Id<"rooms">): () => Promise<void> {
+  const convex = useConvex();
+  return useCallback(async () => {
+    try {
+      const { filename, content } = await convex.query(api.retro.exportMarkdown, { roomId });
+      downloadFile(content, filename, "text/markdown;charset=utf-8");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : EXPORT_MARKDOWN_FAILED);
+    }
+  }, [convex, roomId]);
+}

--- a/src/hooks/useDeleteAccount.test.tsx
+++ b/src/hooks/useDeleteAccount.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * useDeleteAccount — Delete account for a permanent account (spec §15.2,
+ * ADR-0019): the user-deletion mutation first, then the session is signed
+ * out the way the sign-out hook does, the register's line is shown and the
+ * person lands on the homepage. A refused deletion (the last-admin rule)
+ * surfaces the server's copy and signs nothing out.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const spy = vi.hoisted(() => ({
+  order: [] as string[],
+  deleteFails: null as string | null,
+  toasts: [] as { kind: string; message: string }[],
+  push: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => async () => {
+    if (spy.deleteFails) throw new Error(spy.deleteFails);
+    spy.order.push("deleteUser");
+  },
+}));
+vi.mock("@/hooks/useSignOut", () => ({
+  useSignOut: () => async () => {
+    spy.order.push("signOut");
+  },
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: spy.push }) }));
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (message: string) => spy.toasts.push({ kind: "success", message }),
+    error: (message: string) => spy.toasts.push({ kind: "error", message }),
+  },
+}));
+
+import { useDeleteAccount } from "./useDeleteAccount";
+import { ACCOUNT_DELETED } from "@/convex/retroCopy";
+
+beforeEach(() => {
+  spy.order = [];
+  spy.deleteFails = null;
+  spy.toasts = [];
+  spy.push.mockReset();
+});
+
+describe("useDeleteAccount", () => {
+  it("deletes the account, then signs out, tells what stays, and goes home", async () => {
+    const { result } = renderHook(() => useDeleteAccount());
+    expect(await result.current()).toBe(true);
+    expect(spy.order).toEqual(["deleteUser", "signOut"]);
+    expect(spy.toasts).toEqual([{ kind: "success", message: ACCOUNT_DELETED }]);
+    expect(spy.push).toHaveBeenCalledWith("/");
+  });
+
+  it("a refused deletion surfaces the server's copy and signs nothing out", async () => {
+    spy.deleteFails = "Make someone else an admin first, or delete the team.";
+    const { result } = renderHook(() => useDeleteAccount());
+    expect(await result.current()).toBe(false);
+    expect(spy.order).toEqual([]);
+    expect(spy.toasts).toEqual([{ kind: "error", message: "Make someone else an admin first, or delete the team." }]);
+    expect(spy.push).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDeleteAccount.ts
+++ b/src/hooks/useDeleteAccount.ts
@@ -1,0 +1,34 @@
+import { useMutation } from "convex/react";
+import { useRouter } from "next/navigation";
+import { api } from "@/convex/_generated/api";
+import { useSignOut } from "@/hooks/useSignOut";
+import { toast } from "@/lib/toast";
+import { ACCOUNT_DELETED, DELETE_ACCOUNT_FAILED } from "@/convex/retroCopy";
+
+/**
+ * Delete account for a permanent account (spec §15.2, ADR-0019): the same
+ * user-deletion mutation sign-out already runs for an anonymous account,
+ * then the session is cleared the way the sign-out hook does. Content
+ * stays behind unnamed; the auth provider's own record is untouched. A
+ * refusal (the last-admin rule) shows the server's copy and signs nothing
+ * out, so the person can fix the Team and try again. Returns whether the
+ * account is gone.
+ */
+export function useDeleteAccount(): () => Promise<boolean> {
+  const deleteUser = useMutation(api.users.deleteUser);
+  const signOut = useSignOut();
+  const router = useRouter();
+
+  return async () => {
+    try {
+      await deleteUser({});
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : DELETE_ACCOUNT_FAILED);
+      return false;
+    }
+    await signOut();
+    toast.success(ACCOUNT_DELETED);
+    router.push("/");
+    return true;
+  };
+}


### PR DESCRIPTION
Closes #299 (second of two PRs; stacked on #324).

## What

**`retro.exportMarkdown`** (spec §15.3) under `requireRoomReader`, from the board header menu and from the Team reader's banner (a reader without a seat has no menu, and anyone with room access may export). Content: the retro's facts, each topic with its cards under their prompts and its dot count, the walk as covered / not covered then the topics outside it, then the action items with owner, due date, status and note. It runs through `projectCard` with the requester as reader, the attribution projection and the tally's own dot-count rule, so a hidden entry exports "(hidden card)", an anonymous retro has no authors, a hidden vote round has no counts, and no export names a voter.

**`teams.exportHistory`** (spec §15.4) is an action that pages the Team's rooms through `by_team` and reads each board through `retro.exportBoard` as the caller, so every read runs under its own guard. One JSON file of every retro in creation order in the board's shape, with the tally's counts and the names beside it, plus the Team's action items. Downloaded from the team page's Retros header. No share page.

**Delete account** (spec §15.2) in Settings → Account for permanent accounts: the existing user-deletion mutation, then the session signed out the way the sign-out hook does, then "/". Cards, dots and action items stay with dangling references that render "Former member"; a team retro whose owner deletes their account is in lockdown and `claim` recovers it.

The last commit is the `/code-review` follow-up: `countDots` in `retroVotes` is the one dot-count rule (a member card's dot carrying into its cluster) shared by the tally and the export; `TeamFacts` extends `ActionCounts`; the team cap has its own name instead of shadowing the per-retro one.

## Notes for review

- The JSON export's board read is the identity-free one (spec §9): the requester's own hidden text travels in `retro.mine` and in the Markdown export, not in the Team's JSON. Documented on `exportBoard`.
- Delete account toasts the register's line once the user row is gone, even if the sign-out hook swallowed a failure; the account is removed either way.

## Verification

- convex-test `convex/retroExport.test.ts` (8): silhouettes in `collect`, no authors in anonymous, no voters anywhere, hidden round exports no counts, non-reader and non-team-member refused, the JSON pages every retro.
- convex-test `convex/accountDeletion.test.ts` (3): dangling refs remain, "Former member" on actions and in the export, `isOwnerAbsent` then `claim` recovers.
- jsdom tests for the menu item, the reader banner, `useExportMarkdown`, `useDeleteAccount`, the Account tab dialog, the team page export button.
- Full suite green (126 files, 1175 tests), `ts:check` and eslint clean.

https://claude.ai/code/session_01G9bjAL6awe9ayTe8X2MnqS
