### PR TITLE
feat(retro): features, metadata, about, privacy drafts and the claims register (#300)

### DIFF
--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { 
-  Heart, 
-  Shield, 
-  Zap, 
-  ArrowRight, 
-  Star, 
-  Code2, 
-  Database, 
-  Layers, 
+import type { ComponentType } from "react";
+import {
+  Heart,
+  Shield,
+  Zap,
+  ArrowRight,
+  Star,
+  Code2,
+  Database,
+  Layers,
   Palette,
   GitMerge
 } from "lucide-react";
@@ -19,36 +20,27 @@ import { Navbar } from "@/components/navbar";
 import { useGitHubStats } from "@/hooks/use-github-stats";
 import { GithubIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { HERO, PRINCIPLES, STACK, CTA } from "./copy";
 
-const values = [
-  {
-    icon: Heart,
-    title: "Open Source Core",
-    description: "Built in the open. Core features free forever. Community-driven development with complete transparency.",
-    gradient: "from-rose-500 to-pink-600",
-  },
-  {
-    icon: Shield,
-    title: "Privacy First",
-    description: "No accounts required. No tracking. Your estimation data and team dynamics stay completely private.",
-    gradient: "from-emerald-500 to-teal-600",
-  },
-  {
-    icon: Zap,
-    title: "Real-time Sync",
-    description: "Instant collaboration with live updates. Built from the ground up for distributed agile teams.",
-    gradient: "from-amber-500 to-orange-600",
-  },
-];
+type Icon = ComponentType<{ className?: string }>;
+type ValueId = (typeof PRINCIPLES.values)[number]["id"];
+type StackId = (typeof STACK.items)[number]["id"];
 
-const techStack = [
-  { name: "Next.js 15", category: "Framework", icon: Code2 },
-  { name: "React 19", category: "UI Library", icon: Layers },
-  { name: "Convex", category: "Real-time Backend", icon: Database },
-  { name: "React Flow", category: "Interactive Canvas", icon: GitMerge },
-  { name: "Tailwind CSS", category: "Styling", icon: Palette },
-  { name: "TypeScript", category: "Language", icon: Code2 },
-];
+// Icons and gradients are keyed by the copy's ids; the words live in copy.ts.
+const VALUE_ICONS: Record<ValueId, { icon: Icon; gradient: string }> = {
+  open: { icon: Heart, gradient: "from-rose-500 to-pink-600" },
+  privacy: { icon: Shield, gradient: "from-emerald-500 to-teal-600" },
+  realtime: { icon: Zap, gradient: "from-amber-500 to-orange-600" },
+};
+
+const STACK_ICONS: Record<StackId, Icon> = {
+  next: Code2,
+  react: Layers,
+  convex: Database,
+  flow: GitMerge,
+  tailwind: Palette,
+  typescript: Code2,
+};
 
 export function AboutContent() {
   const { stars, isLoading } = useGitHubStats();
@@ -61,29 +53,29 @@ export function AboutContent() {
         {/* Hero Section */}
         <section className="relative pt-32 pb-24 sm:pt-40 sm:pb-32 overflow-hidden bg-white dark:bg-black">
           <div className="absolute inset-0 bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,#18181b_1px,transparent_1px),linear-gradient(to_bottom,#18181b_1px,transparent_1px)] bg-size-[4rem_4rem]"></div>
-          
+
           <div className="mx-auto max-w-360 px-6 lg:px-8 relative z-10">
             <div className="mx-auto max-w-4xl text-center">
               <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Planning poker,<br />
+                {HERO.headline}<br />
                 <span className="text-gray-300 dark:text-zinc-700">
-                  simplified.
+                  {HERO.headlineMuted}
                 </span>
               </h1>
 
               <p className="mt-8 text-xl sm:text-2xl leading-relaxed text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light">
-                AgileKit is an open-source planning poker tool designed to remove friction from your sprint planning. No sign-up required. Just create a room and estimate.
+                {HERO.position}
               </p>
 
               <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
                 <a
-                  href="https://github.com/spokvulcan/poker-planning"
+                  href={STACK.link.href}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex h-16 items-center justify-center gap-3 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
                 >
                   <GithubIcon className="h-6 w-6" />
-                  Star on GitHub
+                  {HERO.star}
                   <span className="inline-flex items-center gap-1.5 rounded-full bg-white/20 dark:bg-black/10 px-3 py-1 text-sm font-bold text-white dark:text-black ml-2">
                     <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
                     {isLoading ? "..." : stars.toLocaleString()}
@@ -99,39 +91,42 @@ export function AboutContent() {
           <div className="mx-auto max-w-360 px-6 lg:px-8">
             <div className="mb-16">
               <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Core Principles
+                {PRINCIPLES.eyebrow}
               </p>
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Built on trust.<br />
-                <span className="text-gray-400 dark:text-zinc-600">Designed for speed.</span>
+                {PRINCIPLES.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{PRINCIPLES.headingMuted}</span>
               </h2>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6 sm:gap-8">
-              {values.map((value) => (
-                <div
-                  key={value.title}
-                  className="group relative overflow-hidden rounded-[2rem] bg-white dark:bg-black p-8 sm:p-10 border border-gray-200/50 dark:border-zinc-800/50 hover:border-gray-300 dark:hover:border-zinc-700 transition-colors"
-                >
-                  <div className="relative z-10">
-                    <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-50 dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 mb-8 group-hover:scale-110 transition-transform duration-300 shadow-sm">
-                      <value.icon className="h-6 w-6 text-gray-900 dark:text-white" />
+              {PRINCIPLES.values.map((value) => {
+                const { icon: Icon, gradient } = VALUE_ICONS[value.id];
+                return (
+                  <div
+                    key={value.id}
+                    className="group relative overflow-hidden rounded-[2rem] bg-white dark:bg-black p-8 sm:p-10 border border-gray-200/50 dark:border-zinc-800/50 hover:border-gray-300 dark:hover:border-zinc-700 transition-colors"
+                  >
+                    <div className="relative z-10">
+                      <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-50 dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 mb-8 group-hover:scale-110 transition-transform duration-300 shadow-sm">
+                        <Icon className="h-6 w-6 text-gray-900 dark:text-white" />
+                      </div>
+                      <h3 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
+                        {value.title}
+                      </h3>
+                      <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
+                        {value.description}
+                      </p>
                     </div>
-                    <h3 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
-                      {value.title}
-                    </h3>
-                    <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                      {value.description}
-                    </p>
+
+                    {/* Subtle gradient background on hover */}
+                    <div className={cn(
+                      "absolute -bottom-24 -right-24 w-48 h-48 rounded-full blur-[3xl] opacity-0 group-hover:opacity-20 transition-opacity duration-500 bg-linear-to-br pointer-events-none",
+                      gradient
+                    )} />
                   </div>
-                  
-                  {/* Subtle gradient background on hover */}
-                  <div className={cn(
-                    "absolute -bottom-24 -right-24 w-48 h-48 rounded-full blur-[3xl] opacity-0 group-hover:opacity-20 transition-opacity duration-500 bg-linear-to-br pointer-events-none",
-                    value.gradient
-                  )} />
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         </section>
@@ -142,46 +137,49 @@ export function AboutContent() {
             <div className="grid lg:grid-cols-2 gap-16 lg:gap-24 items-center">
               <div>
                 <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                  Architecture
+                  {STACK.eyebrow}
                 </p>
                 <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                  Modern stack.<br />
-                  <span className="text-gray-400 dark:text-zinc-600">Zero compromises.</span>
+                  {STACK.heading}<br />
+                  <span className="text-gray-400 dark:text-zinc-600">{STACK.headingMuted}</span>
                 </h2>
                 <p className="mt-6 text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                  We built AgileKit using the latest technologies to ensure maximum performance, real-time reliability, and an exceptional developer experience for contributors.
+                  {STACK.description}
                 </p>
 
                 <div className="mt-10">
                   <a
-                    href="https://github.com/spokvulcan/poker-planning"
+                    href={STACK.link.href}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-lg font-medium text-gray-900 dark:text-white hover:text-primary transition-colors"
                   >
-                    View the architecture
+                    {STACK.link.label}
                     <ArrowRight className="h-5 w-5" />
                   </a>
                 </div>
               </div>
 
               <div className="grid grid-cols-2 gap-4 sm:gap-6">
-                {techStack.map((tech) => (
-                  <div
-                    key={tech.name}
-                    className="flex flex-col gap-4 rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-6 sm:p-8 border border-gray-200/50 dark:border-zinc-800/50 hover:bg-gray-50 dark:hover:bg-zinc-900/50 transition-colors"
-                  >
-                    <tech.icon className="h-6 w-6 text-gray-900 dark:text-white" />
-                    <div>
-                      <h3 className="text-lg font-bold tracking-tight text-gray-900 dark:text-white">
-                        {tech.name}
-                      </h3>
-                      <p className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-1">
-                        {tech.category}
-                      </p>
+                {STACK.items.map((tech) => {
+                  const Icon = STACK_ICONS[tech.id];
+                  return (
+                    <div
+                      key={tech.id}
+                      className="flex flex-col gap-4 rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-6 sm:p-8 border border-gray-200/50 dark:border-zinc-800/50 hover:bg-gray-50 dark:hover:bg-zinc-900/50 transition-colors"
+                    >
+                      <Icon className="h-6 w-6 text-gray-900 dark:text-white" />
+                      <div>
+                        <h3 className="text-lg font-bold tracking-tight text-gray-900 dark:text-white">
+                          {tech.name}
+                        </h3>
+                        <p className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-1">
+                          {tech.category}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           </div>
@@ -192,28 +190,35 @@ export function AboutContent() {
           <div className="mx-auto max-w-360 px-6 lg:px-8">
             <div className="mx-auto max-w-4xl text-center">
               <h2 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Ready to transform<br />
-                <span className="text-gray-400 dark:text-zinc-600">your planning?</span>
+                {CTA.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{CTA.headingMuted}</span>
               </h2>
               <p className="mt-8 text-xl sm:text-2xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                Join thousands of teams using AgileKit. Free forever, open source, and built for speed.
+                {CTA.description}
               </p>
               <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
                 <Link
-                  href="/"
+                  href={CTA.estimate.href}
                   className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
                 >
-                  Start Planning
+                  {CTA.estimate.label}
+                  <ArrowRight className="h-5 w-5" />
+                </Link>
+                <Link
+                  href={CTA.retro.href}
+                  className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
+                >
+                  {CTA.retro.label}
                   <ArrowRight className="h-5 w-5" />
                 </Link>
                 <a
-                  href="https://github.com/spokvulcan/poker-planning"
+                  href={CTA.source.href}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
                 >
                   <GithubIcon className="h-5 w-5" />
-                  View Source
+                  {CTA.source.label}
                 </a>
               </div>
             </div>

--- a/src/app/about/copy.ts
+++ b/src/app/about/copy.ts
@@ -1,0 +1,78 @@
+/**
+ * The About page's copy (spec §18.2, ADR-0014): the position sentence, the
+ * principles and the closing CTA. Read by `about-content.tsx` and checked by
+ * `lib/claims-register.test.ts`.
+ */
+
+import { START_ESTIMATING, START_RETRO } from "@/lib/site-copy";
+
+export const META = {
+  title: "About AgileKit - Free Open Source Planning Poker and Retros",
+  description:
+    "Learn about AgileKit, the free, open-source way for distributed Scrum teams to estimate and reflect in writing. Built with privacy, simplicity, and real-time collaboration in mind.",
+  openGraph: {
+    title: "About AgileKit - Free Open Source Planning Poker and Retros",
+    description:
+      "The free, open-source way for distributed Scrum teams to estimate and reflect in writing, everyone at once.",
+  },
+};
+
+export const HERO = {
+  headline: "Estimate and reflect,",
+  headlineMuted: "simplified.",
+  position:
+    "AgileKit is the free, open-source way for distributed Scrum teams to estimate and reflect in writing, everyone at once, with nothing forgotten between sprints.",
+  star: "Star on GitHub",
+};
+
+export const PRINCIPLES = {
+  eyebrow: "Core Principles",
+  heading: "Built on trust.",
+  headingMuted: "Designed for speed.",
+  values: [
+    {
+      id: "open",
+      title: "Open Source Core",
+      description:
+        "Built in the open. Core features free forever. Community-driven development with complete transparency.",
+    },
+    {
+      id: "privacy",
+      title: "Privacy First",
+      description:
+        "No accounts required to join. Optional analytics stay off unless you opt in. Your estimates and retro cards stay with your team, and an anonymous retro stores no author at all.",
+    },
+    {
+      id: "realtime",
+      title: "Real-time Sync",
+      description:
+        "Instant collaboration with live updates. Built from the ground up for distributed agile teams.",
+    },
+  ] as const,
+};
+
+export const STACK = {
+  eyebrow: "Architecture",
+  heading: "Modern stack.",
+  headingMuted: "Zero compromises.",
+  description:
+    "We built AgileKit using the latest technologies to ensure maximum performance, real-time reliability, and an exceptional developer experience for contributors.",
+  link: { label: "View the architecture", href: "https://github.com/spokvulcan/poker-planning" },
+  items: [
+    { id: "next", name: "Next.js 15", category: "Framework" },
+    { id: "react", name: "React 19", category: "UI Library" },
+    { id: "convex", name: "Convex", category: "Real-time Backend" },
+    { id: "flow", name: "React Flow", category: "Interactive Canvas" },
+    { id: "tailwind", name: "Tailwind CSS", category: "Styling" },
+    { id: "typescript", name: "TypeScript", category: "Language" },
+  ] as const,
+};
+
+export const CTA = {
+  heading: "Ready to estimate,",
+  headingMuted: "or reflect?",
+  description: "Free forever, open source, and built for distributed teams.",
+  estimate: START_ESTIMATING,
+  retro: START_RETRO,
+  source: { label: "View Source", href: "https://github.com/spokvulcan/poker-planning" },
+};

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,14 +1,13 @@
 import { Metadata } from "next";
 import { AboutContent } from "./about-content";
+import { META } from "./copy";
 
 export const metadata: Metadata = {
-  title: "About AgileKit - Free Open Source Planning Poker",
-  description:
-    "Learn about AgileKit, the free and open-source planning poker tool for Scrum teams. Built with privacy, simplicity, and real-time collaboration in mind.",
+  title: META.title,
+  description: META.description,
   openGraph: {
-    title: "About AgileKit - Free Open Source Planning Poker",
-    description:
-      "Learn about AgileKit, the free open-source planning poker tool. Built with privacy, simplicity, and real-time collaboration.",
+    title: META.openGraph.title,
+    description: META.openGraph.description,
     url: "https://agilekit.app/about",
   },
   alternates: {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -47,7 +47,7 @@ export default async function BlogPage() {
                 Blog
               </h1>
               <p className="mt-2 text-muted-foreground">
-                Tips, guides, and insights on planning poker and agile estimation.
+                {siteConfig.blog.description}
               </p>
             </div>
             <Link

--- a/src/app/features/copy.ts
+++ b/src/app/features/copy.ts
@@ -1,0 +1,253 @@
+/**
+ * The /features page's copy (spec §18.1, §18.2, ADR-0014): one page, two
+ * anchored sections, `#planning-poker` and `#retro`; the title drops
+ * "Planning Poker". Poker copy is kept under its anchor; retro copy says only
+ * what the claims register allows (§18.3). Read by `features-content.tsx`
+ * and checked by `lib/claims-register.test.ts`.
+ */
+
+import { START_ESTIMATING, START_RETRO } from "@/lib/site-copy";
+
+export const META = {
+  title: "Features",
+  description:
+    "Explore AgileKit's features: real-time planning poker with results analytics and Jira sync. Retro boards with cards written in parallel, dot voting, action items and team history.",
+  openGraph: {
+    title: "Features | AgileKit",
+    description:
+      "Real-time planning poker with results analytics and Jira sync. Retro boards with team history. Everything a distributed Scrum team needs, free.",
+  },
+};
+
+export const HERO = {
+  headline: "Powerful features,",
+  headlineMuted: "zero complexity.",
+  description:
+    "Planning poker and retros for distributed Scrum teams, in one toolkit. Core features free, no sign-up required.",
+  estimate: START_ESTIMATING,
+  retro: START_RETRO,
+  jumpTo: "Jump to",
+};
+
+export const QUICK_FEATURES = [
+  { id: "signup", name: "No Sign-up Required" },
+  { id: "theme", name: "Dark/Light Theme" },
+  { id: "mobile", name: "Mobile Responsive" },
+  { id: "links", name: "Shareable Links" },
+  { id: "csv", name: "CSV Export" },
+  { id: "spectator", name: "Spectator Mode" },
+] as const;
+
+// --- #planning-poker ---
+
+export const POKER = {
+  anchor: "planning-poker",
+  eyebrow: "Planning poker",
+  heading: "Built for modern teams.",
+  headingMuted: "Faster, more accurate.",
+  unlimited: "Unlimited team members",
+  items: [
+    {
+      id: "voting",
+      name: "Real-time Voting",
+      description: "Simultaneous card selection with instant sync across all participants",
+    },
+    {
+      id: "scales",
+      name: "Multiple Voting Scales",
+      description: "Fibonacci, Standard, T-Shirt sizes, or create your own custom scale",
+    },
+    {
+      id: "analytics",
+      name: "Results Analytics",
+      description: "Average, median, mode, consensus strength, and outlier detection",
+    },
+    {
+      id: "canvas",
+      name: "Whiteboard Canvas",
+      description: "Drag-and-drop React Flow canvas with multiple node types",
+    },
+    {
+      id: "issues",
+      name: "Issues Management",
+      description: "Create, edit, and track issues with CSV export and vote statistics",
+    },
+    {
+      id: "jira",
+      name: "Jira Cloud Integration",
+      description: "Two-way sync — import sprints, push estimates back automatically",
+    },
+    {
+      id: "consensus",
+      name: "Time-to-Consensus Tracking",
+      description: "Measure how long your team takes to reach agreement on each story",
+    },
+    {
+      id: "alignment",
+      name: "Voter Alignment Matrix",
+      description: "Visualize voting patterns and spot persistent disagreements",
+    },
+  ] as const,
+  analytics: {
+    eyebrow: "Results analytics",
+    heading: "Understand your team's",
+    headingMuted: "estimation patterns.",
+    description:
+      "See the voting distribution, the consensus level and the outliers the moment cards are revealed, and estimate with the numbers in front of you.",
+    stats: [
+      { id: "average", name: "Average Score" },
+      { id: "median", name: "Median Value" },
+      { id: "strength", name: "Consensus Strength" },
+      { id: "outliers", name: "Outlier Detection" },
+    ] as const,
+    preview: {
+      title: "Voting Results",
+      badge: "High Consensus",
+      participants: "10 participants",
+      consensus: "89% consensus",
+    },
+  },
+};
+
+// --- #retro ---
+
+export const RETRO = {
+  anchor: "retro",
+  eyebrow: "Retro",
+  heading: "Reflect in writing.",
+  headingMuted: "Everyone at once.",
+  description:
+    "A retro is one board. Everyone writes cards in parallel, in the meeting or before it, then the team groups them, votes with dots and walks the topics. What was decided stays with the team.",
+  items: [
+    {
+      id: "formats",
+      name: "Six formats",
+      description:
+        "Went well / Do differently / Ideas, Start / Stop / Continue, Glad / Sad / Mad, 4Ls, Sailboat and Lean Coffee. Edit the prompts on the create form and the edited copy is your team's own format next time.",
+    },
+    {
+      id: "parallel",
+      name: "Written in parallel",
+      description:
+        "Everyone writes at once. Cards stay hidden while people write and are revealed together.",
+    },
+    {
+      id: "async",
+      name: "Written before the meeting",
+      description:
+        "Open the board days ahead and the team writes when it suits them. In a team retro, one click emails the team that the board is open.",
+    },
+    {
+      id: "anonymous",
+      name: "Anonymous or named",
+      description:
+        "Chosen per team. In an anonymous retro no author is stored with a card, not even for the facilitator, and nobody is shown how you voted.",
+    },
+    {
+      id: "dots",
+      name: "Dots and the discussion walk",
+      description:
+        "Spend a dot budget on the groups that matter, then walk the topics in vote order. Nothing that was voted for is skipped, and anyone can raise the rest.",
+    },
+    {
+      id: "actions",
+      name: "Action items that carry over",
+      description:
+        "An action item has one owner, or none yet. In a team retro, open ones come back at the next retro's review until someone marks them done or dropped.",
+    },
+    {
+      id: "history",
+      name: "History kept by the team",
+      description:
+        "Every retro a team runs stays readable to its members, free, until the team deletes it. Export one retro as Markdown or the whole history as JSON.",
+    },
+    {
+      id: "link",
+      name: "Join by link, no cameras",
+      description:
+        "A retro without a team is one link away and needs no account. It disappears after five quiet days.",
+    },
+  ] as const,
+};
+
+// --- The rest of the page ---
+
+export const TECH_STACK = {
+  eyebrow: "Modern Stack",
+  heading: "Built with the best.",
+  headingMuted: "Speed and reliability.",
+  items: [
+    { id: "next", name: "Next.js 15", description: "React framework with App Router" },
+    { id: "convex", name: "Convex", description: "Real-time serverless backend" },
+    { id: "flow", name: "React Flow", description: "Interactive whiteboard canvas" },
+    { id: "tailwind", name: "Tailwind CSS", description: "Modern utility-first styling" },
+  ] as const,
+};
+
+export const WHY = {
+  eyebrow: "Why AgileKit",
+  heading: "Different by design.",
+  free: {
+    price: "$0",
+    name: "Free Core",
+    description: "Core features free. Optional paid features may be available in the future.",
+  },
+  privacy: {
+    name: "Privacy Controls",
+    description:
+      "Essential cookies keep sign-in and preferences working. Optional analytics stay off unless you opt in.",
+  },
+  openSource: {
+    name: "Open Source",
+    description: "Fully transparent, community-driven. Contribute, fork, or self-host.",
+  },
+};
+
+export const ROADMAP = {
+  eyebrow: "Roadmap",
+  heading: "Shipping fast.",
+  headingMuted: "Here's what's new.",
+  shippedTitle: "Recently Shipped",
+  shippedBadge: "Shipped",
+  shipped: [
+    {
+      id: "retros",
+      name: "Retros",
+      description:
+        "Retro boards with six formats, cards written in parallel, dots, a discussion walk, action items and history kept by the team",
+    },
+    {
+      id: "predictability",
+      name: "Sprint Predictability Score",
+      description: "Track estimation accuracy over time with predictability health metrics",
+    },
+    {
+      id: "exports",
+      name: "Enhanced Data Exports",
+      description: "Export full session data as CSV or JSON with analytics included",
+    },
+  ] as const,
+  upNextTitle: "Up Next",
+  upNextBadge: "Planned",
+  upNext: [
+    {
+      id: "github",
+      name: "GitHub Integration",
+      description: "Import issues from repositories and push estimates to GitHub Projects",
+    },
+    {
+      id: "summaries",
+      name: "Automated Session Summaries",
+      description: "Auto-generated session reports delivered to participants via email",
+    },
+  ] as const,
+};
+
+export const CTA = {
+  heading: "Ready to estimate,",
+  headingMuted: "or reflect?",
+  description: "Open a planning poker room or a retro in seconds. Both free, no sign-up required.",
+  estimate: START_ESTIMATING,
+  retro: START_RETRO,
+  github: { label: "Contribute", href: "https://github.com/spokvulcan/poker-planning" },
+};

--- a/src/app/features/features-content.tsx
+++ b/src/app/features/features-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import type { ComponentType } from "react";
 import {
   Users,
   Zap,
@@ -14,6 +15,7 @@ import {
   ArrowRight,
   Shield,
   Eye,
+  EyeOff,
   Code2,
   Database,
   Palette,
@@ -21,6 +23,13 @@ import {
   TrendingUp,
   Target,
   Layers,
+  LayoutTemplate,
+  PenLine,
+  CalendarClock,
+  CircleDot,
+  ListChecks,
+  History,
+  MessageSquare,
 } from "lucide-react";
 
 import { Footer } from "@/components/footer";
@@ -37,142 +46,76 @@ import {
   IssuesAnimation,
   VoterAlignmentAnimation,
 } from "./feature-animations";
+import { HERO, QUICK_FEATURES, POKER, RETRO, TECH_STACK, WHY, ROADMAP, CTA } from "./copy";
 
-// Features that are available now
-const coreFeatures = [
-  {
-    name: "Real-time Voting",
-    description:
-      "Simultaneous card selection with instant sync across all participants",
-    icon: Users,
-    gradient: "from-violet-500 to-purple-600",
-    visual: RealtimeVotingAnimation,
-  },
-  {
-    name: "Multiple Voting Scales",
-    description:
-      "Fibonacci, Standard, T-Shirt sizes, or create your own custom scale",
-    icon: Layers,
-    gradient: "from-amber-500 to-orange-600",
-    visual: ScalesAnimation,
-  },
-  {
-    name: "Results Analytics",
-    description:
-      "Average, median, mode, consensus strength, and outlier detection",
-    icon: BarChart3,
-    gradient: "from-emerald-500 to-teal-600",
-    visual: AnalyticsAnimation,
-  },
-  {
-    name: "Whiteboard Canvas",
-    description: "Drag-and-drop React Flow canvas with multiple node types",
-    icon: Layout,
-    gradient: "from-blue-500 to-cyan-600",
-    visual: CanvasAnimation,
-  },
-  {
-    name: "Issues Management",
-    description:
-      "Create, edit, and track issues with CSV export and vote statistics",
-    icon: FileText,
-    gradient: "from-sky-500 to-blue-600",
-    visual: IssuesAnimation,
-  },
-  {
-    name: "Jira Cloud Integration",
-    description:
-      "Two-way sync — import sprints, push estimates back automatically",
-    icon: Link2,
-    gradient: "from-blue-500 to-indigo-600",
-    visual: JiraIntegrationAnimation,
-  },
-  {
-    name: "Time-to-Consensus Tracking",
-    description:
-      "Measure how long your team takes to reach agreement on each story",
-    icon: Timer,
-    gradient: "from-rose-500 to-pink-600",
-    visual: TimeToConsensusAnimation,
-  },
-  {
-    name: "Voter Alignment Matrix",
-    description:
-      "Visualize voting patterns and spot persistent disagreements",
-    icon: Target,
-    gradient: "from-fuchsia-500 to-purple-600",
-    visual: VoterAlignmentAnimation,
-  },
-];
+type Icon = ComponentType<{ className?: string }>;
+type Id =
+  | (typeof QUICK_FEATURES)[number]["id"]
+  | (typeof POKER.items)[number]["id"]
+  | (typeof POKER.analytics.stats)[number]["id"]
+  | (typeof RETRO.items)[number]["id"]
+  | (typeof TECH_STACK.items)[number]["id"]
+  | (typeof ROADMAP.shipped)[number]["id"]
+  | (typeof ROADMAP.upNext)[number]["id"];
 
-const quickFeatures = [
-  { name: "No Sign-up Required", icon: Zap },
-  { name: "Dark/Light Theme", icon: Moon },
-  { name: "Mobile Responsive", icon: Smartphone },
-  { name: "Shareable Links", icon: Link2 },
-  { name: "CSV Export", icon: FileDown },
-  { name: "Spectator Mode", icon: Eye },
-];
+// Icons and visuals are keyed by the copy's ids; the words live in copy.ts.
+const ICONS: Record<Id, Icon> = {
+  // quick strip
+  signup: Zap,
+  theme: Moon,
+  mobile: Smartphone,
+  links: Link2,
+  csv: FileDown,
+  spectator: Eye,
+  // planning poker
+  voting: Users,
+  scales: Layers,
+  analytics: BarChart3,
+  canvas: Layout,
+  issues: FileText,
+  jira: Link2,
+  consensus: Timer,
+  alignment: Target,
+  average: TrendingUp,
+  median: Target,
+  strength: Users,
+  outliers: Eye,
+  // retro
+  formats: LayoutTemplate,
+  parallel: PenLine,
+  async: CalendarClock,
+  anonymous: EyeOff,
+  dots: CircleDot,
+  actions: ListChecks,
+  history: History,
+  link: Link2,
+  // stack and roadmap
+  next: Code2,
+  convex: Database,
+  flow: Layers,
+  tailwind: Palette,
+  retros: MessageSquare,
+  predictability: TrendingUp,
+  exports: FileDown,
+  github: Code2,
+  summaries: FileText,
+};
 
-const recentlyShipped = [
-  {
-    name: "Sprint Predictability Score",
-    description:
-      "Track estimation accuracy over time with predictability health metrics",
-    icon: TrendingUp,
-  },
-  {
-    name: "Enhanced Data Exports",
-    description:
-      "Export full session data as CSV or JSON with analytics included",
-    icon: FileDown,
-  },
-];
+const POKER_VISUALS: Record<(typeof POKER.items)[number]["id"], ComponentType> = {
+  voting: RealtimeVotingAnimation,
+  scales: ScalesAnimation,
+  analytics: AnalyticsAnimation,
+  canvas: CanvasAnimation,
+  issues: IssuesAnimation,
+  jira: JiraIntegrationAnimation,
+  consensus: TimeToConsensusAnimation,
+  alignment: VoterAlignmentAnimation,
+};
 
-const upNextFeatures = [
-  {
-    name: "GitHub Integration",
-    description:
-      "Import issues from repositories and push estimates to GitHub Projects",
-    icon: Code2,
-  },
-  {
-    name: "Automated Session Summaries",
-    description:
-      "Auto-generated session reports delivered to participants via email",
-    icon: FileText,
-  },
-];
-
-const techStack = [
-  {
-    name: "Next.js 15",
-    description: "React framework with App Router",
-    icon: Code2,
-  },
-  {
-    name: "Convex",
-    description: "Real-time serverless backend",
-    icon: Database,
-  },
-  {
-    name: "React Flow",
-    description: "Interactive whiteboard canvas",
-    icon: Layers,
-  },
-  {
-    name: "Tailwind CSS",
-    description: "Modern utility-first styling",
-    icon: Palette,
-  },
-];
-
-const analyticsFeatures = [
-  { name: "Average Score", icon: TrendingUp },
-  { name: "Median Value", icon: Target },
-  { name: "Consensus Strength", icon: Users },
-  { name: "Outlier Detection", icon: Eye },
-];
+const primaryCta =
+  "inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto";
+const secondaryCta =
+  "inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto";
 
 export function FeaturesContent() {
   return (
@@ -183,38 +126,39 @@ export function FeaturesContent() {
         {/* Hero Section */}
         <section className="relative pt-32 pb-24 sm:pt-40 sm:pb-32 overflow-hidden bg-white dark:bg-black">
           <div className="absolute inset-0 bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,#18181b_1px,transparent_1px),linear-gradient(to_bottom,#18181b_1px,transparent_1px)] bg-[size:4rem_4rem]"></div>
-          
+
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8 relative z-10">
             <div className="mx-auto max-w-4xl text-center">
               <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Powerful features,<br />
-                <span className="text-gray-300 dark:text-zinc-700">zero complexity.</span>
+                {HERO.headline}<br />
+                <span className="text-gray-300 dark:text-zinc-700">{HERO.headlineMuted}</span>
               </h1>
 
               <p className="mt-8 text-xl sm:text-2xl leading-relaxed text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light">
-                From real-time collaboration to advanced analytics, AgileKit has
-                everything your team needs. Core features free, no sign-up
-                required.
+                {HERO.description}
               </p>
 
               <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
-                <Link
-                  href="/"
-                  className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
-                >
-                  Start Planning Now
+                <Link href={HERO.estimate.href} className={primaryCta}>
+                  {HERO.estimate.label}
                   <ArrowRight className="h-5 w-5" />
                 </Link>
-                <a
-                  href="https://github.com/spokvulcan/poker-planning"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
-                >
-                  <GithubIcon className="h-5 w-5" />
-                  View on GitHub
-                </a>
+                <Link href={HERO.retro.href} className={secondaryCta}>
+                  {HERO.retro.label}
+                  <ArrowRight className="h-5 w-5" />
+                </Link>
               </div>
+
+              <nav aria-label={HERO.jumpTo} className="mt-10 flex items-center justify-center gap-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+                <span>{HERO.jumpTo}:</span>
+                <a href={`#${POKER.anchor}`} className="underline underline-offset-4 hover:text-gray-900 dark:hover:text-white transition-colors">
+                  {POKER.eyebrow}
+                </a>
+                <span aria-hidden="true">·</span>
+                <a href={`#${RETRO.anchor}`} className="underline underline-offset-4 hover:text-gray-900 dark:hover:text-white transition-colors">
+                  {RETRO.eyebrow}
+                </a>
+              </nav>
             </div>
           </div>
         </section>
@@ -223,279 +167,335 @@ export function FeaturesContent() {
         <section className="border-y border-gray-200/50 dark:border-zinc-800/50 bg-gray-50/50 dark:bg-zinc-900/10">
           <div className="mx-auto max-w-[90rem] px-6 py-8 lg:px-8">
             <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6">
-              {quickFeatures.map((feature) => (
-                <div
-                  key={feature.name}
-                  className="flex items-center gap-3 text-base font-medium text-gray-600 dark:text-gray-400"
-                >
-                  <feature.icon className="h-5 w-5 text-gray-900 dark:text-white" />
-                  <span>{feature.name}</span>
-                </div>
-              ))}
+              {QUICK_FEATURES.map((feature) => {
+                const Icon = ICONS[feature.id];
+                return (
+                  <div
+                    key={feature.id}
+                    className="flex items-center gap-3 text-base font-medium text-gray-600 dark:text-gray-400"
+                  >
+                    <Icon className="h-5 w-5 text-gray-900 dark:text-white" />
+                    <span>{feature.name}</span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </section>
 
-        {/* Core Features Bento Grid */}
-        <section className="py-24 sm:py-32 bg-white dark:bg-black">
-          <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
-            <div className="mb-16">
-              <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Core Features
-              </p>
-              <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Built for modern teams.<br />
-                <span className="text-gray-400 dark:text-zinc-600">Faster, more accurate.</span>
-              </h2>
-            </div>
-
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 grid-flow-dense">
-              {coreFeatures.map((feature, index) => (
-                <div
-                  key={feature.name}
-                  className={cn(
-                    "group relative overflow-hidden rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 border border-gray-200/50 dark:border-zinc-800/50 flex flex-col",
-                    index === 0 && "sm:col-span-2 sm:row-span-2",
-                    index === 2 && "lg:col-span-2 min-h-[300px]",
-                    index !== 0 && index !== 2 && "min-h-[320px]"
-                  )}
-                >
-                  {/* Content Top */}
-                  <div className="relative z-10 p-6 sm:p-8 flex-shrink-0 pointer-events-none">
-                    <div
-                      className={cn(
-                        "inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-2xl bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 mb-6 pointer-events-auto shadow-sm",
-                      )}
-                    >
-                      <feature.icon className="h-5 w-5 sm:h-6 sm:w-6 text-gray-900 dark:text-white" />
-                    </div>
-
-                    <h3
-                      className={cn(
-                        "font-bold tracking-tight text-gray-900 dark:text-white mb-2 pointer-events-auto",
-                        index === 0 ? "text-2xl sm:text-3xl" : "text-xl",
-                      )}
-                    >
-                      {feature.name}
-                    </h3>
-                    <p
-                      className={cn(
-                        "text-gray-600 dark:text-gray-400 font-light leading-relaxed pointer-events-auto",
-                        index === 0 ? "text-base sm:text-lg max-w-md" : "text-sm sm:text-base",
-                      )}
-                    >
-                      {feature.description}
-                    </p>
-                    
-                    {index === 0 && (
-                      <div className="mt-6 pt-6 border-t border-gray-200/50 dark:border-zinc-700/50 flex items-center gap-4 pointer-events-auto">
-                        <div className="flex -space-x-3">
-                          {[1, 2, 3, 4].map((i) => (
-                            <div
-                              key={i}
-                              className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-gray-200 dark:bg-zinc-800 border-2 border-white dark:border-zinc-900 flex items-center justify-center text-xs sm:text-sm font-medium text-gray-900 dark:text-white"
-                            >
-                              {i}
-                            </div>
-                          ))}
-                        </div>
-                        <span className="text-sm sm:text-base font-medium text-gray-500 dark:text-gray-400">
-                          Unlimited team members
-                        </span>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Background animation Bottom */}
-                  <div className="relative flex-1 w-full min-h-[140px] pointer-events-none">
-                    {feature.visual && <feature.visual />}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Analytics Showcase */}
-        <section className="py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-y border-gray-200/50 dark:border-zinc-800/50">
-          <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
-            <div className="grid lg:grid-cols-2 gap-16 lg:gap-24 items-center">
-              <div>
+        <div id={POKER.anchor} className="scroll-mt-24">
+          {/* Core Features Bento Grid */}
+          <section className="py-24 sm:py-32 bg-white dark:bg-black">
+            <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
+              <div className="mb-16">
                 <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                  Smart Analytics
+                  {POKER.eyebrow}
                 </p>
                 <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                  Understand your team&apos;s<br />
-                  <span className="text-gray-400 dark:text-zinc-600">estimation patterns.</span>
+                  {POKER.heading}<br />
+                  <span className="text-gray-400 dark:text-zinc-600">{POKER.headingMuted}</span>
                 </h2>
-                <p className="mt-6 text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                  Get instant insights into voting distribution, consensus
-                  levels, and identify outliers. Make better decisions with
-                  data-driven estimation.
-                </p>
-
-                <div className="mt-12 grid grid-cols-2 gap-6">
-                  {analyticsFeatures.map((feature) => (
-                    <div
-                      key={feature.name}
-                      className="flex items-center gap-4 text-gray-900 dark:text-gray-300"
-                    >
-                      <div className="flex h-12 w-12 shrink-0 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
-                        <feature.icon className="h-5 w-5 text-gray-900 dark:text-white" />
-                      </div>
-                      <span className="text-base font-medium text-gray-900 dark:text-white">{feature.name}</span>
-                    </div>
-                  ))}
-                </div>
               </div>
 
-              {/* Results Preview Card */}
-              <div className="bg-white dark:bg-black rounded-[2rem] p-8 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
-                <div className="flex items-center justify-between mb-8">
-                  <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white">
-                    Voting Results
-                  </h3>
-                  <span className="px-4 py-2 rounded-full bg-green-50 dark:bg-green-500/10 text-green-700 dark:text-green-400 text-sm font-bold tracking-wide">
-                    High Consensus
-                  </span>
-                </div>
-
-                <div className="grid grid-cols-3 gap-6 mb-10">
-                  {[
-                    { label: "Average", value: "5.2" },
-                    { label: "Median", value: "5" },
-                    { label: "Mode", value: "5" },
-                  ].map((stat) => (
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 grid-flow-dense">
+                {POKER.items.map((feature, index) => {
+                  const Icon = ICONS[feature.id];
+                  const Visual = POKER_VISUALS[feature.id];
+                  return (
                     <div
-                      key={stat.label}
-                      className="text-center p-6 rounded-2xl bg-gray-50 dark:bg-zinc-900/50 border border-gray-200/50 dark:border-zinc-800/50"
+                      key={feature.id}
+                      className={cn(
+                        "group relative overflow-hidden rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 border border-gray-200/50 dark:border-zinc-800/50 flex flex-col",
+                        index === 0 && "sm:col-span-2 sm:row-span-2",
+                        index === 2 && "lg:col-span-2 min-h-[300px]",
+                        index !== 0 && index !== 2 && "min-h-[320px]"
+                      )}
                     >
-                      <div className="text-3xl font-bold tracking-tighter text-gray-900 dark:text-white">
-                        {stat.value}
+                      {/* Content Top */}
+                      <div className="relative z-10 p-6 sm:p-8 flex-shrink-0 pointer-events-none">
+                        <div className="inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-2xl bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 mb-6 pointer-events-auto shadow-sm">
+                          <Icon className="h-5 w-5 sm:h-6 sm:w-6 text-gray-900 dark:text-white" />
+                        </div>
+
+                        <h3
+                          className={cn(
+                            "font-bold tracking-tight text-gray-900 dark:text-white mb-2 pointer-events-auto",
+                            index === 0 ? "text-2xl sm:text-3xl" : "text-xl",
+                          )}
+                        >
+                          {feature.name}
+                        </h3>
+                        <p
+                          className={cn(
+                            "text-gray-600 dark:text-gray-400 font-light leading-relaxed pointer-events-auto",
+                            index === 0 ? "text-base sm:text-lg max-w-md" : "text-sm sm:text-base",
+                          )}
+                        >
+                          {feature.description}
+                        </p>
+
+                        {index === 0 && (
+                          <div className="mt-6 pt-6 border-t border-gray-200/50 dark:border-zinc-700/50 flex items-center gap-4 pointer-events-auto">
+                            <div className="flex -space-x-3">
+                              {[1, 2, 3, 4].map((i) => (
+                                <div
+                                  key={i}
+                                  className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-gray-200 dark:bg-zinc-800 border-2 border-white dark:border-zinc-900 flex items-center justify-center text-xs sm:text-sm font-medium text-gray-900 dark:text-white"
+                                >
+                                  {i}
+                                </div>
+                              ))}
+                            </div>
+                            <span className="text-sm sm:text-base font-medium text-gray-500 dark:text-gray-400">
+                              {POKER.unlimited}
+                            </span>
+                          </div>
+                        )}
                       </div>
-                      <div className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-2 uppercase tracking-widest">
-                        {stat.label}
+
+                      {/* Background animation Bottom */}
+                      <div className="relative flex-1 w-full min-h-[140px] pointer-events-none">
+                        <Visual />
                       </div>
                     </div>
-                  ))}
-                </div>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
 
-                <div className="space-y-4">
-                  {[
-                    { value: "3", count: 2, width: "20%" },
-                    { value: "5", count: 5, width: "50%" },
-                    { value: "8", count: 3, width: "30%" },
-                  ].map((bar) => (
-                    <div key={bar.value} className="flex items-center gap-4">
-                      <span className="w-8 text-base font-bold text-gray-900 dark:text-white">
-                        {bar.value}
-                      </span>
-                      <div className="flex-1 h-4 bg-gray-100 dark:bg-zinc-900 rounded-full overflow-hidden">
+          {/* Analytics Showcase */}
+          <section className="py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-y border-gray-200/50 dark:border-zinc-800/50">
+            <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
+              <div className="grid lg:grid-cols-2 gap-16 lg:gap-24 items-center">
+                <div>
+                  <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
+                    {POKER.analytics.eyebrow}
+                  </p>
+                  <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
+                    {POKER.analytics.heading}<br />
+                    <span className="text-gray-400 dark:text-zinc-600">{POKER.analytics.headingMuted}</span>
+                  </h2>
+                  <p className="mt-6 text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
+                    {POKER.analytics.description}
+                  </p>
+
+                  <div className="mt-12 grid grid-cols-2 gap-6">
+                    {POKER.analytics.stats.map((feature) => {
+                      const Icon = ICONS[feature.id];
+                      return (
                         <div
-                          className="h-full bg-gray-900 dark:bg-white rounded-full"
-                          style={{ width: bar.width }}
-                        />
-                      </div>
-                      <span className="w-6 text-base font-medium text-gray-500 dark:text-gray-400 text-right">
-                        {bar.count}
-                      </span>
-                    </div>
-                  ))}
+                          key={feature.id}
+                          className="flex items-center gap-4 text-gray-900 dark:text-gray-300"
+                        >
+                          <div className="flex h-12 w-12 shrink-0 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
+                            <Icon className="h-5 w-5 text-gray-900 dark:text-white" />
+                          </div>
+                          <span className="text-base font-medium text-gray-900 dark:text-white">{feature.name}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
 
-                <div className="mt-10 pt-8 border-t border-gray-200/50 dark:border-zinc-800/50 flex items-center justify-between">
-                  <div className="flex items-center gap-3 text-base font-medium text-gray-600 dark:text-gray-400">
-                    <Users className="h-5 w-5" />
-                    <span>10 participants</span>
+                {/* Results Preview Card */}
+                <div className="bg-white dark:bg-black rounded-[2rem] p-8 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
+                  <div className="flex items-center justify-between mb-8">
+                    <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white">
+                      {POKER.analytics.preview.title}
+                    </h3>
+                    <span className="px-4 py-2 rounded-full bg-green-50 dark:bg-green-500/10 text-green-700 dark:text-green-400 text-sm font-bold tracking-wide">
+                      {POKER.analytics.preview.badge}
+                    </span>
                   </div>
-                  <div className="text-base font-bold text-green-700 dark:text-green-400">
-                    89% consensus
+
+                  <div className="grid grid-cols-3 gap-6 mb-10">
+                    {[
+                      { label: "Average", value: "5.2" },
+                      { label: "Median", value: "5" },
+                      { label: "Mode", value: "5" },
+                    ].map((stat) => (
+                      <div
+                        key={stat.label}
+                        className="text-center p-6 rounded-2xl bg-gray-50 dark:bg-zinc-900/50 border border-gray-200/50 dark:border-zinc-800/50"
+                      >
+                        <div className="text-3xl font-bold tracking-tighter text-gray-900 dark:text-white">
+                          {stat.value}
+                        </div>
+                        <div className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-2 uppercase tracking-widest">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="space-y-4">
+                    {[
+                      { value: "3", count: 2, width: "20%" },
+                      { value: "5", count: 5, width: "50%" },
+                      { value: "8", count: 3, width: "30%" },
+                    ].map((bar) => (
+                      <div key={bar.value} className="flex items-center gap-4">
+                        <span className="w-8 text-base font-bold text-gray-900 dark:text-white">
+                          {bar.value}
+                        </span>
+                        <div className="flex-1 h-4 bg-gray-100 dark:bg-zinc-900 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-gray-900 dark:bg-white rounded-full"
+                            style={{ width: bar.width }}
+                          />
+                        </div>
+                        <span className="w-6 text-base font-medium text-gray-500 dark:text-gray-400 text-right">
+                          {bar.count}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-10 pt-8 border-t border-gray-200/50 dark:border-zinc-800/50 flex items-center justify-between">
+                    <div className="flex items-center gap-3 text-base font-medium text-gray-600 dark:text-gray-400">
+                      <Users className="h-5 w-5" />
+                      <span>{POKER.analytics.preview.participants}</span>
+                    </div>
+                    <div className="text-base font-bold text-green-700 dark:text-green-400">
+                      {POKER.analytics.preview.consensus}
+                    </div>
                   </div>
                 </div>
               </div>
+            </div>
+          </section>
+        </div>
+
+        {/* Retro */}
+        <section id={RETRO.anchor} className="scroll-mt-24 py-24 sm:py-32 bg-white dark:bg-black">
+          <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
+            <div className="mb-16 max-w-3xl">
+              <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
+                {RETRO.eyebrow}
+              </p>
+              <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
+                {RETRO.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{RETRO.headingMuted}</span>
+              </h2>
+              <p className="mt-6 text-lg sm:text-xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
+                {RETRO.description}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {RETRO.items.map((item) => {
+                const Icon = ICONS[item.id];
+                return (
+                  <div
+                    key={item.id}
+                    className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-8 border border-gray-200/50 dark:border-zinc-800/50"
+                  >
+                    <div className="flex h-12 w-12 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl mb-6">
+                      <Icon className="h-5 w-5 text-gray-900 dark:text-white" />
+                    </div>
+                    <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
+                      {item.name}
+                    </h3>
+                    <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
+                      {item.description}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="mt-12">
+              <Link
+                href={HERO.retro.href}
+                className="inline-flex h-14 items-center justify-center gap-2 bg-black dark:bg-white px-8 text-base font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl"
+              >
+                {HERO.retro.label}
+                <ArrowRight className="h-5 w-5" />
+              </Link>
             </div>
           </div>
         </section>
 
         {/* Tech Stack */}
-        <section className="py-24 sm:py-32 bg-white dark:bg-black">
+        <section className="py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-y border-gray-200/50 dark:border-zinc-800/50">
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mb-16">
               <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Modern Stack
+                {TECH_STACK.eyebrow}
               </p>
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Built with the best.<br />
-                <span className="text-gray-400 dark:text-zinc-600">Speed and reliability.</span>
+                {TECH_STACK.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{TECH_STACK.headingMuted}</span>
               </h2>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {techStack.map((tech) => (
-                <div
-                  key={tech.name}
-                  className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-8 sm:p-10 border border-gray-200/50 dark:border-zinc-800/50"
-                >
-                  <div className="flex h-14 w-14 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl mb-8">
-                    <tech.icon className="h-6 w-6 text-gray-900 dark:text-white" />
+              {TECH_STACK.items.map((tech) => {
+                const Icon = ICONS[tech.id];
+                return (
+                  <div
+                    key={tech.id}
+                    className="rounded-3xl bg-white dark:bg-black p-8 sm:p-10 border border-gray-200/50 dark:border-zinc-800/50"
+                  >
+                    <div className="flex h-14 w-14 items-center justify-center bg-gray-50 dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl mb-8">
+                      <Icon className="h-6 w-6 text-gray-900 dark:text-white" />
+                    </div>
+                    <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
+                      {tech.name}
+                    </h3>
+                    <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
+                      {tech.description}
+                    </p>
                   </div>
-                  <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
-                    {tech.name}
-                  </h3>
-                  <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                    {tech.description}
-                  </p>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         </section>
 
         {/* Why AgileKit */}
-        <section className="py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-y border-gray-200/50 dark:border-zinc-800/50">
+        <section className="py-24 sm:py-32 bg-white dark:bg-black">
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mb-16">
               <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Why AgileKit
+                {WHY.eyebrow}
               </p>
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Different by design.
+                {WHY.heading}
               </h2>
             </div>
 
             <div className="grid md:grid-cols-3 gap-8">
               <div className="rounded-3xl bg-black dark:bg-white p-10 sm:p-12">
-                <div className="text-6xl sm:text-7xl font-bold tracking-tighter text-white dark:text-black mb-6">$0</div>
-                <h3 className="text-2xl font-bold tracking-tight text-white dark:text-black mb-4">Free Core</h3>
+                <div className="text-6xl sm:text-7xl font-bold tracking-tighter text-white dark:text-black mb-6">{WHY.free.price}</div>
+                <h3 className="text-2xl font-bold tracking-tight text-white dark:text-black mb-4">{WHY.free.name}</h3>
                 <p className="text-lg font-light leading-relaxed text-gray-400 dark:text-gray-600">
-                  Core features free. Optional paid features may be available
-                  in the future.
+                  {WHY.free.description}
                 </p>
               </div>
 
-              <div className="rounded-3xl bg-white dark:bg-black p-10 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
-                <div className="flex h-16 w-16 items-center justify-center bg-gray-50 dark:bg-zinc-900 rounded-2xl mb-8">
+              <div className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-10 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
+                <div className="flex h-16 w-16 items-center justify-center bg-white dark:bg-zinc-900 rounded-2xl mb-8">
                   <Shield className="h-8 w-8 text-gray-900 dark:text-white" />
                 </div>
                 <h3 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
-                  Privacy Controls
+                  {WHY.privacy.name}
                 </h3>
                 <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                  Essential cookies keep sign-in and preferences working.
-                  Optional analytics stay off unless you opt in.
+                  {WHY.privacy.description}
                 </p>
               </div>
 
-              <div className="rounded-3xl bg-white dark:bg-black p-10 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
-                <div className="flex h-16 w-16 items-center justify-center bg-gray-50 dark:bg-zinc-900 rounded-2xl mb-8">
+              <div className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-10 sm:p-12 border border-gray-200/50 dark:border-zinc-800/50">
+                <div className="flex h-16 w-16 items-center justify-center bg-white dark:bg-zinc-900 rounded-2xl mb-8">
                   <GithubIcon className="h-8 w-8 text-gray-900 dark:text-white" />
                 </div>
                 <h3 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
-                  Open Source
+                  {WHY.openSource.name}
                 </h3>
                 <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                  Fully transparent, community-driven. Contribute, fork, or
-                  self-host.
+                  {WHY.openSource.description}
                 </p>
               </div>
             </div>
@@ -503,104 +503,110 @@ export function FeaturesContent() {
         </section>
 
         {/* Roadmap */}
-        <section className="py-24 sm:py-32 bg-white dark:bg-black">
+        <section className="py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-y border-gray-200/50 dark:border-zinc-800/50">
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mb-16">
               <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Roadmap
+                {ROADMAP.eyebrow}
               </p>
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Shipping fast.<br />
-                <span className="text-gray-400 dark:text-zinc-600">Here&apos;s what&apos;s new.</span>
+                {ROADMAP.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{ROADMAP.headingMuted}</span>
               </h2>
             </div>
 
             {/* Recently Shipped */}
             <h3 className="text-xs font-bold tracking-widest text-primary uppercase mb-6">
-              Recently Shipped
+              {ROADMAP.shippedTitle}
             </h3>
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">
-              {recentlyShipped.map((feature) => (
-                <div
-                  key={feature.name}
-                  className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-8 border border-gray-200/50 dark:border-zinc-800/50"
-                >
-                  <div className="flex items-center justify-between mb-6">
-                    <div className="flex h-12 w-12 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
-                      <feature.icon className="h-5 w-5 text-gray-900 dark:text-white" />
+              {ROADMAP.shipped.map((feature) => {
+                const Icon = ICONS[feature.id];
+                return (
+                  <div
+                    key={feature.id}
+                    className="rounded-3xl bg-white dark:bg-black p-8 border border-gray-200/50 dark:border-zinc-800/50"
+                  >
+                    <div className="flex items-center justify-between mb-6">
+                      <div className="flex h-12 w-12 items-center justify-center bg-gray-50 dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
+                        <Icon className="h-5 w-5 text-gray-900 dark:text-white" />
+                      </div>
+                      <span className="px-4 py-2 rounded-full bg-green-50 dark:bg-green-500/10 text-green-700 dark:text-green-400 text-sm font-bold tracking-wide">
+                        {ROADMAP.shippedBadge}
+                      </span>
                     </div>
-                    <span className="px-4 py-2 rounded-full bg-green-50 dark:bg-green-500/10 text-green-700 dark:text-green-400 text-sm font-bold tracking-wide">
-                      Shipped
-                    </span>
+                    <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
+                      {feature.name}
+                    </h3>
+                    <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
+                      {feature.description}
+                    </p>
                   </div>
-                  <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
-                    {feature.name}
-                  </h3>
-                  <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                    {feature.description}
-                  </p>
-                </div>
-              ))}
+                );
+              })}
             </div>
 
             {/* Up Next */}
             <h3 className="text-xs font-bold tracking-widest text-primary uppercase mb-6">
-              Up Next
+              {ROADMAP.upNextTitle}
             </h3>
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {upNextFeatures.map((feature) => (
-                <div
-                  key={feature.name}
-                  className="rounded-3xl bg-gray-50/50 dark:bg-zinc-900/10 p-8 border border-gray-200/50 dark:border-zinc-800/50"
-                >
-                  <div className="flex items-center justify-between mb-6">
-                    <div className="flex h-12 w-12 items-center justify-center bg-white dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
-                      <feature.icon className="h-5 w-5 text-gray-900 dark:text-white" />
+              {ROADMAP.upNext.map((feature) => {
+                const Icon = ICONS[feature.id];
+                return (
+                  <div
+                    key={feature.id}
+                    className="rounded-3xl bg-white dark:bg-black p-8 border border-gray-200/50 dark:border-zinc-800/50"
+                  >
+                    <div className="flex items-center justify-between mb-6">
+                      <div className="flex h-12 w-12 items-center justify-center bg-gray-50 dark:bg-zinc-900 border border-gray-200/50 dark:border-zinc-800/50 rounded-2xl">
+                        <Icon className="h-5 w-5 text-gray-900 dark:text-white" />
+                      </div>
+                      <span className="px-4 py-2 rounded-full bg-gray-200/50 dark:bg-zinc-800/50 text-gray-900 dark:text-white text-sm font-bold tracking-wide">
+                        {ROADMAP.upNextBadge}
+                      </span>
                     </div>
-                    <span className="px-4 py-2 rounded-full bg-gray-200/50 dark:bg-zinc-800/50 text-gray-900 dark:text-white text-sm font-bold tracking-wide">
-                      Planned
-                    </span>
+                    <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
+                      {feature.name}
+                    </h3>
+                    <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
+                      {feature.description}
+                    </p>
                   </div>
-                  <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-3">
-                    {feature.name}
-                  </h3>
-                  <p className="text-base font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                    {feature.description}
-                  </p>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         </section>
 
         {/* CTA Section */}
-        <section className="relative py-24 sm:py-32 bg-gray-50/50 dark:bg-zinc-900/10 border-t border-gray-200/50 dark:border-zinc-800/50">
+        <section className="relative py-24 sm:py-32 bg-white dark:bg-black">
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mx-auto max-w-4xl text-center">
               <h2 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Ready to improve your<br />
-                <span className="text-gray-400 dark:text-zinc-600">sprint planning?</span>
+                {CTA.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{CTA.headingMuted}</span>
               </h2>
               <p className="mt-8 text-xl sm:text-2xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                Join teams worldwide using AgileKit. Start your first session in
-                seconds.
+                {CTA.description}
               </p>
               <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
-                <Link
-                  href="/"
-                  className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
-                >
-                  Get Started Free
+                <Link href={CTA.estimate.href} className={primaryCta}>
+                  {CTA.estimate.label}
+                  <ArrowRight className="h-5 w-5" />
+                </Link>
+                <Link href={CTA.retro.href} className={primaryCta}>
+                  {CTA.retro.label}
                   <ArrowRight className="h-5 w-5" />
                 </Link>
                 <a
-                  href="https://github.com/spokvulcan/poker-planning"
+                  href={CTA.github.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
+                  className={secondaryCta}
                 >
                   <GithubIcon className="h-5 w-5" />
-                  Contribute
+                  {CTA.github.label}
                 </a>
               </div>
             </div>

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,14 +1,13 @@
 import { Metadata } from "next";
 import { FeaturesContent } from "./features-content";
+import { META } from "./copy";
 
 export const metadata: Metadata = {
-  title: "Planning Poker Features",
-  description:
-    "Explore AgileKit's features: real-time voting, analytics, timer sync, and whiteboard canvas. Everything your Scrum team needs for accurate sprint estimation.",
+  title: META.title,
+  description: META.description,
   openGraph: {
-    title: "Planning Poker Features | AgileKit",
-    description:
-      "Explore AgileKit's features: real-time voting, analytics, timer sync, and whiteboard canvas. Everything for accurate estimation.",
+    title: META.openGraph.title,
+    description: META.openGraph.description,
     url: "https://agilekit.app/features",
   },
   alternates: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { getToken } from "@/lib/auth-server";
 import { isEmbeddedDocument } from "@/lib/embed";
 import { TopLevelOnly } from "@/components/top-level-only";
 import { AnalyticsConsentBanner } from "@/components/legal/analytics-consent";
+import { SITE } from "@/lib/site-copy";
 
 import "./globals.css";
 
@@ -30,23 +31,11 @@ const baseUrl = "https://agilekit.app";
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   title: {
-    default: "Free Planning Poker Online | AgileKit - Scrum Estimation Tool",
-    template: "%s | AgileKit",
+    default: SITE.title,
+    template: SITE.titleTemplate,
   },
-  description:
-    "Run free online planning poker sessions with your Scrum team. No signup required. Estimate user stories in real-time with AgileKit's open-source tool.",
-  keywords: [
-    "planning poker",
-    "scrum poker",
-    "agile estimation",
-    "story points",
-    "sprint planning",
-    "free planning poker",
-    "planning poker online",
-    "scrum poker online",
-    "agile poker",
-    "estimation poker",
-  ],
+  description: SITE.description,
+  keywords: SITE.keywords,
   authors: [{ name: "AgileKit Team" }],
   creator: "AgileKit",
   publisher: "AgileKit",
@@ -66,23 +55,21 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: baseUrl,
     siteName: "AgileKit",
-    title: "Free Planning Poker Online | AgileKit",
-    description:
-      "Run free online planning poker sessions with your Scrum team. No signup required. Estimate user stories in real-time.",
+    title: SITE.openGraph.title,
+    description: SITE.openGraph.description,
     images: [
       {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "AgileKit - Free Planning Poker Tool for Scrum Teams",
+        alt: SITE.openGraph.imageAlt,
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Free Planning Poker Online | AgileKit",
-    description:
-      "Run free online planning poker sessions with your Scrum team. No signup required.",
+    title: SITE.twitter.title,
+    description: SITE.twitter.description,
     images: ["/og-image.png"],
   },
   alternates: {

--- a/src/app/pricing/copy.ts
+++ b/src/app/pricing/copy.ts
@@ -1,0 +1,126 @@
+/**
+ * The /pricing page's copy (spec §18.4, ADR-0014): a planning poker plan
+ * comparison. Retros have no tier and appear only in the shared pricing
+ * section's Free card (`components/homepage/copy.ts`); the words rule
+ * ("insights" never) applies here too. Read by `pricing-content.tsx` and
+ * checked by `lib/claims-register.test.ts`.
+ */
+
+export const HERO = {
+  headline: "Simple pricing,",
+  headlineMuted: "infinite value.",
+  description:
+    "AgileKit is completely free for core planning sessions today. Pro is in development and is planned to add deeper planning poker analytics, longer retention, and workflow integrations.",
+  points: ["No credit card required for Free", "Pro checkout not live yet", "Open source"],
+};
+
+export const STATUS = {
+  eyebrow: "Launch status",
+  heading: "Paid checkout is not live yet",
+  description:
+    "We are preparing the site for payment-provider approval before enabling any live checkout. Exact launch pricing, final billing terms, and any Pro-specific retention rules will be published here before checkout goes live.",
+  enterprise: "Custom or enterprise pricing is not currently offered.",
+  links: {
+    refund: { label: "Refund policy", href: "/refund-policy" },
+    terms: { label: "Terms", href: "/terms" },
+    billing: { label: "Contact billing", href: "mailto:support@agilekit.app" },
+  },
+};
+
+export type ComparisonCell = boolean | string;
+
+export interface ComparisonFeature {
+  name: string;
+  free: ComparisonCell;
+  pro: ComparisonCell;
+}
+
+export const COMPARISON = {
+  eyebrow: "Compare Plans",
+  heading: "Everything you need,",
+  headingMuted: "nothing you don't.",
+  columns: { feature: "Feature", free: "Free", pro: "Pro" },
+  categories: [
+    {
+      category: "Core Planning",
+      features: [
+        { name: "Team members", free: "Unlimited", pro: "Unlimited" },
+        { name: "Planning sessions", free: "Unlimited", pro: "Unlimited" },
+        { name: "Real-time voting & whiteboard", free: true, pro: true },
+        { name: "Spectator mode", free: true, pro: true },
+        { name: "Session timer", free: true, pro: true },
+      ],
+    },
+    {
+      category: "History & Retention",
+      features: [
+        { name: "Session history", free: "5-day rolling", pro: "Unlimited" },
+        { name: "Issue & vote data retention", free: "5 days", pro: "Unlimited" },
+      ],
+    },
+    {
+      category: "Analytics",
+      features: [
+        { name: "Basic results summary", free: true, pro: true },
+        { name: "Time-to-consensus tracking", free: false, pro: true },
+        { name: "Voter alignment matrix", free: false, pro: true },
+        { name: "Sprint predictability score", free: false, pro: true },
+        { name: "Estimation accuracy trends", free: false, pro: true },
+        { name: "Automated session summaries", free: false, pro: true },
+      ],
+    },
+    {
+      category: "Exports & Integrations",
+      features: [
+        { name: "CSV export", free: true, pro: true },
+        { name: "JSON & analytics export", free: false, pro: true },
+        { name: "Two-way Jira Cloud sync", free: false, pro: true },
+        { name: "GitHub integration", free: false, pro: true },
+      ],
+    },
+    {
+      category: "Support",
+      features: [
+        { name: "Community support", free: true, pro: true },
+        { name: "Priority email support", free: false, pro: true },
+      ],
+    },
+  ] satisfies { category: string; features: ComparisonFeature[] }[],
+};
+
+export const FAQ = {
+  eyebrow: "FAQ",
+  heading: "Frequently asked questions.",
+  description:
+    "Everything you need to know about AgileKit pricing and plans. Can't find what you're looking for? Reach out to our team.",
+  items: [
+    {
+      question: "Do all team members need a Pro account?",
+      answer:
+        "No! Only the room owner will need Pro to enable advanced features for that room. Other participants will still be able to join and use those features for free.",
+    },
+    {
+      question: "What happens to my past sessions on the Free tier?",
+      answer:
+        "Until paid plans launch, current retention rules stay as they are today. If we introduce a shorter free-tier history window in the future, we will publish that change on this page before it takes effect.",
+    },
+    {
+      question: "Can I cancel my Pro subscription anytime?",
+      answer:
+        "Paid checkout is not live yet. Before Pro launches, we will publish the final cancellation flow, billing cadence, and any downgrade rules on this page and at checkout.",
+    },
+    {
+      question: "Is there a free trial for Pro?",
+      answer:
+        "The Free tier has unlimited usage for core features. When Pro fully launches, existing active accounts will receive early access to evaluate the new features.",
+    },
+  ],
+};
+
+export const CTA = {
+  heading: "Ready to plan better?",
+  description:
+    "Start using AgileKit for faster, more accurate sprint estimation — jump right in, completely free.",
+  start: { label: "Start planning for free", href: "/room/new" },
+  demo: { label: "View demo", href: "/demo" },
+};

--- a/src/app/pricing/pricing-content.tsx
+++ b/src/app/pricing/pricing-content.tsx
@@ -11,76 +11,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-
-const comparisonCategories = [
-  {
-    category: "Core Planning",
-    features: [
-      { name: "Team members", free: "Unlimited", pro: "Unlimited" },
-      { name: "Planning sessions", free: "Unlimited", pro: "Unlimited" },
-      { name: "Real-time voting & whiteboard", free: true, pro: true },
-      { name: "Spectator mode", free: true, pro: true },
-      { name: "Session timer", free: true, pro: true },
-    ],
-  },
-  {
-    category: "History & Retention",
-    features: [
-      { name: "Session history", free: "5-day rolling", pro: "Unlimited" },
-      { name: "Issue & vote data retention", free: "5 days", pro: "Unlimited" },
-    ],
-  },
-  {
-    category: "Analytics & Insights",
-    features: [
-      { name: "Basic results summary", free: true, pro: true },
-      { name: "Time-to-consensus tracking", free: false, pro: true },
-      { name: "Voter alignment matrix", free: false, pro: true },
-      { name: "Sprint predictability score", free: false, pro: true },
-      { name: "Estimation accuracy trends", free: false, pro: true },
-      { name: "Automated session summaries", free: false, pro: true },
-    ],
-  },
-  {
-    category: "Exports & Integrations",
-    features: [
-      { name: "CSV export", free: true, pro: true },
-      { name: "JSON & analytics export", free: false, pro: true },
-      { name: "Two-way Jira Cloud sync", free: false, pro: true },
-      { name: "GitHub integration", free: false, pro: true },
-    ],
-  },
-  {
-    category: "Support",
-    features: [
-      { name: "Community support", free: true, pro: true },
-      { name: "Priority email support", free: false, pro: true },
-    ],
-  },
-];
-
-const faqs = [
-  {
-    question: "Do all team members need a Pro account?",
-    answer:
-      "No! Only the room owner will need Pro to enable advanced features for that room. Other participants will still be able to join and use those features for free.",
-  },
-  {
-    question: "What happens to my past sessions on the Free tier?",
-    answer:
-      "Until paid plans launch, current retention rules stay as they are today. If we introduce a shorter free-tier history window in the future, we will publish that change on this page before it takes effect.",
-  },
-  {
-    question: "Can I cancel my Pro subscription anytime?",
-    answer:
-      "Paid checkout is not live yet. Before Pro launches, we will publish the final cancellation flow, billing cadence, and any downgrade rules on this page and at checkout.",
-  },
-  {
-    question: "Is there a free trial for Pro?",
-    answer:
-      "The Free tier has unlimited usage for core features. When Pro fully launches, existing active accounts will receive early access to evaluate the new features.",
-  },
-];
+import { HERO, STATUS, COMPARISON, FAQ, CTA } from "./copy";
 
 export function PricingContent() {
   return (
@@ -95,29 +26,21 @@ export function PricingContent() {
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8 relative z-10">
             <div className="mx-auto max-w-4xl text-center">
               <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Simple pricing,<br />
-                <span className="text-gray-300 dark:text-zinc-700">infinite value.</span>
+                {HERO.headline}<br />
+                <span className="text-gray-300 dark:text-zinc-700">{HERO.headlineMuted}</span>
               </h1>
 
               <p className="mt-8 text-xl sm:text-2xl leading-relaxed text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light">
-                AgileKit is completely free for core planning sessions today.
-                Pro is in development and is planned to add deeper insights,
-                longer retention, and workflow integrations.
+                {HERO.description}
               </p>
 
               <div className="mt-12 flex flex-wrap items-center justify-center gap-x-8 gap-y-4 text-base font-medium text-gray-500 dark:text-gray-400">
-                <div className="flex items-center gap-2">
-                  <Check className="h-5 w-5 text-gray-900 dark:text-white" />
-                  <span>No credit card required for Free</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Check className="h-5 w-5 text-gray-900 dark:text-white" />
-                  <span>Pro checkout not live yet</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Check className="h-5 w-5 text-gray-900 dark:text-white" />
-                  <span>Open source</span>
-                </div>
+                {HERO.points.map((point) => (
+                  <div key={point} className="flex items-center gap-2">
+                    <Check className="h-5 w-5 text-gray-900 dark:text-white" />
+                    <span>{point}</span>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
@@ -129,26 +52,23 @@ export function PricingContent() {
             <div className="flex flex-col lg:flex-row items-center justify-between gap-8">
               <div className="max-w-2xl">
                 <p className="text-sm font-bold tracking-widest text-primary uppercase mb-2">
-                  Launch status
+                  {STATUS.eyebrow}
                 </p>
                 <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-4">
-                  Paid checkout is not live yet
+                  {STATUS.heading}
                 </h2>
                 <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                  We are preparing the site for payment-provider approval
-                  before enabling any live checkout. Exact launch pricing,
-                  final billing terms, and any Pro-specific retention rules
-                  will be published here before checkout goes live.
+                  {STATUS.description}
                 </p>
               </div>
               <div className="shrink-0 flex flex-col gap-4 w-full lg:w-auto">
                 <div className="rounded-2xl border border-gray-200/50 bg-white p-6 text-center text-base font-medium text-gray-600 dark:border-zinc-800/50 dark:bg-zinc-900/50 dark:text-gray-400">
-                  Custom or enterprise pricing is not currently offered.
+                  {STATUS.enterprise}
                 </div>
                 <div className="flex flex-wrap justify-center gap-4 text-sm font-medium text-gray-500 dark:text-gray-400">
-                  <Link href="/refund-policy" className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">Refund policy</Link>
-                  <Link href="/terms" className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">Terms</Link>
-                  <a href="mailto:support@agilekit.app" className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">Contact billing</a>
+                  <Link href={STATUS.links.refund.href} className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">{STATUS.links.refund.label}</Link>
+                  <Link href={STATUS.links.terms.href} className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">{STATUS.links.terms.label}</Link>
+                  <a href={STATUS.links.billing.href} className="hover:text-gray-900 dark:hover:text-white transition-colors underline underline-offset-4">{STATUS.links.billing.label}</a>
                 </div>
               </div>
             </div>
@@ -163,11 +83,11 @@ export function PricingContent() {
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mb-16 max-w-2xl">
               <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                Compare Plans
+                {COMPARISON.eyebrow}
               </p>
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1]">
-                Everything you need,<br />
-                <span className="text-gray-400 dark:text-zinc-600">nothing you don&apos;t.</span>
+                {COMPARISON.heading}<br />
+                <span className="text-gray-400 dark:text-zinc-600">{COMPARISON.headingMuted}</span>
               </h2>
             </div>
 
@@ -175,18 +95,18 @@ export function PricingContent() {
               {/* Header */}
               <div className="grid grid-cols-[1fr_120px_120px] sm:grid-cols-3 bg-gray-50/80 dark:bg-zinc-900/80 border-b border-gray-200/50 dark:border-zinc-800/50">
                 <div className="px-6 sm:px-8 py-6 text-sm font-bold tracking-widest text-gray-500 dark:text-gray-400 uppercase">
-                  Feature
+                  {COMPARISON.columns.feature}
                 </div>
                 <div className="px-4 sm:px-8 py-6 text-center text-base sm:text-lg font-bold tracking-tight text-gray-900 dark:text-white border-l border-gray-200/50 dark:border-zinc-800/50">
-                  Free
+                  {COMPARISON.columns.free}
                 </div>
                 <div className="px-4 sm:px-8 py-6 text-center text-base sm:text-lg font-bold tracking-tight text-white bg-gray-900 dark:bg-white dark:text-black border-l border-gray-900 dark:border-white">
-                  Pro
+                  {COMPARISON.columns.pro}
                 </div>
               </div>
 
               {/* Category groups */}
-              {comparisonCategories.map((group, groupIndex) => (
+              {COMPARISON.categories.map((group, groupIndex) => (
                 <div key={group.category}>
                   {/* Category header */}
                   <div className="grid grid-cols-[1fr_120px_120px] sm:grid-cols-3 border-b border-gray-200/50 dark:border-zinc-800/50 bg-gray-50/60 dark:bg-zinc-900/40">
@@ -272,7 +192,7 @@ export function PricingContent() {
                   </div>
 
                   {/* Separator between groups */}
-                  {groupIndex < comparisonCategories.length - 1 && (
+                  {groupIndex < COMPARISON.categories.length - 1 && (
                     <div className="border-b-2 border-gray-200/80 dark:border-zinc-800/80" />
                   )}
                 </div>
@@ -287,20 +207,19 @@ export function PricingContent() {
             <div className="grid lg:grid-cols-12 gap-16">
               <div className="lg:col-span-5">
                 <p className="text-sm font-bold tracking-widest text-primary uppercase mb-4">
-                  FAQ
+                  {FAQ.eyebrow}
                 </p>
                 <h2 className="text-4xl sm:text-5xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[1.1] mb-6">
-                  Frequently asked questions.
+                  {FAQ.heading}
                 </h2>
                 <p className="text-lg font-light leading-relaxed text-gray-600 dark:text-gray-400">
-                  Everything you need to know about AgileKit pricing and plans.
-                  Can&apos;t find what you&apos;re looking for? Reach out to our team.
+                  {FAQ.description}
                 </p>
               </div>
 
               <div className="lg:col-span-7">
                 <Accordion className="space-y-4">
-                  {faqs.map((faq, index) => (
+                  {FAQ.items.map((faq, index) => (
                     <AccordionItem
                       key={faq.question}
                       value={`item-${index}`}
@@ -325,26 +244,25 @@ export function PricingContent() {
           <div className="mx-auto max-w-[90rem] px-6 lg:px-8">
             <div className="mx-auto max-w-4xl text-center">
               <h2 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tighter text-gray-900 dark:text-white leading-[0.95]">
-                Ready to plan better?
+                {CTA.heading}
               </h2>
               <p className="mt-8 text-xl sm:text-2xl text-gray-600 dark:text-gray-400 font-light leading-relaxed">
-                Start using AgileKit for faster, more accurate sprint estimation
-                — jump right in, completely free.
+                {CTA.description}
               </p>
               <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
                 <Link
-                  href="/room/new"
+                  href={CTA.start.href}
                   className="inline-flex h-16 items-center justify-center gap-2 bg-black dark:bg-white px-12 text-lg font-bold tracking-tight text-white dark:text-black hover:scale-105 transition-transform duration-200 rounded-2xl w-full sm:w-auto"
                 >
-                  Start planning for free
+                  {CTA.start.label}
                   <ArrowRight className="h-5 w-5" />
                 </Link>
                 <Link
-                  href="/demo"
+                  href={CTA.demo.href}
                   className="inline-flex h-16 items-center justify-center gap-2 bg-white dark:bg-zinc-950 border-2 border-gray-200 dark:border-zinc-800 px-12 text-lg font-bold tracking-tight text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors rounded-2xl w-full sm:w-auto"
                 >
                   <Play className="h-5 w-5" fill="currentColor" />
-                  View demo
+                  {CTA.demo.label}
                 </Link>
               </div>
             </div>

--- a/src/app/privacy/privacy-content.tsx
+++ b/src/app/privacy/privacy-content.tsx
@@ -92,6 +92,26 @@ const sections = [
   },
 ];
 
+/**
+ * Privacy policy drafts (spec §20; ADR-0019, ADR-0020), keyed by section
+ * title because ADR-0020's numbering differs from this file's (spec §23).
+ * NOT RENDERED. Reviewer step: a person reads each draft against the live
+ * section above and replaces it deliberately; nothing on the live page
+ * changes until then. The `[N]` in Data Retention is the provider's backup
+ * retention in days and must be checked against Convex's documentation by
+ * a person before it ships.
+ */
+export const PRIVACY_POLICY_DRAFTS: Record<string, string> = {
+  "Information We Collect":
+    "Depending on how you use the service, we may collect: (a) account and profile data, such as display name, email address, authentication identifiers, and avatar image; (b) collaboration data, such as room memberships, issues, votes, session history, messages or feedback you send us and, in retrospectives, the cards you write, the votes you cast, and the action items you create or own; (c) device and usage data, such as IP address, browser information, page visits, and diagnostic events; and (d) integration data, such as connected Jira account metadata and encrypted OAuth tokens when you connect a third-party integration.",
+  "How We Use Your Information":
+    "We use personal information to provide and secure the service, authenticate users, maintain planning sessions and retrospectives, support collaboration features, send sign-in emails and, unless you opt out, emails about retros and action items in teams you belong to, operate integrations you request, troubleshoot and improve the product, comply with legal obligations, and, where you consent, measure product usage through analytics.",
+  "Data Retention":
+    "We retain personal information for as long as needed to provide the service, maintain security, comply with legal obligations, resolve disputes, and enforce our agreements. Retention periods vary by data type and feature. Retrospectives kept by a team are stored until the team deletes the retrospective or the team. Their members can read them, and we tell you who those readers are before you write. Retrospectives with no team, and planning-poker rooms, are deleted automatically after 5 days without activity. In an anonymous retrospective we do not store who wrote a card; we do store who voted, and we never show it. Deleted data leaves our live database within minutes and our provider's backups within [N] days. You may request deletion of your account data, but we may keep limited records where required for security, fraud prevention, or legal compliance.",
+  "Your Rights and Choices":
+    "Depending on your location, you may have rights to request access, correction, deletion, portability, restriction, objection, or withdrawal of consent. You may also have the right to complain to your local data protection authority. You can export any retrospective you can read, and your team's full history, from inside the app. You can delete your account from Settings; cards and action items you wrote in team retrospectives remain with those teams, without your name. You can stop retro and action emails from Settings or from the unsubscribe link in any such email. We do not provide a public GitHub workflow for privacy requests because those channels can expose personal data; for any other request, email us.",
+};
+
 export function PrivacyContent() {
   return (
     <div className="bg-white dark:bg-black min-h-screen selection:bg-primary/10 selection:text-primary">

--- a/src/lib/claims-register.test.ts
+++ b/src/lib/claims-register.test.ts
@@ -8,6 +8,11 @@
 import { describe, it, expect } from "vitest";
 import * as homepage from "@/components/homepage/copy";
 import * as seo from "@/components/seo/copy";
+import * as site from "@/lib/site-copy";
+import * as features from "@/app/features/copy";
+import * as about from "@/app/about/copy";
+import * as pricing from "@/app/pricing/copy";
+import { siteConfig } from "@/lib/site-config";
 
 describe("the hero (spec §18.2)", () => {
   it("keeps the earned line and widens it", () => {
@@ -34,6 +39,32 @@ describe("the hero (spec §18.2)", () => {
 });
 
 const saysRetro = (text: string) => /\bretros?\b/i.test(text);
+
+describe("metadata, features and about (spec §18.1, §18.2)", () => {
+  it("sets the site default title", () => {
+    expect(site.SITE.title).toBe("Free Planning Poker & Retros Online | AgileKit");
+    expect(site.SITE.openGraph.title).toBe(site.SITE.title);
+    expect(site.SITE.twitter.title).toBe(site.SITE.title);
+  });
+
+  it("drops Planning Poker from the features page title and its Open Graph title", () => {
+    expect(features.META.title).not.toMatch(/planning poker/i);
+    expect(features.META.openGraph.title).not.toMatch(/planning poker/i);
+  });
+
+  it("anchors the features page at #planning-poker and #retro", () => {
+    expect(features.POKER.anchor).toBe("planning-poker");
+    expect(features.RETRO.anchor).toBe("retro");
+    expect(features.RETRO.items.length).toBeGreaterThanOrEqual(4);
+    expect(features.POKER.items.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("gives the About page the position", () => {
+    expect(about.HERO.position).toBe(
+      "AgileKit is the free, open-source way for distributed Scrum teams to estimate and reflect in writing, everyone at once, with nothing forgotten between sprints.",
+    );
+  });
+});
 
 describe("two ceremonies, one toolkit (spec §18.2)", () => {
   it("puts one card per ceremony under the hero, each with its own CTA", () => {
@@ -194,10 +225,15 @@ describe("the checker itself", () => {
   });
 });
 
-/** The copy modules under the register. PR (b) adds features, about, pricing and the site metadata. */
+/** The copy modules under the register; the pricing page is in scope (issue #300). */
 const MODULES: [string, unknown][] = [
   ["homepage", homepage],
   ["seo", seo],
+  ["site", site],
+  ["features", features],
+  ["about", about],
+  ["pricing", pricing],
+  ["siteConfig", { blog: siteConfig.blog, description: siteConfig.description }],
 ];
 
 describe("the claims register and the words rule (spec §18.3, §18.4)", () => {

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,3 +1,5 @@
+import { BLOG_DESCRIPTION, SITE_SHORT_DESCRIPTION } from "./site-copy";
+
 export function getSiteUrl(): string {
   // Convex backend uses SITE_URL (set via `npx convex env set`)
   if (process.env.SITE_URL) {
@@ -18,14 +20,13 @@ export function getSiteUrl(): string {
 export const siteConfig = {
   name: "AgileKit",
   url: getSiteUrl(),
-  description: "Free online planning poker for Scrum teams",
+  description: SITE_SHORT_DESCRIPTION,
   author: {
     name: "AgileKit Team",
   },
   blog: {
     title: "AgileKit Blog",
-    description:
-      "Tips, guides, and insights on planning poker and agile estimation.",
+    description: BLOG_DESCRIPTION,
   },
 } as const;
 

--- a/src/lib/site-copy.ts
+++ b/src/lib/site-copy.ts
@@ -1,8 +1,50 @@
 /**
- * Site-wide copy shared by the marketing pages (spec §18.2, ADR-0014).
- * Checked by `lib/claims-register.test.ts`.
+ * Site-wide metadata copy (spec §18.2, ADR-0014): the default title, the
+ * description and the social cards. Metadata may say "retrospective" where
+ * the UI says "Retro" (§18.4), and it may not contradict the hero. Read by
+ * `app/layout.tsx` and checked by `lib/claims-register.test.ts`.
  */
 
 /** The two CTAs every marketing page shares: one per ceremony (ADR-0014). */
 export const START_ESTIMATING = { label: "Start estimating", href: "/room/new" };
 export const START_RETRO = { label: "Start a retro", href: "/retro/new" };
+
+const TITLE = "Free Planning Poker & Retros Online | AgileKit";
+
+export const SITE = {
+  title: TITLE,
+  titleTemplate: "%s | AgileKit",
+  description:
+    "Run free online planning poker and retrospectives with your Scrum team. No signup required. Estimate in real time and reflect in writing, everyone at once, with AgileKit's open-source toolkit.",
+  keywords: [
+    "planning poker",
+    "scrum poker",
+    "agile estimation",
+    "story points",
+    "sprint planning",
+    "free planning poker",
+    "planning poker online",
+    "scrum poker online",
+    "agile poker",
+    "estimation poker",
+  ],
+  openGraph: {
+    title: TITLE,
+    description:
+      "Run free online planning poker and retrospectives with your Scrum team. No signup required. Estimate in real time, reflect in writing.",
+    imageAlt: "AgileKit - Free Planning Poker and Retros for Scrum Teams",
+  },
+  twitter: {
+    title: TITLE,
+    description:
+      "Run free online planning poker and retrospectives with your Scrum team. No signup required.",
+  },
+};
+
+/** `siteConfig.blog.description` and the blog index's subtitle. */
+export const BLOG_DESCRIPTION =
+  "Tips and guides on planning poker, retros and agile estimation.";
+
+/** `siteConfig.description`. */
+export const SITE_SHORT_DESCRIPTION =
+  "Free online planning poker and retros for Scrum teams";


### PR DESCRIPTION
Part (b) of #300, stacked on #326. Spec: docs/spec/retro.md §18.3–§18.4, §20, §21.1; ADR-0014, ADR-0019, ADR-0020, ADR-0024.

## What changed

- **/features** is one page anchored `#planning-poker` and `#retro`, with a retro section of eight facts. The page title drops "Planning Poker". Copy lives in `src/app/features/copy.ts`.
- **Metadata**: site default title is "Free Planning Poker & Retros Online | AgileKit" (also OG and Twitter). Blog subtitle and short description read from `src/lib/site-copy.ts`.
- **About** carries the position sentence from the spec; copy in `src/app/about/copy.ts`.
- **Pricing page** copy moved to `src/app/pricing/copy.ts`; "insights" replaced per the words rule.
- **Claims register test** (`src/lib/claims-register.test.ts`, node project) now walks every exported line of the six copy modules: no AI, no workspace/org product, no outcome claims, no anonymity claims, no effect sizes, no "X% of action items", no retro pricing tiers, no team-measuring numbers, "Retro" in UI labels, "Session" only inside planning poker, "notification"/"insights" never, "ceremony" docs-only. A fixture self-check proves each rule bites.
- **Privacy drafts**: `PRIVACY_POLICY_DRAFTS` exported, unrendered, keyed by section title, with a reviewer note. Nothing on the live privacy page changes.

## Manual follow-up

- **Privacy drafts** need a reviewer. The `[N]` backup-retention figure in the Data Retention draft must be checked against Convex documentation before any of it is published.
- **Retro screenshots**: see #326.

## Verification

- vitest: 127 files, 1193 passed (claims register 18/18); Playwright: 87 passed, 1 pre-existing skip; `tsc --noEmit` and eslint clean.

Closes #300.

https://claude.ai/code/session_01G9bjAL6awe9ayTe8X2MnqS