### PR TITLE
feat(retro): homepage — two ceremonies, one toolkit (#300)

### DIFF
--- a/src/app/home-content.tsx
+++ b/src/app/home-content.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Play } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import {
+  Ceremonies,
   HowItWorks,
   FAQ,
   UseCases,
@@ -13,6 +14,7 @@ import {
 } from "@/components/homepage";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
+import { HERO } from "@/components/homepage/copy";
 
 interface VersionInfo {
   version: string;
@@ -48,41 +50,41 @@ export function HomeContent({ versionInfo }: HomeContentProps) {
               {/* Left Column */}
               <div className="flex flex-col items-start lg:py-20">
                 <Link
-                  href="/blog/jira-integration"
+                  href={HERO.badgeHref}
                   className="inline-flex items-center gap-2 mb-8 rounded-full bg-white/60 dark:bg-zinc-800/60 backdrop-blur-md px-4 py-1.5 text-sm font-medium text-primary hover:bg-white/80 dark:hover:bg-zinc-800/80 transition-colors shadow-sm"
                 >
                   <span className="inline-flex items-center rounded-full bg-primary px-2 py-0.5 text-[11px] font-bold text-primary-foreground leading-none">
                     {versionInfo ? `v${versionInfo.version}` : "New"}
                   </span>
-                  <span>Jira Cloud integration is here</span>
+                  <span>{HERO.badge}</span>
                   <ArrowRight className="h-3.5 w-3.5" />
                 </Link>
                 
                 <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                  Planning poker,<br />
-                  <span className="text-gray-300 dark:text-zinc-700">without the noise.</span>
+                  {HERO.headline}<br />
+                  <span className="text-gray-300 dark:text-zinc-700">{HERO.headlineMuted}</span>
                 </h1>
                 
                 <p className="mt-8 text-xl sm:text-2xl leading-relaxed text-gray-600 dark:text-gray-400 max-w-xl font-light">
-                  A radically simple estimation tool for agile teams. 
-                  No accounts required. Free forever. Start a session instantly.
+                  {HERO.description}
                 </p>
                 
                 <div className="mt-12 flex flex-col sm:flex-row items-center gap-4 w-full sm:w-auto">
                   <Link
-                    href="/room/new"
-                    data-testid="hero-start-button"
+                    href={HERO.estimate.href}
+                    data-testid={HERO.estimate.testId}
                     className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
                   >
-                    Start Session
+                    {HERO.estimate.label}
                     <ArrowRight className="h-5 w-5" />
                   </Link>
                   <Link
-                    href="/demo"
+                    href={HERO.retro.href}
+                    data-testid={HERO.retro.testId}
                     className="inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
                   >
-                    <Play className="h-5 w-5" fill="currentColor" />
-                    Interactive Demo
+                    {HERO.retro.label}
+                    <ArrowRight className="h-5 w-5" />
                   </Link>
                 </div>
               </div>
@@ -103,7 +105,7 @@ export function HomeContent({ versionInfo }: HomeContentProps) {
                   <iframe
                     src="/demo?embed=true"
                     className="absolute inset-0 w-[calc(100%+2px)] h-[calc(100%+2px)] -left-[1px] -top-[1px] border-none outline-none ring-0"
-                    title="Live Planning Poker Demo"
+                    title={HERO.demoFrameTitle}
                     sandbox="allow-scripts allow-same-origin"
                     style={{ border: 'none', outline: 'none' }}
                   />
@@ -113,6 +115,7 @@ export function HomeContent({ versionInfo }: HomeContentProps) {
           </div>
         </section>
 
+        <Ceremonies />
         <HowItWorks />
         <AppPreview />
         <FeaturesSection />

--- a/src/components/homepage/app-preview.tsx
+++ b/src/components/homepage/app-preview.tsx
@@ -1,95 +1,125 @@
+"use client";
+
 import Image from "next/image";
-import { Zap, Shield, TrendingUp } from "lucide-react";
+import { useState, type ComponentType } from "react";
+import { Zap, Shield, BarChart3, PenLine, EyeOff, History } from "lucide-react";
+import { APP_PREVIEW } from "./copy";
+import { CeremonyTabs, CeremonyTabList, CeremonyTabPanel, type Ceremony } from "./ceremony-tabs";
 
-const features = [
-  {
-    name: "Zero friction.",
-    description: "Create and join rooms instantly. No account creation slowing down your sprint planning.",
-    icon: Zap,
-  },
-  {
-    name: "Unbiased voting.",
-    description: "Cards remain hidden until everyone has voted, ensuring independent estimation.",
-    icon: Shield,
-  },
-  {
-    name: "Clear insights.",
-    description: "Visualize team agreement and identify outliers immediately upon revealing votes.",
-    icon: TrendingUp,
-  },
-];
+type FeatureId =
+  | (typeof APP_PREVIEW.poker.features)[number]["id"]
+  | (typeof APP_PREVIEW.retro.features)[number]["id"];
 
+// Icons are keyed by the copy's ids; the words live in copy.ts.
+const ICONS: Record<FeatureId, ComponentType<{ className?: string; strokeWidth?: number }>> = {
+  friction: Zap,
+  unbiased: Shield,
+  results: BarChart3,
+  parallel: PenLine,
+  anonymous: EyeOff,
+  history: History,
+};
+
+const CEREMONIES: Ceremony[] = ["poker", "retro"];
+
+/** Both boards (spec §18.2): the retro slot ships with the poker image until the manual capture. */
 export function AppPreview() {
+  const [ceremony, setCeremony] = useState<Ceremony>("poker");
+  const slot = APP_PREVIEW[ceremony];
+
   return (
-    <section className="bg-white dark:bg-black py-24 sm:py-32">
-      <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
+    <section id="app-preview" className="bg-white dark:bg-black py-24 sm:py-32">
+      <CeremonyTabs
+        value={ceremony}
+        onValueChange={setCeremony}
+        className="mx-auto max-w-[90rem] px-6 lg:px-8"
+      >
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-16 lg:gap-24 items-center">
-          
+
           <div className="lg:col-span-5 flex flex-col">
             <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-              Interface
+              {APP_PREVIEW.eyebrow}
             </h2>
             <h3 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-              Designed for focus.
+              {APP_PREVIEW.heading}
             </h3>
-            <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light mb-12">
-              A distraction-free environment that keeps your team focused on the conversation, not the tool.
+            <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light mb-8">
+              {APP_PREVIEW.description}
             </p>
 
-            <div className="space-y-8">
-              {features.map((feature) => (
-                <div key={feature.name} className="flex gap-4">
-                  <div className="mt-1 flex-shrink-0 p-3 bg-gray-50 dark:bg-zinc-900 rounded-2xl h-fit">
-                    <feature.icon className="w-5 h-5 text-gray-900 dark:text-white" strokeWidth={2} />
+            <CeremonyTabList
+              prefix="app-preview"
+              labels={APP_PREVIEW.tabs}
+              className="self-start mb-12"
+            />
+
+            <div key={ceremony} className="space-y-8 animate-in fade-in duration-300">
+              {slot.features.map((feature) => {
+                const Icon = ICONS[feature.id];
+                return (
+                  <div key={feature.id} className="flex gap-4">
+                    <div className="mt-1 flex-shrink-0 p-3 bg-gray-50 dark:bg-zinc-900 rounded-2xl h-fit">
+                      <Icon className="w-5 h-5 text-gray-900 dark:text-white" strokeWidth={2} />
+                    </div>
+                    <div>
+                      <h4 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
+                        {feature.name}
+                      </h4>
+                      <p className="text-base text-gray-600 dark:text-gray-400 font-light leading-relaxed">
+                        {feature.description}
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <h4 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
-                      {feature.name}
-                    </h4>
-                    <p className="text-base text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                      {feature.description}
-                    </p>
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
 
           <div className="lg:col-span-7 relative">
-            <div className="relative w-full aspect-square sm:aspect-video lg:aspect-[4/3] rounded-[2rem] overflow-hidden border border-gray-200/80 dark:border-zinc-800/80 bg-white dark:bg-black flex flex-col ring-1 ring-inset ring-black/5 dark:ring-white/5">
-              {/* macOS style browser header */}
-              <div className="flex items-center gap-2 px-4 h-6 sm:h-8 bg-gray-50/80 dark:bg-zinc-900/80 border-b border-gray-200/50 dark:border-zinc-800/50 backdrop-blur-md shrink-0">
-                <div className="flex gap-1.5 sm:gap-2">
-                  <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-red-400 dark:bg-red-500"></div>
-                  <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-amber-400 dark:bg-amber-500"></div>
-                  <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-green-400 dark:bg-green-500"></div>
-                </div>
-              </div>
-              {/* Simulated Glass overlay on top of image container */}
-              <div className="absolute inset-0 pointer-events-none ring-1 ring-inset ring-black/5 dark:ring-white/5 rounded-[2rem] z-10"></div>
-              <div className="relative flex-1 w-full bg-white dark:bg-black">
-                <Image
-                  alt="Planning Poker app interface showing real-time collaboration"
-                  src="/agilekit_light.png"
-                  fill
-                  className="object-cover object-left-top dark:hidden"
-                  sizes="(max-width: 1024px) 100vw, 60vw"
-                  priority
-                />
-                <Image
-                  alt="Planning Poker app interface showing real-time collaboration"
-                  src="/agilekit_dark.png"
-                  fill
-                  className="object-cover object-left-top hidden dark:block"
-                  sizes="(max-width: 1024px) 100vw, 60vw"
-                  priority
-                />
-              </div>
-            </div>
+            {CEREMONIES.map((c) => (
+              <CeremonyTabPanel key={c} value={c}>
+                <PreviewFrame image={APP_PREVIEW[c].image} />
+              </CeremonyTabPanel>
+            ))}
           </div>
 
         </div>
-      </div>
+      </CeremonyTabs>
     </section>
+  );
+}
+
+function PreviewFrame({ image }: { image: { light: string; dark: string; alt: string } }) {
+  return (
+    <div className="relative w-full aspect-square sm:aspect-video lg:aspect-[4/3] rounded-[2rem] overflow-hidden border border-gray-200/80 dark:border-zinc-800/80 bg-white dark:bg-black flex flex-col ring-1 ring-inset ring-black/5 dark:ring-white/5">
+      {/* macOS style browser header */}
+      <div className="flex items-center gap-2 px-4 h-6 sm:h-8 bg-gray-50/80 dark:bg-zinc-900/80 border-b border-gray-200/50 dark:border-zinc-800/50 backdrop-blur-md shrink-0">
+        <div className="flex gap-1.5 sm:gap-2">
+          <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-red-400 dark:bg-red-500"></div>
+          <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-amber-400 dark:bg-amber-500"></div>
+          <div className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-green-400 dark:bg-green-500"></div>
+        </div>
+      </div>
+      {/* Simulated Glass overlay on top of image container */}
+      <div className="absolute inset-0 pointer-events-none ring-1 ring-inset ring-black/5 dark:ring-white/5 rounded-[2rem] z-10"></div>
+      <div className="relative flex-1 w-full bg-white dark:bg-black">
+        <Image
+          alt={image.alt}
+          src={image.light}
+          fill
+          className="object-cover object-left-top dark:hidden"
+          sizes="(max-width: 1024px) 100vw, 60vw"
+          priority
+        />
+        <Image
+          alt={image.alt}
+          src={image.dark}
+          fill
+          className="object-cover object-left-top hidden dark:block"
+          sizes="(max-width: 1024px) 100vw, 60vw"
+          priority
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/homepage/call-to-action.tsx
+++ b/src/components/homepage/call-to-action.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import { CALL_TO_ACTION } from "./copy";
 
 export const CallToAction = () => {
   return (
@@ -7,30 +8,37 @@ export const CallToAction = () => {
       <div className="mx-auto max-w-[90rem] px-6 lg:px-8 relative z-10">
         <div className="relative rounded-[3rem] overflow-hidden bg-black dark:bg-white py-24 px-6 sm:px-12 text-center">
           <div className="absolute inset-0 bg-[linear-gradient(to_right,#ffffff15_1px,transparent_1px),linear-gradient(to_bottom,#ffffff15_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,#00000015_1px,transparent_1px),linear-gradient(to_bottom,#00000015_1px,transparent_1px)] bg-[size:4rem_4rem]"></div>
-          
+
           <div className="relative z-10 max-w-3xl mx-auto">
             <h2 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tighter text-white dark:text-black mb-8 leading-[1.05]">
-              Ready to estimate?
+              {CALL_TO_ACTION.heading}
             </h2>
             <p className="text-xl sm:text-2xl text-gray-400 dark:text-gray-600 mb-12 font-light">
-              Start your first planning session in seconds. Zero configuration, zero friction.
+              {CALL_TO_ACTION.description}
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <Link
-                href="/room/new"
+                href={CALL_TO_ACTION.estimate.href}
                 className="inline-flex h-16 w-full sm:w-auto items-center justify-center gap-2 bg-white dark:bg-black px-12 text-lg font-bold tracking-tight text-black dark:text-white hover:scale-105 transition-transform duration-200 rounded-2xl"
               >
-                Create Free Room
+                {CALL_TO_ACTION.estimate.label}
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+              <Link
+                href={CALL_TO_ACTION.retro.href}
+                className="inline-flex h-16 w-full sm:w-auto items-center justify-center gap-2 bg-white dark:bg-black px-12 text-lg font-bold tracking-tight text-black dark:text-white hover:scale-105 transition-transform duration-200 rounded-2xl"
+              >
+                {CALL_TO_ACTION.retro.label}
                 <ArrowRight className="h-5 w-5" />
               </Link>
               <a
-                href="https://github.com/spokvulcan/poker-planning"
+                href={CALL_TO_ACTION.github.href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex h-16 w-full sm:w-auto items-center justify-center bg-transparent border-2 border-white/20 dark:border-black/20 px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:bg-white/10 dark:hover:bg-black/10 transition-colors rounded-2xl"
               >
-                View on GitHub
+                {CALL_TO_ACTION.github.label}
               </a>
             </div>
           </div>

--- a/src/components/homepage/ceremonies.tsx
+++ b/src/components/homepage/ceremonies.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+import { ArrowRight, Check, Play } from "lucide-react";
+import { CEREMONIES } from "./copy";
+
+/**
+ * Two ceremonies, one toolkit (spec §18.2, ADR-0014): one card per ceremony
+ * directly under the hero, each with its own CTA. The poker card carries the
+ * Interactive Demo; there is no retro demo.
+ */
+export function Ceremonies() {
+  const { poker, retro } = CEREMONIES;
+  return (
+    <section id="toolkit" className="bg-white dark:bg-black py-24 sm:py-32 border-t border-gray-100 dark:border-zinc-900">
+      <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
+        <div className="max-w-2xl mb-16">
+          <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
+            {CEREMONIES.eyebrow}
+          </h2>
+          <p className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
+            {CEREMONIES.heading}<br />
+            <span className="text-gray-400 dark:text-zinc-600">{CEREMONIES.headingMuted}</span>
+          </p>
+          <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light">
+            {CEREMONIES.description}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <CeremonyCard
+            name={poker.name}
+            description={poker.description}
+            points={poker.points}
+            testId="toolkit-card-poker"
+          >
+            <Link
+              href={poker.cta.href}
+              className="inline-flex h-14 items-center justify-center gap-2 bg-black dark:bg-white px-8 text-base font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
+            >
+              {poker.cta.label}
+              <ArrowRight className="h-5 w-5" />
+            </Link>
+            <Link
+              href={poker.demo.href}
+              className="inline-flex h-14 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-8 text-base font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
+            >
+              <Play className="h-5 w-5" fill="currentColor" />
+              {poker.demo.label}
+            </Link>
+          </CeremonyCard>
+
+          <CeremonyCard
+            name={retro.name}
+            description={retro.description}
+            points={retro.points}
+            testId="toolkit-card-retro"
+          >
+            <Link
+              href={retro.cta.href}
+              className="inline-flex h-14 items-center justify-center gap-2 bg-black dark:bg-white px-8 text-base font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
+            >
+              {retro.cta.label}
+              <ArrowRight className="h-5 w-5" />
+            </Link>
+          </CeremonyCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CeremonyCard({
+  name,
+  description,
+  points,
+  testId,
+  children,
+}: {
+  name: string;
+  description: string;
+  points: readonly string[];
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-col p-8 sm:p-10 rounded-[2rem] bg-gray-50/50 dark:bg-surface-1 border border-gray-200/50 dark:border-zinc-800/50"
+    >
+      <h3 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
+        {name}
+      </h3>
+      <p className="text-lg text-gray-600 dark:text-gray-400 font-light leading-relaxed mb-8">
+        {description}
+      </p>
+      <ul className="space-y-3 mb-10 flex-1">
+        {points.map((point) => (
+          <li key={point} className="flex items-start gap-3 text-base font-medium text-gray-900 dark:text-gray-200">
+            <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-200/50 dark:bg-zinc-800/50">
+              <Check className="h-3.5 w-3.5 text-gray-900 dark:text-white" />
+            </span>
+            {point}
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-col sm:flex-row gap-4">{children}</div>
+    </div>
+  );
+}

--- a/src/components/homepage/ceremony-tabs.tsx
+++ b/src/components/homepage/ceremony-tabs.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+/** The two ceremonies a homepage section can be tabbed by (ADR-0014). */
+export type Ceremony = "poker" | "retro";
+
+const ORDER: Ceremony[] = ["poker", "retro"];
+
+export const tabTestId = (prefix: string, ceremony: Ceremony) => `${prefix}-tab-${ceremony}`;
+
+interface CeremonyTabsProps {
+  /** Controlled value; leave unset for an uncontrolled switch that starts on poker. */
+  value?: Ceremony;
+  onValueChange?: (ceremony: Ceremony) => void;
+  className?: string;
+  children: ReactNode;
+}
+
+/** One tabbed section: the shadcn/Base UI Tabs root, which owns the roles and the arrow keys. */
+export function CeremonyTabs({ value, onValueChange, className, children }: CeremonyTabsProps) {
+  return (
+    <Tabs
+      value={value}
+      defaultValue={value === undefined ? "poker" : undefined}
+      onValueChange={(next) => onValueChange?.(next as Ceremony)}
+      className={cn("block", className)}
+    >
+      {children}
+    </Tabs>
+  );
+}
+
+interface CeremonyTabListProps {
+  /** Prefix for the triggers' test ids, e.g. `how-it-works`. */
+  prefix: string;
+  labels: Record<Ceremony, string>;
+  className?: string;
+}
+
+/** The two triggers as a pill switch. */
+export function CeremonyTabList({ prefix, labels, className }: CeremonyTabListProps) {
+  return (
+    <TabsList
+      aria-label={`${labels.poker} or ${labels.retro}`}
+      className={cn("rounded-full p-1", className)}
+    >
+      {ORDER.map((ceremony) => (
+        <TabsTrigger
+          key={ceremony}
+          value={ceremony}
+          data-testid={tabTestId(prefix, ceremony)}
+          className="rounded-full px-5 font-bold tracking-tight"
+        >
+          {labels[ceremony]}
+        </TabsTrigger>
+      ))}
+    </TabsList>
+  );
+}
+
+/** The panel a trigger controls; unmounted while inactive, so its animations stop. */
+export function CeremonyTabPanel({
+  value,
+  className,
+  children,
+}: {
+  value: Ceremony;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <TabsContent value={value} className={cn("text-base animate-in fade-in duration-300", className)}>
+      {children}
+    </TabsContent>
+  );
+}

--- a/src/components/homepage/copy.ts
+++ b/src/components/homepage/copy.ts
@@ -1,0 +1,435 @@
+/**
+ * The homepage's copy (spec §18.2–§18.4, ADR-0014), in one plain module the
+ * section components render from, so `src/lib/claims-register.test.ts` can
+ * read every register-checked line without a DOM. Two ceremonies, one
+ * toolkit: poker copy is kept and scoped under its ceremony, never deleted;
+ * retro copy says only what the storage backs (the claims register, §18.3).
+ *
+ * Words (§18.4): "Retro" wherever a person reads it, "retrospective" only in
+ * long-form copy; "session" only inside planning poker; "ceremony" never.
+ */
+
+import { START_ESTIMATING, START_RETRO } from "@/lib/site-copy";
+
+export interface Cta {
+  label: string;
+  href: string;
+  testId?: string;
+}
+
+// --- Hero ---
+
+export const HERO = {
+  badge: "Jira Cloud integration is here",
+  badgeHref: "/blog/jira-integration",
+  headline: "Estimate and reflect,",
+  headlineMuted: "without the noise.",
+  description:
+    "Planning poker and retros for Scrum teams that think in writing, everyone at once. No accounts required. Free forever. Open source.",
+  estimate: { ...START_ESTIMATING, testId: "hero-start-button" } satisfies Cta,
+  retro: { ...START_RETRO, testId: "hero-retro-button" } satisfies Cta,
+  /** The framed poker simulation (ADR-0003). There is no retro demo (ADR-0014). */
+  demoFrameTitle: "Live Planning Poker Demo",
+};
+
+// --- Two ceremonies, one toolkit (directly under the hero) ---
+
+export const CEREMONIES = {
+  eyebrow: "One toolkit",
+  heading: "Plan the sprint.",
+  headingMuted: "Reflect on it.",
+  description:
+    "Planning poker for the estimates, Retro for what the team learned. Both free, both open source, both one link away.",
+  poker: {
+    name: "Planning poker",
+    description:
+      "Everyone picks a card, cards stay hidden until all have voted, and the numbers land in front of the team. Rooms open instantly, no accounts required.",
+    points: [
+      "Fibonacci, T-shirt or your own scale",
+      "Jira Cloud sync and CSV export",
+      "Timer, spectators and issues",
+    ],
+    cta: START_ESTIMATING satisfies Cta,
+    demo: { label: "Interactive Demo", href: "/demo" } satisfies Cta,
+  },
+  retro: {
+    name: "Retro",
+    description:
+      "Everyone writes cards at once, in the meeting or before it. Group them, vote with dots, walk the topics and leave with action items.",
+    points: [
+      "Six formats, or edit your own",
+      "Anonymous or named, chosen per team",
+      "History kept for the team, free",
+    ],
+    cta: START_RETRO satisfies Cta,
+  },
+};
+
+// --- How it works, tabbed per ceremony ---
+
+export const HOW_IT_WORKS = {
+  eyebrow: "How it works",
+  heading: "A refined workflow for",
+  headingMuted: "both halves of the sprint.",
+  tabs: { poker: "Planning poker", retro: "Retro" },
+  poker: {
+    steps: [
+      {
+        number: "01",
+        title: "Create Room Instantly",
+        description:
+          "Start a session with zero configuration. No sign-up required, no passwords to remember. Just click and go.",
+      },
+      {
+        number: "02",
+        title: "Invite Team",
+        description: "Share the secure link. Members join from any browser.",
+      },
+      {
+        number: "03",
+        title: "Estimate",
+        description: "Simultaneous voting to eliminate anchoring bias.",
+      },
+      {
+        number: "04",
+        title: "Align & Conquer",
+        description:
+          "Reveal votes, discuss discrepancies, and establish consensus faster than ever before.",
+      },
+    ],
+    /** Strings the poker step animations draw. */
+    animation: {
+      roomName: "Sprint 42 Planning",
+      startButton: "Start Session",
+      created: "Room Created!",
+      you: "You",
+      waiting: "Waiting for others...",
+      consensus: "Consensus:",
+    },
+  },
+  retro: {
+    steps: [
+      {
+        number: "01",
+        title: "Open a board",
+        description:
+          "Pick a format, name the retro and share the link. Keep it with a team, or run it with no account at all.",
+      },
+      {
+        number: "02",
+        title: "Write in parallel",
+        description:
+          "Everyone writes at once, before the meeting or in it. Cards stay hidden until revealed.",
+      },
+      {
+        number: "03",
+        title: "Group and vote",
+        description:
+          "Drag cards into groups, then spend your dots on what matters.",
+      },
+      {
+        number: "04",
+        title: "Discuss and decide",
+        description:
+          "Walk the topics in vote order and write action items with owners. In a team retro, open ones come back next time.",
+      },
+    ],
+    /** Strings the retro step animations draw. */
+    animation: {
+      formatName: "Start, Stop, Continue",
+      startButton: "Start a retro",
+      created: "Board open",
+      hidden: "Hidden until reveal",
+      cards: ["Fewer meetings", "Pairing on the API", "Flaky deploys"],
+      groupLabel: "Flow",
+      dots: 3,
+      topic: "Flaky deploys",
+      action: "Owner: Bea",
+    },
+  },
+};
+
+// --- App preview: both boards ---
+
+export const APP_PREVIEW = {
+  eyebrow: "Interface",
+  heading: "Designed for focus.",
+  description:
+    "A distraction-free environment that keeps your team on the conversation, not the tool.",
+  tabs: { poker: "Planning poker", retro: "Retro" },
+  poker: {
+    image: {
+      light: "/agilekit_light.png",
+      dark: "/agilekit_dark.png",
+      alt: "Planning poker room showing players, cards and results",
+    },
+    features: [
+      {
+        id: "friction",
+        name: "Zero friction.",
+        description:
+          "Create and join rooms instantly. No account creation slowing down your sprint planning.",
+      },
+      {
+        id: "unbiased",
+        name: "Unbiased voting.",
+        description:
+          "Cards remain hidden until everyone has voted, ensuring independent estimation.",
+      },
+      {
+        id: "results",
+        name: "Clear results.",
+        description:
+          "See where the team agrees and who the outlier is the moment votes are revealed.",
+      },
+    ] as const,
+  },
+  retro: {
+    /**
+     * Ships with the poker image until the retro board is captured by hand
+     * (light and dark), a manual step named in the PR. Swap both paths and
+     * the alt text when the captures land under public/.
+     */
+    image: {
+      light: "/agilekit_light.png",
+      dark: "/agilekit_dark.png",
+      alt: "AgileKit board preview",
+    },
+    features: [
+      {
+        id: "parallel",
+        name: "Everyone at once.",
+        description:
+          "Everyone writes at the same time, in the meeting or before it. Cards stay hidden until they are revealed together.",
+      },
+      {
+        id: "anonymous",
+        name: "Anonymous when you choose.",
+        description:
+          "In an anonymous retro no author is stored with a card, not even for the facilitator.",
+      },
+      {
+        id: "history",
+        name: "Nothing forgotten.",
+        description:
+          "History and open action items stay with the team from one retro to the next, free.",
+      },
+    ] as const,
+  },
+};
+
+// --- Capabilities (the homepage feature list) ---
+
+export const CAPABILITIES = {
+  eyebrow: "Capabilities",
+  heading: "Everything you need.",
+  headingMuted: "Nothing you don't.",
+  description:
+    "One toolkit for estimating and reflecting. Core functionality is completely free and instantly accessible.",
+  cta: { label: "View full feature list", href: "/features" } satisfies Cta,
+  poker: {
+    name: "Planning poker",
+    features: [
+      "Unlimited team members",
+      "Unlimited sessions",
+      "Real-time updates",
+      "Multiple voting scales",
+      "Issues management",
+      "Jira Cloud integration",
+      "CSV export with stats",
+      "Session timer",
+      "Spectator mode",
+    ],
+  },
+  retro: {
+    name: "Retro",
+    features: [
+      "Six retro formats",
+      "Cards written in parallel",
+      "Anonymous or named retros",
+      "Dot voting and a guided discussion",
+      "Action items with owners",
+      "History kept for the team",
+      "Markdown and JSON export",
+    ],
+  },
+};
+
+// --- Pricing section (also rendered on /pricing) ---
+
+export const PRICING_SECTION = {
+  eyebrow: "Pricing",
+  heading: "Transparent pricing.",
+  description:
+    "Start using AgileKit completely free today. A Pro tier for planning poker, with integrations and deeper analytics, is in development.",
+  badge: "In Development",
+  tiers: [
+    {
+      id: "free",
+      name: "Free",
+      price: "$0",
+      period: "forever",
+      description: "For every team: planning poker rooms and retros, free.",
+      features: [
+        "Unlimited participants",
+        "Real-time voting & whiteboard",
+        "5-day history for planning poker rooms",
+        "Basic results analytics",
+        "CSV exports",
+        "Retros, with history kept for the team",
+      ],
+      cta: "Start planning for free",
+      href: "/room/new",
+      disabled: false,
+    },
+    {
+      id: "pro",
+      name: "Pro",
+      price: "Coming Soon",
+      period: "",
+      description:
+        "For engineering teams that want deeper planning poker analytics and workflow automation.",
+      features: [
+        "Everything in Free, plus:",
+        "Time-to-consensus tracking",
+        "Voter alignment matrix",
+        "Sprint predictability score",
+        "Two-way Jira & GitHub sync",
+        "Unlimited session history",
+      ],
+      cta: "Join Waitlist",
+      href: "#",
+      disabled: true,
+    },
+  ],
+};
+
+// --- Use cases ---
+
+export const USE_CASES = {
+  eyebrow: "Architecture",
+  heading: "Built for modern teams.",
+  description:
+    "Under the hood, a real-time sync engine ensures every vote, card, reveal and state change lands instantly across all clients.",
+  items: [
+    {
+      id: "remote",
+      title: "Remote-first",
+      description: "Real-time collaboration that works seamlessly across continents.",
+    },
+    {
+      id: "instant",
+      title: "Instant execution",
+      description: "No lag, no waiting. Built on a high-performance reactive backend.",
+    },
+    {
+      id: "data",
+      title: "Data-driven estimates",
+      description: "Visualize voting patterns to identify disagreement and align quickly.",
+    },
+    {
+      id: "async",
+      title: "Async by default",
+      description:
+        "Open a retro before the meeting; the board is already full when everyone arrives.",
+    },
+    {
+      id: "access",
+      title: "Universal access",
+      description: "Designed for all teams. No accounts required to participate.",
+    },
+    {
+      id: "history",
+      title: "Nothing forgotten",
+      description:
+        "Retro history and open action items stay with the team, sprint after sprint.",
+    },
+  ] as const,
+};
+
+// --- FAQ (the visible list; the structured-data list is components/seo/copy.ts) ---
+
+export const FAQ = {
+  eyebrow: "FAQ",
+  heading: "Common",
+  headingMuted: "questions.",
+  description:
+    "Everything you need to know about AgileKit, how it works, and our commitment to keeping it free.",
+  stillQuestions: "Still have questions?",
+  reachOut: "Reach out to us on GitHub or check our detailed documentation.",
+  github: {
+    label: "View GitHub",
+    href: "https://github.com/spokvulcan/poker-planning",
+  } satisfies Cta,
+  items: [
+    {
+      question: "What is Planning Poker?",
+      answer:
+        "Planning Poker is an agile estimation technique where team members use cards to vote on the complexity of user stories. It helps teams reach consensus on effort estimates through discussion and collaboration, making sprint planning more accurate and engaging.",
+    },
+    {
+      question: "Does AgileKit do retros too?",
+      answer:
+        "Yes. A retro is a board your team writes on together: everyone adds cards at once, in the meeting or before it, then you group them, vote with dots and walk through the topics. Start one from the homepage with no account, or keep it with a team so its history and action items are there next sprint. Retros are free for every team.",
+    },
+    {
+      question: "How much does AgileKit cost?",
+      answer:
+        "AgileKit's core features are free with no limitations on team size or number of planning poker rooms. As an open-source project, we believe in making quality tools accessible to everyone. We may introduce optional paid features for planning poker in the future, but the core planning poker functionality will always remain free.",
+    },
+    {
+      question: "Do I need to create an account?",
+      answer:
+        "No account is required! Click 'Start estimating' or 'Start a retro' and share the link with your team. We designed it this way to remove barriers and get your team going as quickly as possible. A team that wants to keep its retro history signs in, so the history has a knowable set of readers.",
+    },
+    {
+      question: "Can retro cards be anonymous?",
+      answer:
+        "Yes. A team can make its retros anonymous: no author is stored with a card, not even for the facilitator. Votes are counted but nobody is shown how you voted. Anyone with the link can join a retro that is not kept by a team.",
+    },
+    {
+      question: "How many people can join a planning session?",
+      answer:
+        "There's no limit on the number of participants in a planning session. Whether you have 5 or 500 team members, everyone can join and participate seamlessly.",
+    },
+    {
+      question: "What voting scale does AgileKit use?",
+      answer:
+        "AgileKit uses the Fibonacci sequence (0, 1, 2, 3, 5, 8, 13, 21, ?) which is the industry standard for story point estimation. We're working on adding T-shirt sizes and custom scales in a future update.",
+    },
+    {
+      question: "Can I use this tool offline or self-host it?",
+      answer:
+        "While the online version requires an internet connection, the entire codebase is open-source on GitHub. You can download and host your own instance for offline use or to meet specific security requirements.",
+    },
+    {
+      question: "What browsers and devices are supported?",
+      answer:
+        "AgileKit works on all modern browsers (Chrome, Firefox, Safari, Edge) and is fully responsive on desktop, tablet, and mobile devices. No app installation required - it works directly in your browser.",
+    },
+    {
+      question: "How does it compare to other planning poker tools?",
+      answer:
+        "Unlike other tools that charge monthly fees or limit core features, our essential planning poker functionality is free with no restrictions. Our tool is open-source, requires no registration, and includes real-time voting, Fibonacci estimation, and team collaboration.",
+    },
+    {
+      question: "Can I contribute to the project?",
+      answer:
+        "Yes! We welcome contributions. Visit our GitHub repository to report bugs, suggest features, or submit pull requests. You can also star the project to show your support.",
+    },
+  ],
+};
+
+// --- Closing call to action ---
+
+export const CALL_TO_ACTION = {
+  heading: "Ready to estimate, or reflect?",
+  description:
+    "Open a planning poker room or a retro in seconds. Zero configuration, zero friction.",
+  estimate: START_ESTIMATING satisfies Cta,
+  retro: START_RETRO satisfies Cta,
+  github: {
+    label: "View on GitHub",
+    href: "https://github.com/spokvulcan/poker-planning",
+  } satisfies Cta,
+};

--- a/src/components/homepage/faq.tsx
+++ b/src/components/homepage/faq.tsx
@@ -4,54 +4,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-
-const faqs = [
-  {
-    question: "What is Planning Poker?",
-    answer:
-      "Planning Poker is an agile estimation technique where team members use cards to vote on the complexity of user stories. It helps teams reach consensus on effort estimates through discussion and collaboration, making sprint planning more accurate and engaging.",
-  },
-  {
-    question: "How much does AgileKit cost?",
-    answer:
-      "AgileKit's core features are free with no limitations on team size or number of sessions. As an open-source project, we believe in making quality tools accessible to everyone. We may introduce optional paid features in the future, but the core planning poker functionality will always remain free.",
-  },
-  {
-    question: "Do I need to create an account?",
-    answer:
-      "No account is required! Simply click 'Start New Game' and share the room link with your team. We designed it this way to remove barriers and get your team estimating as quickly as possible.",
-  },
-  {
-    question: "How many people can join a planning session?",
-    answer:
-      "There's no limit on the number of participants in a planning session. Whether you have 5 or 500 team members, everyone can join and participate seamlessly.",
-  },
-  {
-    question: "What voting scale does AgileKit use?",
-    answer:
-      "AgileKit uses the Fibonacci sequence (0, 1, 2, 3, 5, 8, 13, 21, ?) which is the industry standard for story point estimation. We're working on adding T-shirt sizes and custom scales in a future update.",
-  },
-  {
-    question: "Can I use this tool offline or self-host it?",
-    answer:
-      "While the online version requires an internet connection, the entire codebase is open-source on GitHub. You can download and host your own instance for offline use or to meet specific security requirements.",
-  },
-  {
-    question: "What browsers and devices are supported?",
-    answer:
-      "AgileKit works on all modern browsers (Chrome, Firefox, Safari, Edge) and is fully responsive on desktop, tablet, and mobile devices. No app installation required - it works directly in your browser.",
-  },
-  {
-    question: "How does it compare to other planning poker tools?",
-    answer:
-      "Unlike other tools that charge monthly fees or limit core features, our essential planning poker functionality is free with no restrictions. Our tool is open-source, requires no registration, and includes real-time voting, Fibonacci estimation, and team collaboration.",
-  },
-  {
-    question: "Can I contribute to the project?",
-    answer:
-      "Yes! We welcome contributions. Visit our GitHub repository to report bugs, suggest features, or submit pull requests. You can also star the project to show your support.",
-  },
-];
+import { FAQ as COPY } from "./copy";
 
 export function FAQ() {
   return (
@@ -60,19 +13,19 @@ export function FAQ() {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-16 lg:gap-24">
           <div className="lg:col-span-5">
             <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-              FAQ
+              {COPY.eyebrow}
             </h2>
             <h3 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-              Common<br />questions.
+              {COPY.heading}<br />{COPY.headingMuted}
             </h3>
             <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light mb-8">
-              Everything you need to know about AgileKit, how it works, and our commitment to keeping it free.
+              {COPY.description}
             </p>
             <div className="p-8 bg-white dark:bg-black rounded-3xl border border-gray-200/50 dark:border-zinc-800/50">
-              <p className="text-base text-gray-900 dark:text-gray-100 font-medium mb-2">Still have questions?</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">Reach out to us on GitHub or check our detailed documentation.</p>
-              <a href="https://github.com/spokvulcan/poker-planning" target="_blank" rel="noopener noreferrer" className="inline-flex h-12 items-center justify-center gap-2 bg-gray-100 dark:bg-zinc-800 px-6 text-sm font-medium text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-zinc-700 transition-colors rounded-xl">
-                View GitHub
+              <p className="text-base text-gray-900 dark:text-gray-100 font-medium mb-2">{COPY.stillQuestions}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">{COPY.reachOut}</p>
+              <a href={COPY.github.href} target="_blank" rel="noopener noreferrer" className="inline-flex h-12 items-center justify-center gap-2 bg-gray-100 dark:bg-zinc-800 px-6 text-sm font-medium text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-zinc-700 transition-colors rounded-xl">
+                {COPY.github.label}
               </a>
             </div>
           </div>
@@ -80,9 +33,9 @@ export function FAQ() {
           <div className="lg:col-span-7">
             <div className="bg-white dark:bg-black rounded-3xl p-4 sm:p-8 border border-gray-200/50 dark:border-zinc-800/50">
               <Accordion className="w-full">
-                {faqs.map((faq, index) => (
+                {COPY.items.map((faq, index) => (
                   <AccordionItem
-                    key={index}
+                    key={faq.question}
                     value={`item-${index}`}
                     className="border-b border-gray-100 dark:border-zinc-900 last:border-0 px-2 sm:px-4"
                   >

--- a/src/components/homepage/features-section.tsx
+++ b/src/components/homepage/features-section.tsx
@@ -1,59 +1,52 @@
 import Link from "next/link";
 import { Check } from "lucide-react";
-
-const features = [
-  { name: "Unlimited team members", available: true },
-  { name: "Unlimited sessions", available: true },
-  { name: "Real-time updates", available: true },
-  { name: "Multiple voting scales", available: true },
-  { name: "Issues management", available: true },
-  { name: "Jira Cloud integration", available: true },
-  { name: "CSV export with stats", available: true },
-  { name: "Session timer", available: true },
-  { name: "Spectator mode", available: true },
-];
+import { CAPABILITIES } from "./copy";
 
 export function FeaturesSection() {
   return (
     <section className="bg-gray-50/50 dark:bg-zinc-900/10 py-24 sm:py-32">
       <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 lg:gap-24 items-center">
-          
+
           <div>
             <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-              Capabilities
+              {CAPABILITIES.eyebrow}
             </h2>
             <h3 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-              Everything you need.<br />
-              <span className="text-gray-400 dark:text-zinc-600">Nothing you don&apos;t.</span>
+              {CAPABILITIES.heading}<br />
+              <span className="text-gray-400 dark:text-zinc-600">{CAPABILITIES.headingMuted}</span>
             </h3>
             <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light mb-8 max-w-md">
-              A comprehensive toolset designed specifically for agile estimation. Core functionality is completely free and instantly accessible.
+              {CAPABILITIES.description}
             </p>
             <Link
-              href="/features"
+              href={CAPABILITIES.cta.href}
               className="inline-flex h-14 items-center justify-center gap-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 px-8 text-base font-medium text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors rounded-2xl"
             >
-              View full feature list
+              {CAPABILITIES.cta.label}
             </Link>
           </div>
 
-          <div className="bg-white dark:bg-black rounded-3xl p-8 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-8">
-              {features.map((feature) => (
-                <div
-                  key={feature.name}
-                  className="flex items-center gap-4"
-                >
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center bg-gray-50 dark:bg-zinc-900 rounded-full">
-                    <Check className="h-5 w-5 text-gray-900 dark:text-white" strokeWidth={2.5} />
-                  </div>
-                  <span className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                    {feature.name}
-                  </span>
-                </div>
-              ))}
-            </div>
+          <div className="bg-white dark:bg-black rounded-3xl p-8 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-10">
+            {[CAPABILITIES.poker, CAPABILITIES.retro].map((group) => (
+              <div key={group.name}>
+                <h4 className="text-xs font-bold tracking-widest text-primary uppercase mb-6">
+                  {group.name}
+                </h4>
+                <ul className="space-y-5">
+                  {group.features.map((feature) => (
+                    <li key={feature} className="flex items-center gap-4">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center bg-gray-50 dark:bg-zinc-900 rounded-full">
+                        <Check className="h-5 w-5 text-gray-900 dark:text-white" strokeWidth={2.5} />
+                      </div>
+                      <span className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                        {feature}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
 
         </div>

--- a/src/components/homepage/how-it-works.tsx
+++ b/src/components/homepage/how-it-works.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { Check, Loader2 } from "lucide-react";
-import { useState, useEffect } from "react";
+import { Check, Loader2, EyeOff } from "lucide-react";
+import { useState, useEffect, type ComponentType } from "react";
+import { HOW_IT_WORKS } from "./copy";
+import { CeremonyTabs, CeremonyTabList, CeremonyTabPanel, type Ceremony } from "./ceremony-tabs";
 
-function CreateRoomAnimation() {
+const POKER = HOW_IT_WORKS.poker.animation;
+const RETRO = HOW_IT_WORKS.retro.animation;
+
+/** Types a name, presses the button, shows the created state, loops. */
+function useCreateLoop(typed: string) {
   const [text, setText] = useState("");
   const [clicked, setClicked] = useState(false);
   const [created, setCreated] = useState(false);
@@ -15,22 +21,21 @@ function CreateRoomAnimation() {
         setText("");
         setClicked(false);
         setCreated(false);
-        
+
         await new Promise(r => setTimeout(r, 800));
         if(!isMounted) break;
-        
-        const str = "Sprint 42 Planning";
-        for(let i=1; i<=str.length; i++) {
-          setText(str.slice(0, i));
+
+        for(let i=1; i<=typed.length; i++) {
+          setText(typed.slice(0, i));
           await new Promise(r => setTimeout(r, 60)); // Typing speed
         }
         await new Promise(r => setTimeout(r, 400));
         if(!isMounted) break;
-        
+
         setClicked(true);
         await new Promise(r => setTimeout(r, 150));
         if(!isMounted) break;
-        
+
         setClicked(false);
         setCreated(true);
         await new Promise(r => setTimeout(r, 2500));
@@ -38,7 +43,13 @@ function CreateRoomAnimation() {
     };
     play();
     return () => { isMounted = false; };
-  }, []);
+  }, [typed]);
+
+  return { text, clicked, created };
+}
+
+function CreateAnimation({ typed, button, created: createdLabel }: { typed: string; button: string; created: string }) {
+  const { text, clicked, created } = useCreateLoop(typed);
 
   return (
     <div className="w-full max-w-[260px] bg-white dark:bg-zinc-950 rounded-xl shadow-lg border border-gray-100 dark:border-zinc-800 p-5">
@@ -47,7 +58,7 @@ function CreateRoomAnimation() {
            <div className="w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-4">
              <Check className="w-6 h-6 text-green-600 dark:text-green-400" />
            </div>
-           <p className="text-sm font-medium text-gray-900 dark:text-white">Room Created!</p>
+           <p className="text-sm font-medium text-gray-900 dark:text-white">{createdLabel}</p>
         </div>
       ) : (
         <div className="flex flex-col gap-4 animate-in fade-in duration-300">
@@ -57,7 +68,7 @@ function CreateRoomAnimation() {
             <span className="w-[2px] h-4 bg-primary animate-pulse ml-1"></span>
           </div>
           <div className={`h-10 w-full bg-primary text-primary-foreground rounded-lg flex items-center justify-center text-sm font-medium transition-transform ${clicked ? 'scale-95' : 'scale-100'}`}>
-            Start Session
+            {button}
           </div>
         </div>
       )}
@@ -65,9 +76,17 @@ function CreateRoomAnimation() {
   )
 }
 
+function CreateRoomAnimation() {
+  return <CreateAnimation typed={POKER.roomName} button={POKER.startButton} created={POKER.created} />;
+}
+
+function OpenBoardAnimation() {
+  return <CreateAnimation typed={RETRO.formatName} button={RETRO.startButton} created={RETRO.created} />;
+}
+
 function InviteTeamAnimation() {
   const [avatars, setAvatars] = useState<number[]>([]);
-  
+
   useEffect(() => {
     let isMounted = true;
     const play = async () => {
@@ -75,7 +94,7 @@ function InviteTeamAnimation() {
         setAvatars([]);
         await new Promise(r => setTimeout(r, 1000));
         if(!isMounted) break;
-        
+
         setAvatars([1]);
         await new Promise(r => setTimeout(r, 500));
         if(!isMounted) break;
@@ -93,8 +112,8 @@ function InviteTeamAnimation() {
   }, []);
 
   const colors = [
-    "bg-blue-500 text-blue-50", 
-    "bg-purple-500 text-purple-50", 
+    "bg-blue-500 text-blue-50",
+    "bg-purple-500 text-purple-50",
     "bg-orange-500 text-orange-50"
   ];
   const initials = ["JS", "AL", "MK"];
@@ -103,12 +122,12 @@ function InviteTeamAnimation() {
     <div className="w-full flex flex-col items-center justify-center gap-6 h-full">
       <div className="flex -space-x-4">
         <div className="w-12 h-12 rounded-full bg-gray-200 dark:bg-zinc-800 border-2 border-white dark:border-zinc-900 flex items-center justify-center z-10 shadow-sm">
-          <span className="text-xs font-medium text-gray-600 dark:text-gray-300">You</span>
+          <span className="text-xs font-medium text-gray-600 dark:text-gray-300">{POKER.you}</span>
         </div>
         {avatars.map((a, i) => (
-          <div 
-            key={a} 
-            className={`w-12 h-12 rounded-full ${colors[i]} border-2 border-white dark:border-zinc-900 flex items-center justify-center shadow-sm animate-in fade-in zoom-in slide-in-from-bottom-4 duration-300`} 
+          <div
+            key={a}
+            className={`w-12 h-12 rounded-full ${colors[i]} border-2 border-white dark:border-zinc-900 flex items-center justify-center shadow-sm animate-in fade-in zoom-in slide-in-from-bottom-4 duration-300`}
             style={{ zIndex: 10 - a }}
           >
             <span className="text-xs font-medium">{initials[i]}</span>
@@ -116,7 +135,7 @@ function InviteTeamAnimation() {
         ))}
       </div>
       <div className="flex items-center gap-2 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-sm px-4 py-2 rounded-full border border-gray-200 dark:border-zinc-800 text-xs font-medium text-gray-600 dark:text-gray-400 shadow-sm">
-        <Loader2 className="w-3 h-3 animate-spin text-primary" /> Waiting for others...
+        <Loader2 className="w-3 h-3 animate-spin text-primary" /> {POKER.waiting}
       </div>
     </div>
   )
@@ -134,11 +153,11 @@ function EstimateAnimation() {
         setSelected(null);
         await new Promise(r => setTimeout(r, 1000));
         if(!isMounted) break;
-        
+
         setHovered(2); // The card '3'
         await new Promise(r => setTimeout(r, 400));
         if(!isMounted) break;
-        
+
         setSelected(2);
         await new Promise(r => setTimeout(r, 2500));
       }
@@ -153,12 +172,12 @@ function EstimateAnimation() {
     <div className="w-full flex items-center justify-center h-full">
       <div className="flex gap-2 sm:gap-3">
         {cards.map((c, i) => (
-          <div 
+          <div
             key={c}
             className={`w-12 h-16 sm:w-14 sm:h-20 rounded-xl flex items-center justify-center font-bold text-lg sm:text-xl transition-all duration-300
-              ${selected === i 
-                ? 'bg-primary text-primary-foreground -translate-y-4 shadow-xl scale-110' 
-                : hovered === i 
+              ${selected === i
+                ? 'bg-primary text-primary-foreground -translate-y-4 shadow-xl scale-110'
+                : hovered === i
                   ? 'bg-white dark:bg-zinc-800 text-primary -translate-y-2 shadow-lg border border-primary/30'
                   : 'bg-white dark:bg-zinc-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-zinc-700 shadow-sm'
               }
@@ -182,7 +201,7 @@ function AlignAnimation() {
         setRevealed(false);
         await new Promise(r => setTimeout(r, 1500));
         if(!isMounted) break;
-        
+
         setRevealed(true);
         await new Promise(r => setTimeout(r, 3500));
       }
@@ -211,10 +230,10 @@ function AlignAnimation() {
           </div>
         ))}
       </div>
-      
+
       <div className={`transition-all duration-500 delay-300 ${revealed ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'}`}>
         <div className="px-5 py-2.5 bg-white dark:bg-zinc-800/90 backdrop-blur-md rounded-full border border-gray-200 dark:border-zinc-700 flex items-center gap-3 shadow-xl">
-          <span className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Consensus:</span>
+          <span className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{POKER.consensus}</span>
           <span className="font-bold text-xl text-primary">5</span>
         </div>
       </div>
@@ -222,101 +241,287 @@ function AlignAnimation() {
   )
 }
 
+/** Three silhouettes appear one by one, then reveal together (ADR-0015). */
+function WriteCardsAnimation() {
+  const [written, setWritten] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    const play = async () => {
+      while (isMounted) {
+        setWritten(0);
+        setRevealed(false);
+        await new Promise(r => setTimeout(r, 800));
+        if (!isMounted) break;
+        for (let i = 1; i <= RETRO.cards.length; i++) {
+          setWritten(i);
+          await new Promise(r => setTimeout(r, 500));
+          if (!isMounted) break;
+        }
+        await new Promise(r => setTimeout(r, 900));
+        if (!isMounted) break;
+        setRevealed(true);
+        await new Promise(r => setTimeout(r, 3000));
+      }
+    };
+    play();
+    return () => { isMounted = false; };
+  }, []);
+
+  return (
+    <div className="w-full flex flex-col items-center justify-center gap-2 h-full">
+      {RETRO.cards.map((card, i) => (
+        <div
+          key={card}
+          className={`w-44 sm:w-52 rounded-xl border px-4 py-2 text-sm transition-all duration-500 ${
+            i < written ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"
+          } ${
+            revealed
+              ? "bg-white dark:bg-zinc-800 border-gray-200 dark:border-zinc-700 text-gray-900 dark:text-white shadow-md"
+              : "bg-gray-100 dark:bg-zinc-800/60 border-dashed border-gray-300 dark:border-zinc-700 text-gray-400 dark:text-gray-500"
+          }`}
+        >
+          {revealed ? card : (
+            <span className="flex items-center gap-2">
+              <EyeOff className="w-3.5 h-3.5" /> {RETRO.hidden}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Two cards slide together under a group chip, then dots land on the group. */
+function GroupVoteAnimation() {
+  const [grouped, setGrouped] = useState(false);
+  const [dots, setDots] = useState(0);
+
+  useEffect(() => {
+    let isMounted = true;
+    const play = async () => {
+      while (isMounted) {
+        setGrouped(false);
+        setDots(0);
+        await new Promise(r => setTimeout(r, 1000));
+        if (!isMounted) break;
+        setGrouped(true);
+        await new Promise(r => setTimeout(r, 900));
+        if (!isMounted) break;
+        for (let i = 1; i <= RETRO.dots; i++) {
+          setDots(i);
+          await new Promise(r => setTimeout(r, 350));
+          if (!isMounted) break;
+        }
+        await new Promise(r => setTimeout(r, 2500));
+      }
+    };
+    play();
+    return () => { isMounted = false; };
+  }, []);
+
+  return (
+    <div className="w-full flex flex-col items-center justify-center gap-4 h-full">
+      <div className={`px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-bold tracking-wide transition-all duration-500 ${grouped ? "opacity-100 scale-100" : "opacity-0 scale-90"}`}>
+        {RETRO.groupLabel}
+      </div>
+      <div className="relative flex items-center justify-center h-14 w-56">
+        {[0, 1].map((i) => (
+          <div
+            key={i}
+            className={`absolute w-24 h-12 rounded-xl bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 shadow-sm px-2.5 py-1.5 text-[11px] leading-tight overflow-hidden text-gray-700 dark:text-gray-300 transition-transform duration-700 ${
+              grouped
+                ? i === 0 ? "-translate-x-6 -rotate-3" : "translate-x-6 rotate-3"
+                : i === 0 ? "-translate-x-20" : "translate-x-20"
+            }`}
+          >
+            {RETRO.cards[i]}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-1.5 h-3">
+        {Array.from({ length: RETRO.dots }, (_, i) => (
+          <span
+            key={i}
+            className={`w-3 h-3 rounded-full bg-primary transition-all duration-300 ${i < dots ? "opacity-100 scale-100" : "opacity-0 scale-50"}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The walk lands on a topic and an owned action item appears under it. */
+function DiscussAnimation() {
+  const [stage, setStage] = useState(0);
+
+  useEffect(() => {
+    let isMounted = true;
+    const play = async () => {
+      while (isMounted) {
+        setStage(0);
+        await new Promise(r => setTimeout(r, 1000));
+        if (!isMounted) break;
+        setStage(1);
+        await new Promise(r => setTimeout(r, 1200));
+        if (!isMounted) break;
+        setStage(2);
+        await new Promise(r => setTimeout(r, 3000));
+      }
+    };
+    play();
+    return () => { isMounted = false; };
+  }, []);
+
+  return (
+    <div className="w-full flex flex-col items-center justify-center gap-3 h-full">
+      <div className={`w-56 rounded-xl border px-4 py-3 flex items-center justify-between text-sm transition-all duration-500 ${
+        stage >= 1
+          ? "bg-white/10 border-white/20 text-white"
+          : "bg-white/5 border-white/10 text-gray-400"
+      }`}>
+        <span className="font-medium">{RETRO.topic}</span>
+        <span className="flex gap-1">
+          {Array.from({ length: RETRO.dots }, (_, i) => (
+            <span key={i} className="w-2 h-2 rounded-full bg-primary" />
+          ))}
+        </span>
+      </div>
+      <div className={`w-56 rounded-xl bg-white text-gray-900 px-4 py-3 flex items-center gap-3 text-sm shadow-xl transition-all duration-500 ${
+        stage >= 2 ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"
+      }`}>
+        <span className="w-6 h-6 rounded-full bg-green-100 flex items-center justify-center shrink-0">
+          <Check className="w-3.5 h-3.5 text-green-600" />
+        </span>
+        <span className="font-medium">{RETRO.action}</span>
+      </div>
+    </div>
+  );
+}
+
+const VISUALS: Record<Ceremony, [ComponentType, ComponentType, ComponentType, ComponentType]> = {
+  poker: [CreateRoomAnimation, InviteTeamAnimation, EstimateAnimation, AlignAnimation],
+  retro: [OpenBoardAnimation, WriteCardsAnimation, GroupVoteAnimation, DiscussAnimation],
+};
+
+/** The four-step bento, one per ceremony; the layout is shared, the words and visuals are not. */
+function StepGrid({ ceremony }: { ceremony: Ceremony }) {
+  const steps = HOW_IT_WORKS[ceremony].steps;
+  const [First, Second, Third, Fourth] = VISUALS[ceremony];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 auto-rows-auto md:auto-rows-[380px]">
+      {/* Main feature - spanning 2 columns */}
+      <div className="md:col-span-2 relative bg-surface-2 dark:bg-zinc-900 rounded-3xl p-8 sm:p-10 border border-gray-200 dark:border-zinc-800 overflow-hidden group flex flex-col md:flex-row gap-8">
+        <div className="relative z-10 flex flex-col justify-between flex-1">
+          <div className="w-12 h-12 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
+            <span className="text-lg font-bold text-gray-900 dark:text-white">{steps[0].number}</span>
+          </div>
+          <div className="mt-8 md:mt-0">
+            <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">{steps[0].title}</h3>
+            <p className="text-gray-600 dark:text-gray-400 max-w-md leading-relaxed">
+              {steps[0].description}
+            </p>
+          </div>
+        </div>
+
+        <div className="relative z-10 flex-1 flex items-center justify-center lg:justify-end">
+          <First />
+        </div>
+      </div>
+
+      {/* Feature 2 */}
+      <div className="relative bg-status-info-bg dark:bg-zinc-900/50 rounded-3xl p-8 sm:p-10 border border-status-info-bg dark:border-zinc-800 overflow-hidden group flex flex-col min-h-[350px] md:min-h-0">
+        <div className="flex justify-between items-start mb-6 z-10">
+          <div className="w-10 h-10 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
+            <span className="text-base font-bold text-gray-900 dark:text-white">{steps[1].number}</span>
+          </div>
+        </div>
+        <div className="flex-1 min-h-0 flex items-center justify-center -mx-4 z-10">
+          <Second />
+        </div>
+        <div className="mt-6 z-10">
+          <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{steps[1].title}</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {steps[1].description}
+          </p>
+        </div>
+      </div>
+
+      {/* Feature 3 */}
+      <div className="relative bg-surface-3 dark:bg-zinc-900/80 rounded-3xl p-8 sm:p-10 border border-gray-200 dark:border-zinc-800 overflow-hidden group flex flex-col min-h-[350px] md:min-h-0">
+        <div className="flex justify-between items-start mb-6 z-10">
+          <div className="w-10 h-10 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
+            <span className="text-base font-bold text-gray-900 dark:text-white">{steps[2].number}</span>
+          </div>
+        </div>
+        <div className="flex-1 min-h-0 flex items-center justify-center z-10">
+          <Third />
+        </div>
+        <div className="mt-6 z-10">
+          <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{steps[2].title}</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {steps[2].description}
+          </p>
+        </div>
+      </div>
+
+      {/* Feature 4 - spanning 2 columns */}
+      <div className="md:col-span-2 relative bg-gray-900 dark:bg-zinc-900 rounded-3xl p-8 sm:p-10 border border-gray-800 overflow-hidden group flex flex-col md:flex-row gap-8">
+        <div className="absolute inset-0 bg-gradient-to-r from-gray-900 to-gray-800 dark:from-zinc-900 dark:to-zinc-800 z-0" />
+
+        <div className="relative z-10 flex flex-col justify-between flex-1">
+          <div className="flex justify-between items-start">
+            <div className="w-12 h-12 bg-white/10 rounded-xl flex items-center justify-center backdrop-blur-sm border border-white/10">
+              <span className="text-lg font-bold text-white">{steps[3].number}</span>
+            </div>
+          </div>
+          <div className="mt-8 md:mt-0">
+            <h3 className="text-2xl font-bold text-white mb-3">{steps[3].title}</h3>
+            <p className="text-gray-400 max-w-md leading-relaxed">
+              {steps[3].description}
+            </p>
+          </div>
+        </div>
+
+        <div className="relative z-10 flex-1 flex items-center justify-center">
+           <Fourth />
+        </div>
+      </div>
+
+    </div>
+  );
+}
+
 export function HowItWorks() {
   return (
     <section id="how-it-works" className="py-24 sm:py-32 bg-surface-1 dark:bg-black overflow-hidden border-t border-b border-gray-100 dark:border-zinc-900">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 max-w-2xl">
-          <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-6">
-            HOW IT WORKS
-          </h2>
-          <p className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-            A refined workflow for<br />
-            <span className="text-primary text-opacity-80">agile consensus.</span>
-          </p>
+      <CeremonyTabs className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mb-12 flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
+          <div className="max-w-2xl">
+            <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-6">
+              {HOW_IT_WORKS.eyebrow}
+            </h2>
+            <p className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
+              {HOW_IT_WORKS.heading}<br />
+              <span className="text-primary text-opacity-80">{HOW_IT_WORKS.headingMuted}</span>
+            </p>
+          </div>
+          <CeremonyTabList
+            prefix="how-it-works"
+            labels={HOW_IT_WORKS.tabs}
+            className="self-start lg:self-auto lg:mb-2"
+          />
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 auto-rows-auto md:auto-rows-[380px]">
-          {/* Main feature - spanning 2 columns */}
-          <div className="md:col-span-2 relative bg-surface-2 dark:bg-zinc-900 rounded-3xl p-8 sm:p-10 border border-gray-200 dark:border-zinc-800 overflow-hidden group flex flex-col md:flex-row gap-8">
-            <div className="relative z-10 flex flex-col justify-between flex-1">
-              <div className="w-12 h-12 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
-                <span className="text-lg font-bold text-gray-900 dark:text-white">01</span>
-              </div>
-              <div className="mt-8 md:mt-0">
-                <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">Create Room Instantly</h3>
-                <p className="text-gray-600 dark:text-gray-400 max-w-md leading-relaxed">
-                  Start a session with zero configuration. No sign-up required, no passwords to remember. Just click and go.
-                </p>
-              </div>
-            </div>
-            
-            <div className="relative z-10 flex-1 flex items-center justify-center lg:justify-end">
-              <CreateRoomAnimation />
-            </div>
-          </div>
-
-          {/* Feature 2 */}
-          <div className="relative bg-status-info-bg dark:bg-zinc-900/50 rounded-3xl p-8 sm:p-10 border border-status-info-bg dark:border-zinc-800 overflow-hidden group flex flex-col min-h-[350px] md:min-h-0">
-            <div className="flex justify-between items-start mb-6 z-10">
-              <div className="w-10 h-10 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
-                <span className="text-base font-bold text-gray-900 dark:text-white">02</span>
-              </div>
-            </div>
-            <div className="flex-1 flex items-center justify-center -mx-4 z-10">
-              <InviteTeamAnimation />
-            </div>
-            <div className="mt-6 z-10">
-              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Invite Team</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                Share the secure link. Members join from any browser.
-              </p>
-            </div>
-          </div>
-
-          {/* Feature 3 */}
-          <div className="relative bg-surface-3 dark:bg-zinc-900/80 rounded-3xl p-8 sm:p-10 border border-gray-200 dark:border-zinc-800 overflow-hidden group flex flex-col min-h-[350px] md:min-h-0">
-            <div className="flex justify-between items-start mb-6 z-10">
-              <div className="w-10 h-10 bg-white dark:bg-black rounded-xl flex items-center justify-center shadow-sm border border-gray-100 dark:border-zinc-800">
-                <span className="text-base font-bold text-gray-900 dark:text-white">03</span>
-              </div>
-            </div>
-            <div className="flex-1 flex items-center justify-center z-10">
-              <EstimateAnimation />
-            </div>
-            <div className="mt-6 z-10">
-              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Estimate</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                Simultaneous voting to eliminate anchoring bias.
-              </p>
-            </div>
-          </div>
-
-          {/* Feature 4 - spanning 2 columns */}
-          <div className="md:col-span-2 relative bg-gray-900 dark:bg-zinc-900 rounded-3xl p-8 sm:p-10 border border-gray-800 overflow-hidden group flex flex-col md:flex-row gap-8">
-            <div className="absolute inset-0 bg-gradient-to-r from-gray-900 to-gray-800 dark:from-zinc-900 dark:to-zinc-800 z-0" />
-            
-            <div className="relative z-10 flex flex-col justify-between flex-1">
-              <div className="flex justify-between items-start">
-                <div className="w-12 h-12 bg-white/10 rounded-xl flex items-center justify-center backdrop-blur-sm border border-white/10">
-                  <span className="text-lg font-bold text-white">04</span>
-                </div>
-              </div>
-              <div className="mt-8 md:mt-0">
-                <h3 className="text-2xl font-bold text-white mb-3">Align & Conquer</h3>
-                <p className="text-gray-400 max-w-md leading-relaxed">
-                  Reveal votes, discuss discrepancies, and establish consensus faster than ever before.
-                </p>
-              </div>
-            </div>
-
-            <div className="relative z-10 flex-1 flex items-center justify-center">
-               <AlignAnimation />
-            </div>
-          </div>
-
-        </div>
-      </div>
+        <CeremonyTabPanel value="poker">
+          <StepGrid ceremony="poker" />
+        </CeremonyTabPanel>
+        <CeremonyTabPanel value="retro">
+          <StepGrid ceremony="retro" />
+        </CeremonyTabPanel>
+      </CeremonyTabs>
     </section>
   );
 }

--- a/src/components/homepage/index.ts
+++ b/src/components/homepage/index.ts
@@ -1,4 +1,5 @@
 export * from "./banner";
+export * from "./ceremonies";
 export * from "./how-it-works";
 export * from "./faq";
 export * from "./use-cases";

--- a/src/components/homepage/pricing-section.tsx
+++ b/src/components/homepage/pricing-section.tsx
@@ -3,44 +3,9 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { ArrowRight, Check } from "lucide-react";
+import { PRICING_SECTION } from "./copy";
 
-const tiers = [
-  {
-    name: "Free",
-    id: "free",
-    price: "$0",
-    period: "forever",
-    description: "For ad-hoc teams and quick estimating sessions.",
-    features: [
-      "Unlimited participants",
-      "Real-time voting & whiteboard",
-      "5-day session history",
-      "Basic results analytics",
-      "CSV exports",
-    ],
-    cta: "Start planning for free",
-    href: "/room/new",
-  },
-  {
-    name: "Pro",
-    id: "pro",
-    price: "Coming Soon",
-    period: "",
-    description:
-      "For engineering teams that need deep insights and workflow automation.",
-    features: [
-      "Everything in Free, plus:",
-      "Time-to-consensus tracking",
-      "Voter alignment matrix",
-      "Sprint predictability score",
-      "Two-way Jira & GitHub sync",
-      "Unlimited session history",
-    ],
-    cta: "Join Waitlist",
-    href: "#",
-    disabled: true,
-  },
-];
+const { tiers } = PRICING_SECTION;
 
 export function PricingSection() {
   return (
@@ -48,14 +13,13 @@ export function PricingSection() {
       <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
         <div className="max-w-2xl mb-16">
           <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-            Pricing
+            {PRICING_SECTION.eyebrow}
           </h2>
           <h3 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-            Transparent pricing.
+            {PRICING_SECTION.heading}
           </h3>
           <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light max-w-xl">
-            Start using AgileKit completely free today. Our Pro tier brings
-            powerful integrations and team insights, currently in development.
+            {PRICING_SECTION.description}
           </p>
         </div>
 
@@ -72,7 +36,7 @@ export function PricingSection() {
             >
               {tier.disabled && (
                 <div className="absolute top-6 right-6 px-4 py-1.5 bg-white/20 dark:bg-black/10 backdrop-blur-md rounded-full text-xs font-bold tracking-wider uppercase">
-                  In Development
+                  {PRICING_SECTION.badge}
                 </div>
               )}
 

--- a/src/components/homepage/use-cases.tsx
+++ b/src/components/homepage/use-cases.tsx
@@ -1,27 +1,18 @@
-import { Globe, Zap, BarChart3, Users } from "lucide-react";
+import { Globe, Zap, BarChart3, Users, Clock, History } from "lucide-react";
+import type { ComponentType } from "react";
+import { USE_CASES } from "./copy";
 
-const useCases = [
-  {
-    title: "Remote-first",
-    description: "Real-time collaboration that works seamlessly across continents.",
-    icon: Globe,
-  },
-  {
-    title: "Instant execution",
-    description: "No lag, no waiting. Built on a high-performance reactive backend.",
-    icon: Zap,
-  },
-  {
-    title: "Data-driven",
-    description: "Visualize voting patterns to identify disagreement and align quickly.",
-    icon: BarChart3,
-  },
-  {
-    title: "Universal access",
-    description: "Designed for all teams. No accounts required to participate.",
-    icon: Users,
-  },
-];
+type UseCaseId = (typeof USE_CASES.items)[number]["id"];
+
+// Icons are keyed by the copy's ids; the words live in copy.ts.
+const ICONS: Record<UseCaseId, ComponentType<{ className?: string; strokeWidth?: number }>> = {
+  remote: Globe,
+  instant: Zap,
+  data: BarChart3,
+  async: Clock,
+  access: Users,
+  history: History,
+};
 
 export function UseCases() {
   return (
@@ -30,30 +21,33 @@ export function UseCases() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 lg:gap-24 items-center">
           <div>
             <h2 className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-              Architecture
+              {USE_CASES.eyebrow}
             </h2>
             <h3 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-              Built for modern teams.
+              {USE_CASES.heading}
             </h3>
             <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light">
-              Under the hood, a real-time sync engine ensures every vote, reveal, and state change happens instantaneously across all clients.
+              {USE_CASES.description}
             </p>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-            {useCases.map((useCase) => (
-              <div key={useCase.title} className="flex flex-col p-8 bg-gray-50 dark:bg-zinc-900/50 rounded-3xl border border-gray-200/50 dark:border-zinc-800/50">
-                <div className="p-3 bg-white dark:bg-black rounded-2xl w-fit mb-6 border border-gray-200/50 dark:border-zinc-800/50">
-                  <useCase.icon className="w-6 h-6 text-gray-900 dark:text-white" strokeWidth={2} />
+            {USE_CASES.items.map((useCase) => {
+              const Icon = ICONS[useCase.id];
+              return (
+                <div key={useCase.id} className="flex flex-col p-8 bg-gray-50 dark:bg-zinc-900/50 rounded-3xl border border-gray-200/50 dark:border-zinc-800/50">
+                  <div className="p-3 bg-white dark:bg-black rounded-2xl w-fit mb-6 border border-gray-200/50 dark:border-zinc-800/50">
+                    <Icon className="w-6 h-6 text-gray-900 dark:text-white" strokeWidth={2} />
+                  </div>
+                  <h4 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
+                    {useCase.title}
+                  </h4>
+                  <p className="text-base text-gray-600 dark:text-gray-400 font-light leading-relaxed">
+                    {useCase.description}
+                  </p>
                 </div>
-                <h4 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
-                  {useCase.title}
-                </h4>
-                <p className="text-base text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                  {useCase.description}
-                </p>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/components/seo/copy.ts
+++ b/src/components/seo/copy.ts
@@ -1,0 +1,106 @@
+/**
+ * The homepage's structured data as plain strings (spec §18.2, ADR-0014):
+ * the FAQ schema is the second FAQ list, kept beside the visible one in
+ * `components/homepage/copy.ts` and read by the same claims-register test.
+ * Metadata may say "retrospective" where the UI says "Retro" (§18.4).
+ */
+
+export const WEB_APPLICATION = {
+  name: "AgileKit",
+  description:
+    "Free online planning poker and retrospectives for Scrum teams. Real-time collaboration, no registration required.",
+  featureList: [
+    "Real-time voting",
+    "No registration required",
+    "Unlimited team members",
+    "Fibonacci scale for story point estimation",
+    "Results analytics with average, median, and consensus",
+    "Synchronized timer",
+    "Whiteboard canvas interface",
+    "Retro boards with cards written in parallel",
+    "Retro history kept for the team",
+  ],
+};
+
+export const FAQ_SCHEMA = [
+  {
+    question: "What is Planning Poker?",
+    answer:
+      "Planning Poker is an agile estimation technique where team members use cards to vote on the complexity of user stories. It helps teams reach consensus on effort estimates through discussion and collaboration, making sprint planning more accurate and engaging.",
+  },
+  {
+    question: "Does AgileKit do retros too?",
+    answer:
+      "Yes. A retro is a board your team writes on together: everyone adds cards at once, in the meeting or before it, then you group them, vote with dots and walk through the topics. Start one with no account, or keep it with a team so its history and action items are there next sprint. Retros are free for every team.",
+  },
+  {
+    question: "How much does AgileKit cost?",
+    answer:
+      "AgileKit's core features are completely free. There are no limitations on team size or number of planning poker rooms for core functionality. As an open-source project, we believe in making quality tools accessible to everyone. Optional paid features for planning poker may be available in the future.",
+  },
+  {
+    question: "Do I need to create an account?",
+    answer:
+      "No account is required! Click 'Start estimating' or 'Start a retro' and share the link with your team. We designed it this way to remove barriers and get your team going as quickly as possible. A team that wants to keep its retro history signs in.",
+  },
+  {
+    question: "Can retro cards be anonymous?",
+    answer:
+      "Yes. A team can make its retros anonymous: no author is stored with a card, not even for the facilitator. Votes are counted but nobody is shown how you voted. Anyone with the link can join a retro that is not kept by a team.",
+  },
+  {
+    question: "How many people can join a planning session?",
+    answer:
+      "There's no limit on the number of participants in a planning session. Whether you have 5 or 500 team members, everyone can join and participate seamlessly.",
+  },
+  {
+    question: "What voting scale does AgileKit use?",
+    answer:
+      "AgileKit uses the Fibonacci sequence (0, 1, 2, 3, 5, 8, 13, 21, ?) which is the industry standard for story point estimation. We're working on adding T-shirt sizes and custom scales in a future update.",
+  },
+  {
+    question: "Can I use this tool offline or self-host it?",
+    answer:
+      "While the online version requires an internet connection, the entire codebase is open-source on GitHub. You can download and host your own instance for offline use or to meet specific security requirements.",
+  },
+  {
+    question: "What browsers and devices are supported?",
+    answer:
+      "AgileKit works on all modern browsers (Chrome, Firefox, Safari, Edge) and is fully responsive on desktop, tablet, and mobile devices. No app installation required - it works directly in your browser.",
+  },
+  {
+    question: "How does it compare to other planning poker tools?",
+    answer:
+      "Unlike other tools that charge monthly fees or limit features, our core features are free with no restrictions. Our tool is open-source, requires no registration, and includes features like real-time voting, multiple card sets, and team collaboration.",
+  },
+  {
+    question: "Can I contribute to the project?",
+    answer:
+      "Yes! We welcome contributions. Visit our GitHub repository to report bugs, suggest features, or submit pull requests. You can also star the project to show your support.",
+  },
+];
+
+/** Planning poker's how-to; the retro has no schema of its own in v1. */
+export const HOW_TO = {
+  name: "How to Run a Planning Poker Session",
+  description:
+    "Start free online planning poker sessions with your Scrum team in 4 easy steps. No registration required.",
+  steps: [
+    {
+      name: "Create a Room",
+      text: "Start a new planning session with one click. No registration required.",
+    },
+    {
+      name: "Invite Your Team",
+      text: "Share the room URL. Team members join instantly from any device.",
+    },
+    {
+      name: "Vote on Stories",
+      text: "Everyone votes simultaneously. Cards stay hidden until revealed.",
+    },
+    {
+      name: "Reach Consensus",
+      text: "Reveal votes, discuss differences, and align on story points.",
+    },
+  ],
+};

--- a/src/components/seo/structured-data.tsx
+++ b/src/components/seo/structured-data.tsx
@@ -1,10 +1,12 @@
+import { WEB_APPLICATION, FAQ_SCHEMA, HOW_TO } from "./copy";
+
 const baseUrl = "https://agilekit.app";
 
 export function WebApplicationSchema() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    name: "AgileKit Planning Poker",
+    name: WEB_APPLICATION.name,
     applicationCategory: "BusinessApplication",
     operatingSystem: "All",
     offers: {
@@ -12,8 +14,7 @@ export function WebApplicationSchema() {
       price: "0.00",
       priceCurrency: "USD",
     },
-    description:
-      "Free online planning poker tool for agile teams. Real-time collaboration, no registration required.",
+    description: WEB_APPLICATION.description,
     url: baseUrl,
     author: {
       "@type": "Organization",
@@ -21,15 +22,7 @@ export function WebApplicationSchema() {
       url: "https://github.com/spokvulcan/poker-planning",
     },
     screenshot: `${baseUrl}/og-image.png`,
-    featureList: [
-      "Real-time voting",
-      "No registration required",
-      "Unlimited team members",
-      "Fibonacci scale for story point estimation",
-      "Results analytics with average, median, and consensus",
-      "Synchronized timer",
-      "Whiteboard canvas interface",
-    ],
+    featureList: WEB_APPLICATION.featureList,
   };
 
   return (
@@ -58,59 +51,11 @@ export function OrganizationSchema() {
   );
 }
 
-const faqData = [
-  {
-    question: "What is Planning Poker?",
-    answer:
-      "Planning Poker is an agile estimation technique where team members use cards to vote on the complexity of user stories. It helps teams reach consensus on effort estimates through discussion and collaboration, making sprint planning more accurate and engaging.",
-  },
-  {
-    question: "How much does AgileKit cost?",
-    answer:
-      "AgileKit's core features are completely free. There are no limitations on team size or number of sessions for core functionality. As an open-source project, we believe in making quality tools accessible to everyone. Optional paid features may be available in the future.",
-  },
-  {
-    question: "Do I need to create an account?",
-    answer:
-      "No account is required! Simply click 'Start New Game' and share the room link with your team. We designed it this way to remove barriers and get your team estimating as quickly as possible.",
-  },
-  {
-    question: "How many people can join a planning session?",
-    answer:
-      "There's no limit on the number of participants in a planning session. Whether you have 5 or 500 team members, everyone can join and participate seamlessly.",
-  },
-  {
-    question: "What voting scale does AgileKit use?",
-    answer:
-      "AgileKit uses the Fibonacci sequence (0, 1, 2, 3, 5, 8, 13, 21, ?) which is the industry standard for story point estimation. We're working on adding T-shirt sizes and custom scales in a future update.",
-  },
-  {
-    question: "Can I use this tool offline or self-host it?",
-    answer:
-      "While the online version requires an internet connection, the entire codebase is open-source on GitHub. You can download and host your own instance for offline use or to meet specific security requirements.",
-  },
-  {
-    question: "What browsers and devices are supported?",
-    answer:
-      "AgileKit works on all modern browsers (Chrome, Firefox, Safari, Edge) and is fully responsive on desktop, tablet, and mobile devices. No app installation required - it works directly in your browser.",
-  },
-  {
-    question: "How does it compare to other planning poker tools?",
-    answer:
-      "Unlike other tools that charge monthly fees or limit features, our core features are free with no restrictions. Our tool is open-source, requires no registration, and includes features like real-time voting, multiple card sets, and team collaboration.",
-  },
-  {
-    question: "Can I contribute to the project?",
-    answer:
-      "Yes! We welcome contributions. Visit our GitHub repository to report bugs, suggest features, or submit pull requests. You can also star the project to show your support.",
-  },
-];
-
 export function FAQSchema() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    mainEntity: faqData.map((faq) => ({
+    mainEntity: FAQ_SCHEMA.map((faq) => ({
       "@type": "Question",
       name: faq.question,
       acceptedAnswer: {
@@ -128,34 +73,14 @@ export function FAQSchema() {
   );
 }
 
-const howToSteps = [
-  {
-    name: "Create a Room",
-    text: "Start a new planning session with one click. No registration required.",
-  },
-  {
-    name: "Invite Your Team",
-    text: "Share the room URL. Team members join instantly from any device.",
-  },
-  {
-    name: "Vote on Stories",
-    text: "Everyone votes simultaneously. Cards stay hidden until revealed.",
-  },
-  {
-    name: "Reach Consensus",
-    text: "Reveal votes, discuss differences, and align on story points.",
-  },
-];
-
 export function HowToSchema() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    name: "How to Run a Planning Poker Session",
-    description:
-      "Start free online planning poker sessions with your Scrum team in 4 easy steps. No registration required.",
+    name: HOW_TO.name,
+    description: HOW_TO.description,
     totalTime: "PT5M",
-    step: howToSteps.map((step, index) => ({
+    step: HOW_TO.steps.map((step, index) => ({
       "@type": "HowToStep",
       position: index + 1,
       name: step.name,

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/lib/claims-register.test.ts
+++ b/src/lib/claims-register.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The claims register and the words rule (spec §18.2–§18.4, ADR-0014,
+ * ADR-0024) over the site's copy modules: the register-checked strings live
+ * in plain `.ts` modules the components import, so this node-project test
+ * can read every line without a DOM. The §19 copy register is
+ * `src/components/retro/copy-register.test.ts`.
+ */
+import { describe, it, expect } from "vitest";
+import * as homepage from "@/components/homepage/copy";
+import * as seo from "@/components/seo/copy";
+
+describe("the hero (spec §18.2)", () => {
+  it("keeps the earned line and widens it", () => {
+    expect(`${homepage.HERO.headline} ${homepage.HERO.headlineMuted}`).toBe(
+      "Estimate and reflect, without the noise.",
+    );
+  });
+
+  it("sends Start estimating to /room/new under the existing test id", () => {
+    expect(homepage.HERO.estimate).toEqual({
+      label: "Start estimating",
+      href: "/room/new",
+      testId: "hero-start-button",
+    });
+  });
+
+  it("sends Start a retro to /retro/new under hero-retro-button", () => {
+    expect(homepage.HERO.retro).toEqual({
+      label: "Start a retro",
+      href: "/retro/new",
+      testId: "hero-retro-button",
+    });
+  });
+});
+
+const saysRetro = (text: string) => /\bretros?\b/i.test(text);
+
+describe("two ceremonies, one toolkit (spec §18.2)", () => {
+  it("puts one card per ceremony under the hero, each with its own CTA", () => {
+    expect(homepage.CEREMONIES.poker.cta).toEqual({ label: "Start estimating", href: "/room/new" });
+    expect(homepage.CEREMONIES.retro.cta).toEqual({ label: "Start a retro", href: "/retro/new" });
+  });
+
+  it("moves the Interactive Demo CTA onto the planning poker card", () => {
+    expect(homepage.CEREMONIES.poker.demo).toEqual({ label: "Interactive Demo", href: "/demo" });
+    expect(homepage.CEREMONIES.retro).not.toHaveProperty("demo");
+  });
+
+  it("tabs how-it-works per ceremony, four steps each", () => {
+    expect(homepage.HOW_IT_WORKS.poker.steps).toHaveLength(4);
+    expect(homepage.HOW_IT_WORKS.retro.steps).toHaveLength(4);
+    expect(homepage.HOW_IT_WORKS.poker.animation.startButton).toBe("Start Session");
+  });
+
+  it("gives app-preview a retro slot, with the poker image in it until the manual capture", () => {
+    expect(homepage.APP_PREVIEW.poker.features).toHaveLength(3);
+    expect(homepage.APP_PREVIEW.retro.features).toHaveLength(3);
+    expect(homepage.APP_PREVIEW.retro.image.light).toMatch(/\.png$/);
+    expect(homepage.APP_PREVIEW.retro.image.dark).toMatch(/\.png$/);
+  });
+
+  it("gives use-cases, the capabilities list and the closing CTA retro lines", () => {
+    expect(homepage.USE_CASES.items.some((c) => saysRetro(c.description))).toBe(true);
+    expect(homepage.CAPABILITIES.retro.features.length).toBeGreaterThanOrEqual(4);
+    expect(homepage.CAPABILITIES.poker.features.length).toBeGreaterThanOrEqual(4);
+    expect(homepage.CALL_TO_ACTION.retro).toEqual({ label: "Start a retro", href: "/retro/new" });
+  });
+
+  it("gives both FAQ lists, the visible one and the structured-data one, retro questions", () => {
+    expect(homepage.FAQ.items.filter((f) => saysRetro(f.question)).length).toBeGreaterThanOrEqual(2);
+    expect(seo.FAQ_SCHEMA.filter((f) => saysRetro(f.question)).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("gives the Free tier a retro line and keeps the Pro tier silent on retros", () => {
+    const [free, pro] = homepage.PRICING_SECTION.tiers;
+    expect(free.id).toBe("free");
+    expect(free.features.some(saysRetro)).toBe(true);
+    expect(pro.id).toBe("pro");
+    expect([pro.name, pro.description, ...pro.features].some(saysRetro)).toBe(false);
+  });
+});
+
+// --- The claims register and the words rule over every string ---
+
+interface Line {
+  path: string;
+  text: string;
+}
+
+/** Every string in a copy module, with the path it was found at. */
+function everyLine(moduleName: string, value: unknown, path = moduleName, out: Line[] = []): Line[] {
+  if (typeof value === "string") out.push({ path, text: value });
+  else if (Array.isArray(value)) value.forEach((v, i) => everyLine(moduleName, v, `${path}[${i}]`, out));
+  else if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) everyLine(moduleName, v, `${path}.${k}`, out);
+  }
+  return out;
+}
+
+/** A line is retro-scoped when it says "retro" or sits under a `retro` key. */
+const retroScoped = ({ path, text }: Line) => /(^|\.)retro(\.|\[|$)/i.test(path) || saysRetro(text);
+
+/**
+ * The sentences of a line the retro rules apply to: every sentence under a
+ * `retro` key, otherwise only the sentences that say "retro". A mixed line
+ * may describe poker's analytics in one sentence and the retro in the next.
+ */
+function retroSentences({ path, text }: Line): string[] {
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  return /(^|\.)retro(\.|\[|$)/i.test(path) ? sentences : sentences.filter(saysRetro);
+}
+
+/** Labels a person reads in the UI, where "Retro" is the word and "retrospective" is not (§18.4). Metadata is exempt. */
+const uiLabel = ({ path }: Line) =>
+  !/(^|\.)meta(data)?(\.|$)/i.test(path) &&
+  /\.(label|cta|title|name|heading|headingMuted|eyebrow|points\[\d+\]|features\[\d+\]|tabs\.(poker|retro))$/.test(path);
+
+/** May-not-say phrases and the two product words that never appear (§18.3, §18.4). Applies to every line. */
+const NEVER: [string, RegExp][] = [
+  ["insights", /\binsights?\b/i],
+  ["notification", /\bnotifications?\b/i],
+  ["ceremony (a docs-only word)", /\bceremon(y|ies)\b/i],
+  ["any AI", /\bAI\b|\bA\.I\.|artificial intelligence|machine learning|\bLLMs?\b|\bGPT\b|\bcopilot\b|\bAI-\w+/i],
+  ["a workspace or org product", /\bworkspaces?\b|\borgani[sz]ations?\b|\borg\b|\bSSO\b|\bseats?\b/i],
+  ["an effect size", /effect size|\bd\s?=\s?\d|Hedges|Cohen|meta-analy/i],
+  ["X% of action items", /\d+\s?%[^.]*\baction items?\b|\baction items?\b[^.]*\d+\s?%/i],
+];
+
+/** What a line about the retro may not add (§18.3, §18.4, ADR-0024). */
+const RETRO_NEVER: [string, RegExp][] = [
+  ["session (planning poker's word)", /\bsessions?\b/i],
+  ["a pricing tier", /\bPro\b|\btiers?\b|\bplans?\b|\bpaid\b|\bsubscriptions?\b|\bupgrade\b|\bpremium\b|\bwaitlist\b/i],
+  ["an outcome", /\bimprov\w*\b|\boutcomes?\b|\bvelocity\b|\bproductiv\w*\b|\bdeliver\w*\b|\bbetter\b|\beffective\w*\b|\bmorale\b|\bengagement\b|\bfaster\b|\bhappier\b/i],
+  ["anonymity making it better", /\banonym\w*\b[^.]*\b(honest|candid|safe|safer|better|braver)\b|\b(honest|candid|safe|safer|better|braver)\b[^.]*\banonym\w*/i],
+  ["a number measuring the team", /\bscores?\b|\brates?\b|\brating\b|\bstreaks?\b|\btrends?\b|\bpercent\w*|%|\bhealth\b|\bmaturity\b|\bbenchmark\w*|\baverage\b|\bmetrics?\b|\banalytics\b/i],
+];
+
+/** Every violation in a set of lines, as "rule @ path: text". */
+function violations(lines: Line[]): string[] {
+  const out: string[] = [];
+  for (const line of lines) {
+    for (const [rule, pattern] of NEVER) {
+      if (pattern.test(line.text)) out.push(`${rule} @ ${line.path}: ${line.text}`);
+    }
+    if (retroScoped(line)) {
+      const sentences = retroSentences(line);
+      for (const [rule, pattern] of RETRO_NEVER) {
+        if (sentences.some((sentence) => pattern.test(sentence))) out.push(`${rule} @ ${line.path}: ${line.text}`);
+      }
+      if (uiLabel(line) && /retrospective/i.test(line.text)) {
+        out.push(`retrospective in a UI label @ ${line.path}: ${line.text}`);
+      }
+    }
+  }
+  return out;
+}
+
+describe("the checker itself", () => {
+  it("catches each kind of forbidden line", () => {
+    const fixture = everyLine("f", {
+      a: "Deep team insights",
+      b: "Email notifications",
+      c: "Two ceremonies, one toolkit",
+      d: "AI summaries of your retro",
+      e: "One workspace for the org",
+      retro: {
+        f: "Run a retro session",
+        g: "Retros are in the Pro tier",
+        h: "Retros improve delivery",
+        i: "Anonymous retros are more honest",
+        j: "Your retro health score",
+        label: "Start a retrospective",
+      },
+      RETRO: { points: ["Improves your retrospective"] },
+      meta: { title: "Free Retrospectives Online" },
+      poker: { k: "Unlimited sessions, 89% consensus, faster than ever" },
+    });
+    const rules = violations(fixture).map((v) => v.split(" @ ")[0]);
+    expect(rules).toEqual([
+      "insights",
+      "notification",
+      "ceremony (a docs-only word)",
+      "any AI",
+      "a workspace or org product",
+      "session (planning poker's word)",
+      "a pricing tier",
+      "an outcome",
+      "anonymity making it better",
+      "a number measuring the team",
+      "retrospective in a UI label",
+      "an outcome",
+      "retrospective in a UI label",
+    ]);
+  });
+});
+
+/** The copy modules under the register. PR (b) adds features, about, pricing and the site metadata. */
+const MODULES: [string, unknown][] = [
+  ["homepage", homepage],
+  ["seo", seo],
+];
+
+describe("the claims register and the words rule (spec §18.3, §18.4)", () => {
+  const lines = MODULES.flatMap(([name, mod]) => everyLine(name, mod));
+
+  it("reads a sizeable set of copy", () => {
+    expect(lines.length).toBeGreaterThan(150);
+  });
+
+  it("finds no forbidden line", () => {
+    expect(violations(lines)).toEqual([]);
+  });
+
+  it("says retro in the product and retrospective only in long-form copy", () => {
+    const labels = lines.filter(retroScoped).filter(uiLabel);
+    expect(labels.length).toBeGreaterThan(5);
+    expect(labels.some((l) => /\bRetro\b/.test(l.text))).toBe(true);
+  });
+});

--- a/src/lib/site-copy.ts
+++ b/src/lib/site-copy.ts
@@ -1,0 +1,8 @@
+/**
+ * Site-wide copy shared by the marketing pages (spec §18.2, ADR-0014).
+ * Checked by `lib/claims-register.test.ts`.
+ */
+
+/** The two CTAs every marketing page shares: one per ceremony (ADR-0014). */
+export const START_ESTIMATING = { label: "Start estimating", href: "/room/new" };
+export const START_RETRO = { label: "Start a retro", href: "/retro/new" };

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,10 @@ tests/
 
 ### 3. Data Test Attributes
 Added `data-testid` attributes to key components:
-- `hero-start-button` - Main CTA button
+- `hero-start-button` - Hero CTA *Start estimating* → `/room/new`
+- `hero-retro-button` - Hero CTA *Start a retro* → `/retro/new`
+- `toolkit-card-poker`, `toolkit-card-retro` - The two cards under the hero
+- `how-it-works-tab-poker`, `how-it-works-tab-retro`, `app-preview-tab-poker`, `app-preview-tab-retro` - Per-ceremony tabs
 - `hero-github-link` - GitHub repository link
 - `trust-free`, `trust-no-account`, `trust-realtime` - Trust indicators
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -21,10 +21,10 @@ test.describe("Home Page - Basic Elements", () => {
 
   test("should display description text", async ({ page }) => {
     const description = page.locator(
-      "text=A radically simple estimation tool"
+      "text=Planning poker and retros for Scrum teams"
     );
     await expect(description).toBeVisible();
-    await expect(description).toContainText("estimation tool");
+    await expect(description).toContainText("No accounts required");
   });
 
   test("should display key action buttons", async ({ page }) => {
@@ -32,6 +32,9 @@ test.describe("Home Page - Basic Elements", () => {
     const startButton = page.getByTestId("hero-start-button");
     await expect(startButton).toBeVisible();
     await expect(startButton).toBeEnabled();
+
+    // The retro CTA beside it (spec §18.2); its href is pinned by the node test
+    await expect(page.getByTestId("hero-retro-button")).toBeVisible();
 
     // GitHub link with data-testid
     const githubLink = page.getByTestId("hero-github-link");
@@ -81,6 +84,11 @@ test.describe("Home Page - Room Creation Flow", () => {
     
     expect(roomId).toMatch(/^[a-z0-9]+$/);
     await expect(page).toHaveURL(/\/room\/[a-z0-9]+/);
+  });
+
+  test("should open the retro create page from Start a retro", async ({ page }) => {
+    await homePage.startRetroButton.click();
+    await expect(page).toHaveURL(/\/retro\/new/);
   });
 
   test("should copy room URL to clipboard", async ({ page }) => {

--- a/tests/pages/home-page.ts
+++ b/tests/pages/home-page.ts
@@ -6,6 +6,7 @@ export class HomePage {
   readonly heroHeading: Locator;
   readonly heroDescription: Locator;
   readonly startGameButton: Locator;
+  readonly startRetroButton: Locator;
   readonly githubLink: Locator;
   readonly skipToMainLink: Locator;
   readonly trustIndicators: {
@@ -20,9 +21,10 @@ export class HomePage {
     // Hero section elements
     this.heroHeading = page.locator("h1");
     this.heroDescription = page.locator(
-      "text=A radically simple estimation tool"
+      "text=Planning poker and retros for Scrum teams"
     );
     this.startGameButton = page.getByTestId("hero-start-button");
+    this.startRetroButton = page.getByTestId("hero-retro-button");
     this.githubLink = page.getByTestId("hero-github-link").first();
     this.skipToMainLink = page.getByRole("link", {
       name: /skip to main content/i,
@@ -51,10 +53,10 @@ export class HomePage {
 
   async verifyHeroSection(): Promise<void> {
     await expect(this.heroHeading).toBeVisible();
-    await expect(this.heroHeading).toContainText("Planning poker");
+    await expect(this.heroHeading).toContainText("Estimate and reflect");
 
     await expect(this.heroDescription).toBeVisible();
-    await expect(this.heroDescription).toContainText("estimation tool");
+    await expect(this.heroDescription).toContainText("No accounts required");
   }
 
   async verifyTrustIndicators(): Promise<void> {


### PR DESCRIPTION
Part (a) of #300: the homepage. Spec: docs/spec/retro.md §18.2, §20, §21.1; ADR-0014, ADR-0024.

## What changed

- **Hero** reads "Estimate and reflect, without the noise." with *Start estimating* → `/room/new` (`hero-start-button`) and *Start a retro* → `/retro/new` (`hero-retro-button`).
- **Two ceremonies section** directly under the hero (`toolkit-card-poker`, `toolkit-card-retro`). The Interactive Demo CTA moved onto the planning poker card.
- **How it works** and **app preview** are tabbed per ceremony on shadcn Base UI Tabs (`how-it-works-tab-*`, `app-preview-tab-*`). The retro tab has its own four step animations.
- **Retro lines** added to use-cases, capabilities, both FAQ lists (visible and structured data), the Free pricing tier and the closing CTA. Poker copy scoped under its ceremony, nothing deleted.
- **Copy modules**: register-checked strings moved out of JSX into `src/components/homepage/copy.ts`, `src/components/seo/copy.ts` and `src/lib/site-copy.ts`. The node test `src/lib/claims-register.test.ts` checks the hero contract and the words rule over them; part (b) extends it to the claims register.
- Existing homepage Playwright assertions and `tests/README.md` updated. No client-side retro demo.

## Manual follow-up

- **Retro screenshots** (light and dark) are a manual capture. Until then the app-preview retro slot ships with the poker image; swap both paths and the alt in `APP_PREVIEW.retro.image`.

## Verification

- vitest: all projects pass; Playwright: 87 passed, 1 pre-existing skip; `tsc --noEmit` and eslint clean.

Part (b) (features, metadata, about, privacy drafts) is stacked on this branch.

https://claude.ai/code/session_01G9bjAL6awe9ayTe8X2MnqS